### PR TITLE
feat: wave 13 — metrics instrumentation, compliance, and operational tooling

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -923,16 +923,57 @@ Key deliverables:
 - Pyright: 0 errors
 - Ruff: 0 errors
 
-## 16. Wave 13+ Recommendations
+## 16. Wave 13 — Metrics Instrumentation & Compliance ✅
 
-### Wave 13 — Instrumentation & Operational Completeness
+### Completed
 
-1. Close instrumentation gaps: turn pipeline, session, cost, and pool metrics (23 defined, only HTTP + semaphore active)
+- **Prometheus metrics instrumentation** (S15 FR-15.6/7/8/9, S28 FR-28.10/11)
+  - LLM call metrics: TURN_LLM_CALLS, TURN_LLM_DURATION, TURN_LLM_TOKENS in litellm_client.py
+  - Safety metrics: TURN_SAFETY_FLAGS in moderation hook.py
+  - Session lifecycle: SESSIONS_ACTIVE, SESSION_TURNS, SESSION_DURATION in games.py
+  - Re-enabled LLMAPIUnreachable alert (was disabled pending instrumentation)
+  - Pool metrics (PG_POOL_SIZE, REDIS_POOL_ACTIVE, NEO4J_POOL_ACTIVE) deferred — need periodic sampling
+
+- **Admin auth test coverage** (quality gap)
+  - 7 test cases in tests/unit/admin/test_auth.py
+  - Covers: no key configured, missing header, invalid token, valid token, timing-safe comparison, bearer prefix
+
+- **Automated data purge job** (S17 FR-17.15)
+  - New src/tta/privacy/purge.py: run_purge() (single pass, dry_run) + purge_loop() (24h background)
+  - Deletes terminal sessions + associated turns older than retention policy (default 90 days)
+  - Integrated into FastAPI lifespan (create_task on startup, cancel on shutdown)
+  - Admin endpoint POST /admin/purge for manual trigger
+
+- **SECURITY.md** (S17 FR-17.46–17.50)
+  - Vulnerability reporting process with 48h acknowledgment SLA
+  - Breach response plan with 72h notification timeline
+  - Data categories and severity classification
+
+- **Runtime log level endpoint** (S15 FR-15.4)
+  - POST /admin/log-level with Pydantic validation
+  - Changes structlog/stdlib root logger level at runtime
+  - Audit-logged, returns previous and new level
+
+- **X-Trace-Id response header** (S15 FR-15.16)
+  - Always emits X-Trace-Id in responses (falls back to request_id when no trace ID provided)
+  - Updated test to verify fallback behavior
+
+### Metrics
+
+- Tests: 1305 (7 new admin auth + 1 updated middleware test)
+- Pyright: 0 errors
+- Ruff: 0 errors
+
+## 17. Wave 14+ Recommendations
+
+### Wave 14 — Operational Completeness
+
+1. Pool metrics via periodic sampling (PG_POOL_SIZE, REDIS_POOL_ACTIVE, NEO4J_POOL_ACTIVE)
 2. Alertmanager integration for notification routing (PagerDuty, Slack, email)
 3. Performance load testing and SLO validation against S28 targets
 4. node_exporter for disk usage alerting (S15 FR-15.23)
 5. Session token rotation (security improvement)
-6. 72-hour auto-purge scheduled job for expired sessions
+6. Privacy policy page at /privacy (S17 FR-17.51–53)
 
 ### Beyond v1
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,111 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| main    | ✅         |
+
+Only the latest commit on `main` receives security updates.
+
+---
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for security vulnerabilities.**
+
+1. Email **security@tta-game.example** with:
+   - Description of the vulnerability
+   - Steps to reproduce
+   - Potential impact assessment
+2. You will receive an acknowledgement within **48 hours**.
+3. We aim to provide a fix or mitigation within **7 days** of confirmation.
+
+If you do not receive a response within 48 hours, follow up via the same
+email address.
+
+---
+
+## Data Breach Response Plan
+
+*Per S17 FR-17.46–FR-17.50.*
+
+### Detection Signals (FR-17.47)
+
+- Unauthorized database access or unusual query patterns
+- Exposed environment variables or secrets in logs / public repos
+- Player reports of unauthorized account access
+- Unexpected data exports or bulk queries
+
+### Response Timeline (FR-17.48)
+
+| Phase       | Deadline                    | Actions                                                                                         |
+|-------------|-----------------------------|-------------------------------------------------------------------------------------------------|
+| **Contain** | Within 1 hour of detection  | Revoke compromised credentials, rotate API keys, disable affected endpoints                     |
+| **Assess**  | Within 24 hours             | Determine exposed data, number of affected players, attack vector                               |
+| **Notify**  | Within 72 hours of confirm  | Inform affected players via email, post public notice, notify GDPR authority if applicable       |
+| **Remediate** | Within 7 days             | Fix the vulnerability, deploy additional safeguards                                             |
+| **Review**  | Within 30 days              | Post-incident review, update security practices, publish lessons learned                        |
+
+### Breach Notification Template (FR-17.50)
+
+When notifying affected players, include:
+
+```
+Subject: [TTA] Security Incident Notification
+
+What happened:
+  [Description of the breach]
+
+When it happened:
+  [Date/time of breach and date/time of detection]
+
+What data was exposed:
+  [List of affected data categories]
+
+What we are doing:
+  [Steps being taken to contain and remediate]
+
+What you should do:
+  [Recommended player actions — e.g., change password]
+
+Contact:
+  security@tta-game.example
+```
+
+### Edge Cases
+
+- **System-only breach** (no player PII): a public notice is sufficient;
+  individual notification is not required (EC-17.6).
+- **Third-party breach** (e.g., LLM provider compromised): inform players
+  and link to the provider's breach notice (EC-17.7).
+
+---
+
+## Security Practices
+
+### Authentication
+
+- Admin API uses Bearer token authentication with timing-safe comparison
+  (`secrets.compare_digest`).
+- Player sessions use opaque tokens stored server-side.
+
+### Data Protection
+
+- All database connections use TLS in production.
+- PII fields are classified in the data model (S17 FR-17.5).
+- Completed game sessions are automatically purged after 90 days
+  (S17 FR-17.15).
+- Application logs are retained for 30 days maximum.
+
+### Infrastructure
+
+- Security headers (CSP, HSTS, X-Content-Type-Options, X-Frame-Options,
+  Referrer-Policy, Permissions-Policy) are applied to all responses.
+- Rate limiting protects against brute-force and abuse (S25).
+- Content moderation scans all player input (S24).
+
+### Dependencies
+
+- Dependencies are managed via `uv` with a locked `uv.lock` file.
+- Dependabot is configured for automated security updates.

--- a/monitoring/prometheus/alerts.yml
+++ b/monitoring/prometheus/alerts.yml
@@ -3,7 +3,7 @@
 #
 # Six conditions monitored:
 #   1. API error rate > 10% over 5 min (Critical) — ACTIVE
-#   2. LLM API unreachable > 2 min (Critical) — DISABLED (metric not yet instrumented)
+#   2. LLM API unreachable > 2 min (Critical) — ACTIVE
 #   3. Turn processing > 30s p95 (Warning) — ACTIVE
 #   4. Daily LLM cost > threshold (Warning) — ACTIVE (uses cost histogram)
 #   5. DB connection pool exhausted (Critical) — DISABLED (metric not yet instrumented)
@@ -36,23 +36,22 @@ groups:
             over the last 5 minutes.
 
       # 2. LLM API unreachable > 2 min → Critical
-      # DISABLED: tta_turn_llm_calls_total is not yet instrumented.
-      # TODO: Re-enable after Wave 13 metrics instrumentation.
-      # - alert: LLMAPIUnreachable
-      #   expr: |
-      #     (
-      #       sum(rate(tta_turn_llm_calls_total[2m])) == 0
-      #       and
-      #       sum(rate(tta_turn_total[2m])) > 0
-      #     )
-      #   for: 2m
-      #   labels:
-      #     severity: critical
-      #   annotations:
-      #     summary: "LLM API appears unreachable"
-      #     description: >-
-      #       No LLM calls have succeeded in the last 2 minutes while
-      #       turns are still being requested.
+      # Re-enabled: tta_turn_llm_calls_total is now instrumented (Wave 13).
+      - alert: LLMAPIUnreachable
+        expr: |
+          (
+            sum(rate(tta_turn_llm_calls_total[2m])) == 0
+            and
+            sum(rate(tta_turn_total[2m])) > 0
+          )
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "LLM API appears unreachable"
+          description: >-
+            No LLM calls have succeeded in the last 2 minutes while
+            turns are still being requested.
 
       # 3. Turn processing > 30s p95 → Warning
       - alert: SlowTurnProcessing

--- a/src/tta/api/app.py
+++ b/src/tta/api/app.py
@@ -267,9 +267,21 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         redis=settings.redis_url,
     )
 
+    # Start background purge loop (S17 FR-17.15)
+    import asyncio
+
+    from tta.privacy.purge import purge_loop
+
+    purge_task = asyncio.create_task(purge_loop(session_factory, interval_hours=24))
+
     yield
 
     # --- Shutdown ---
+    purge_task.cancel()
+    try:
+        await purge_task
+    except asyncio.CancelledError:
+        pass
     shutdown_langfuse()
     shutdown_tracing()
     if app.state.neo4j_driver is not None:

--- a/src/tta/api/middleware.py
+++ b/src/tta/api/middleware.py
@@ -58,9 +58,8 @@ class RequestIDMiddleware:
         request.state.request_id = request_id
         bind_correlation_id(request_id)
 
-        trace_id = current_trace_id() or request.headers.get("x-trace-id")
-        if trace_id:
-            bind_context(trace_id=trace_id)
+        trace_id = current_trace_id() or request.headers.get("x-trace-id") or request_id
+        bind_context(trace_id=trace_id)
 
         start = time.monotonic()
         status_code = 500
@@ -72,8 +71,7 @@ class RequestIDMiddleware:
                 # Inject correlation headers into the response
                 headers = list(message.get("headers", []))
                 headers.append((b"x-request-id", request_id.encode()))
-                if trace_id:
-                    headers.append((b"x-trace-id", trace_id.encode()))
+                headers.append((b"x-trace-id", trace_id.encode()))
                 message = {**message, "headers": headers}
             await send(message)
 

--- a/src/tta/api/routes/admin.py
+++ b/src/tta/api/routes/admin.py
@@ -8,6 +8,8 @@ Endpoint inventory (Appendix A):
   §3.2  Player management  — GET/POST /admin/players/…
   §3.3  Game inspection     — GET/POST /admin/games/…
   §3.4  System health       — GET /admin/health, /admin/metrics
+  §3.4b Log level           — POST /admin/log-level
+  §3.4c Data purge          — POST /admin/purge
   §3.5  Moderation queue    — GET/POST /admin/moderation/…
   §3.6  Rate-limit mgmt     — GET/POST /admin/rate-limits/…
   §3.7  Audit log           — GET /admin/audit-log
@@ -15,6 +17,7 @@ Endpoint inventory (Appendix A):
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from uuid import UUID
 
@@ -490,6 +493,70 @@ async def admin_metrics(
         content=generate_latest(REGISTRY),
         media_type="text/plain; version=0.0.4; charset=utf-8",
     )
+
+
+# §3.4b Log level management
+
+
+class _LogLevelBody(BaseModel):
+    level: str = Field(
+        ...,
+        pattern="^(DEBUG|INFO|WARNING|ERROR)$",
+        description="Target log level.",
+    )
+
+
+@router.post("/log-level")
+async def set_log_level(
+    body: _LogLevelBody,
+    request: Request,
+    _admin: AdminIdentity = Depends(require_admin),
+) -> dict[str, Any]:
+    """Change runtime log level (S15 FR-15.4)."""
+    root = logging.getLogger()
+    previous = logging.getLevelName(root.level)
+    root.setLevel(body.level)
+    log.info(
+        "log_level_changed",
+        previous=previous,
+        new=body.level,
+    )
+    await _audit(
+        request,
+        _admin,
+        action="log_level_changed",
+        target_type="system",
+        target_id="root_logger",
+        reason=f"{previous} → {body.level}",
+    )
+    return {"data": {"previous": previous, "current": body.level}}
+
+
+# §3.4c Data purge
+
+
+@router.post("/purge")
+async def trigger_purge(
+    request: Request,
+    _admin: AdminIdentity = Depends(require_admin),
+    dry_run: bool = Query(False, description="Preview without deleting"),
+) -> dict[str, Any]:
+    """Manual data purge trigger (S17 FR-17.15)."""
+    from tta.privacy.purge import run_purge
+
+    result = await run_purge(
+        request.app.state.pg,
+        dry_run=dry_run,
+    )
+    await _audit(
+        request,
+        _admin,
+        action="purge_triggered",
+        target_type="system",
+        target_id="data_purge",
+        reason=f"dry_run={dry_run} deleted={result.get('sessions_deleted', 0)}",
+    )
+    return {"data": result}
 
 
 # ==================================================================

--- a/src/tta/api/routes/admin.py
+++ b/src/tta/api/routes/admin.py
@@ -29,7 +29,7 @@ from pydantic import BaseModel, Field
 from tta.admin.auth import AdminIdentity, require_admin
 from tta.api.errors import AppError
 from tta.errors import ErrorCategory
-from tta.observability.metrics import REGISTRY, generate_latest
+from tta.observability.metrics import REGISTRY, SESSIONS_ACTIVE, generate_latest
 
 router = APIRouter(tags=["admin"])
 log = structlog.get_logger()
@@ -435,6 +435,8 @@ async def terminate_game(
             f"Game {game_id} not found or not in active/paused state.",
         )
 
+    SESSIONS_ACTIVE.dec()
+
     await _audit(
         request,
         admin,
@@ -554,7 +556,11 @@ async def trigger_purge(
         action="purge_triggered",
         target_type="system",
         target_id="data_purge",
-        reason=f"dry_run={dry_run} deleted={result.get('sessions_deleted', 0)}",
+        reason=(
+            f"dry_run={dry_run} "
+            f"sessions_purged={result.get('sessions_purged', 0)} "
+            f"turns_purged={result.get('turns_purged', 0)}"
+        ),
     )
     return {"data": result}
 

--- a/src/tta/api/routes/games.py
+++ b/src/tta/api/routes/games.py
@@ -32,6 +32,11 @@ from tta.models.events import (
 from tta.models.game import GameStatus
 from tta.models.player import Player
 from tta.models.turn import TurnState, TurnStatus
+from tta.observability.metrics import (
+    SESSION_DURATION,
+    SESSION_TURNS,
+    SESSIONS_ACTIVE,
+)
 from tta.pipeline.orchestrator import run_pipeline
 
 log = structlog.get_logger()
@@ -465,6 +470,7 @@ async def create_game(
         },
     )
     await pg.commit()
+    SESSIONS_ACTIVE.inc()
 
     return {
         "data": GameData(
@@ -1124,6 +1130,12 @@ async def end_game(
     await pg.commit()
 
     turn_count = await _get_turn_count(pg, game_id)
+
+    # Session lifecycle metrics (S15 FR-15.8)
+    SESSIONS_ACTIVE.dec()
+    SESSION_TURNS.observe(turn_count)
+    duration_s = (now - row.created_at).total_seconds()
+    SESSION_DURATION.observe(duration_s)
 
     return {
         "data": GameEndedData(

--- a/src/tta/llm/litellm_client.py
+++ b/src/tta/llm/litellm_client.py
@@ -35,6 +35,11 @@ from tta.llm.roles import (
     ModelRoleConfig,
 )
 from tta.models.turn import TokenCount
+from tta.observability.metrics import (
+    TURN_LLM_CALLS,
+    TURN_LLM_DURATION,
+    TURN_LLM_TOKENS,
+)
 
 log = structlog.get_logger(__name__)
 
@@ -227,6 +232,13 @@ class LiteLLMClient:
             completion_tokens=token_count.completion_tokens,
             cost_usd=cost_usd,
         )
+
+        # Prometheus instrumentation (S15 FR-15.6/7/8)
+        provider = model.split("/", 1)[0] if "/" in model else "unknown"
+        TURN_LLM_CALLS.labels(model=model, provider=provider).inc()
+        TURN_LLM_DURATION.labels(model=model).observe(elapsed_ms / 1000)
+        TURN_LLM_TOKENS.labels(model=model, direction="prompt").inc(prompt_tok)
+        TURN_LLM_TOKENS.labels(model=model, direction="completion").inc(completion_tok)
 
         return LLMResponse(
             content=content,

--- a/src/tta/moderation/hook.py
+++ b/src/tta/moderation/hook.py
@@ -27,6 +27,7 @@ from tta.moderation.models import (
 )
 from tta.moderation.recorder import ModerationRecorder
 from tta.moderation.service import ModerationService
+from tta.observability.metrics import TURN_SAFETY_FLAGS
 from tta.safety.hooks import SafetyResult
 
 log = structlog.get_logger()
@@ -151,6 +152,9 @@ class ModerationHook:
             game_id=ctx.game_id,
             player_id=ctx.player_id,
         )
+
+        # Prometheus: safety flag counter (S15 FR-15.9)
+        TURN_SAFETY_FLAGS.labels(level=result.verdict.value).inc()
 
         # FR-24.09: persist full record
         if self._recorder is not None:

--- a/src/tta/privacy/purge.py
+++ b/src/tta/privacy/purge.py
@@ -65,9 +65,16 @@ async def run_purge(
             }
 
         if dry_run:
-            # Count turns without deleting
+            # Count dependent rows without deleting
+            we_result = await pg.execute(
+                sa.text(
+                    "SELECT count(*) FROM world_events WHERE session_id = ANY(:ids)"
+                ),
+                {"ids": session_ids},
+            )
+            world_events_count = we_result.scalar() or 0
             turn_result = await pg.execute(
-                sa.text("SELECT count(*) FROM turns WHERE game_session_id = ANY(:ids)"),
+                sa.text("SELECT count(*) FROM turns WHERE session_id = ANY(:ids)"),
                 {"ids": session_ids},
             )
             turn_count = turn_result.scalar() or 0
@@ -76,22 +83,31 @@ async def run_purge(
                 action="dry_run",
                 sessions=len(session_ids),
                 turns=turn_count,
+                world_events=world_events_count,
             )
             return {
                 "sessions_purged": len(session_ids),
                 "turns_purged": turn_count,
+                "world_events_purged": world_events_count,
                 "dry_run": True,
                 "cutoff": cutoff.isoformat(),
             }
 
-        # Delete turns first (FK constraint)
+        # Delete in FK-safe order: world_events → turns → sessions.
+        # world_events.turn_id → turns.id has no ON DELETE CASCADE,
+        # so we must delete world_events before turns.
+        we_result = await pg.execute(
+            sa.text("DELETE FROM world_events WHERE session_id = ANY(:ids)"),
+            {"ids": session_ids},
+        )
+        world_events_deleted = we_result.rowcount or 0
+
         turn_result = await pg.execute(
-            sa.text("DELETE FROM turns WHERE game_session_id = ANY(:ids)"),
+            sa.text("DELETE FROM turns WHERE session_id = ANY(:ids)"),
             {"ids": session_ids},
         )
         turns_deleted = turn_result.rowcount or 0
 
-        # Delete game sessions
         session_result = await pg.execute(
             sa.text("DELETE FROM game_sessions WHERE id = ANY(:ids)"),
             {"ids": session_ids},
@@ -105,11 +121,13 @@ async def run_purge(
             action="executed",
             sessions=sessions_deleted,
             turns=turns_deleted,
+            world_events=world_events_deleted,
             cutoff=cutoff.isoformat(),
         )
         return {
             "sessions_purged": sessions_deleted,
             "turns_purged": turns_deleted,
+            "world_events_purged": world_events_deleted,
             "dry_run": False,
             "cutoff": cutoff.isoformat(),
         }

--- a/src/tta/privacy/purge.py
+++ b/src/tta/privacy/purge.py
@@ -1,0 +1,135 @@
+"""Automated data purge for S17 FR-17.15 retention enforcement.
+
+Deletes completed/abandoned game sessions (and their turns) that
+exceed the 90-day retention window defined in ``retention.py``.
+
+Usage:
+  - Background: started automatically by the FastAPI lifespan.
+  - Manual: ``POST /admin/purge?dry_run=true`` for a one-off pass.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import sqlalchemy as sa
+import structlog
+
+from tta.privacy.retention import get_retention_policy
+
+log = structlog.get_logger()
+
+_TERMINAL_STATUSES = ("ended", "abandoned", "completed", "expired")
+
+
+def _retention_days() -> int:
+    policy = get_retention_policy("completed_session_postgresql")
+    if policy and policy.retention_days is not None:
+        return policy.retention_days
+    return 90
+
+
+async def run_purge(
+    session_factory: Any,
+    *,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Execute a single purge pass.
+
+    Returns a summary dict with counts of affected rows.
+    """
+    retention = _retention_days()
+    cutoff = datetime.now(UTC) - timedelta(days=retention)
+
+    async with session_factory() as pg:
+        # Find sessions to purge
+        result = await pg.execute(
+            sa.text(
+                "SELECT id FROM game_sessions "
+                "WHERE status = ANY(:statuses) "
+                "AND updated_at < :cutoff"
+            ),
+            {"statuses": list(_TERMINAL_STATUSES), "cutoff": cutoff},
+        )
+        session_ids = [row[0] for row in result.fetchall()]
+
+        if not session_ids:
+            log.info("purge_pass", action="noop", sessions=0)
+            return {
+                "sessions_purged": 0,
+                "turns_purged": 0,
+                "dry_run": dry_run,
+                "cutoff": cutoff.isoformat(),
+            }
+
+        if dry_run:
+            # Count turns without deleting
+            turn_result = await pg.execute(
+                sa.text("SELECT count(*) FROM turns WHERE game_session_id = ANY(:ids)"),
+                {"ids": session_ids},
+            )
+            turn_count = turn_result.scalar() or 0
+            log.info(
+                "purge_pass",
+                action="dry_run",
+                sessions=len(session_ids),
+                turns=turn_count,
+            )
+            return {
+                "sessions_purged": len(session_ids),
+                "turns_purged": turn_count,
+                "dry_run": True,
+                "cutoff": cutoff.isoformat(),
+            }
+
+        # Delete turns first (FK constraint)
+        turn_result = await pg.execute(
+            sa.text("DELETE FROM turns WHERE game_session_id = ANY(:ids)"),
+            {"ids": session_ids},
+        )
+        turns_deleted = turn_result.rowcount or 0
+
+        # Delete game sessions
+        session_result = await pg.execute(
+            sa.text("DELETE FROM game_sessions WHERE id = ANY(:ids)"),
+            {"ids": session_ids},
+        )
+        sessions_deleted = session_result.rowcount or 0
+
+        await pg.commit()
+
+        log.info(
+            "purge_pass",
+            action="executed",
+            sessions=sessions_deleted,
+            turns=turns_deleted,
+            cutoff=cutoff.isoformat(),
+        )
+        return {
+            "sessions_purged": sessions_deleted,
+            "turns_purged": turns_deleted,
+            "dry_run": False,
+            "cutoff": cutoff.isoformat(),
+        }
+
+
+async def purge_loop(
+    session_factory: Any,
+    *,
+    interval_hours: int = 24,
+) -> None:
+    """Run purge passes on a timer until cancelled."""
+    log.info(
+        "purge_loop_started",
+        interval_hours=interval_hours,
+    )
+    while True:
+        try:
+            await run_purge(session_factory)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception("purge_pass_failed")
+        await asyncio.sleep(interval_hours * 3600)

--- a/tests/unit/admin/test_auth.py
+++ b/tests/unit/admin/test_auth.py
@@ -1,0 +1,123 @@
+"""Tests for admin authentication (S26 FR-26.01–FR-26.04)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from tta.admin.auth import AdminIdentity, require_admin
+from tta.api.errors import AppError
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeClient:
+    host: str = "127.0.0.1"
+
+
+@dataclass
+class _FakeURL:
+    path: str = "/admin/test"
+
+
+@dataclass
+class _FakeSettings:
+    admin_api_key: str | None = "test-secret-key"
+
+
+@dataclass
+class _FakeAppState:
+    settings: _FakeSettings = field(default_factory=_FakeSettings)
+
+
+@dataclass
+class _FakeApp:
+    state: _FakeAppState = field(default_factory=_FakeAppState)
+
+
+class _FakeRequest:
+    """Minimal Request double for testing require_admin."""
+
+    def __init__(
+        self,
+        headers: dict[str, str] | None = None,
+        *,
+        admin_key: str | None = "test-secret-key",
+    ) -> None:
+        self._headers = headers or {}
+        self.client = _FakeClient()
+        self.url = _FakeURL()
+        self.method = "GET"
+        self.app = _FakeApp(
+            state=_FakeAppState(settings=_FakeSettings(admin_api_key=admin_key))
+        )
+
+    @property
+    def headers(self) -> dict[str, Any]:
+        return self._headers
+
+
+# ── Tests ────────────────────────────────────────────────────────────
+
+
+class TestRequireAdmin:
+    """Test the require_admin FastAPI dependency."""
+
+    @pytest.mark.anyio
+    async def test_valid_token_returns_identity(self) -> None:
+        req = _FakeRequest(headers={"Authorization": "Bearer test-secret-key"})
+        result = await require_admin(req)  # type: ignore[arg-type]
+        assert isinstance(result, AdminIdentity)
+        assert result.admin_id == "admin"
+
+    @pytest.mark.anyio
+    async def test_missing_auth_header_raises_401(self) -> None:
+        req = _FakeRequest(headers={})
+        with pytest.raises(AppError) as exc:
+            await require_admin(req)  # type: ignore[arg-type]
+        assert exc.value.code == "ADMIN_TOKEN_MISSING"
+
+    @pytest.mark.anyio
+    async def test_no_bearer_prefix_raises_401(self) -> None:
+        req = _FakeRequest(headers={"Authorization": "test-secret-key"})
+        with pytest.raises(AppError) as exc:
+            await require_admin(req)  # type: ignore[arg-type]
+        assert exc.value.code == "ADMIN_TOKEN_MISSING"
+
+    @pytest.mark.anyio
+    async def test_wrong_token_raises_403(self) -> None:
+        req = _FakeRequest(headers={"Authorization": "Bearer wrong-token"})
+        with pytest.raises(AppError) as exc:
+            await require_admin(req)  # type: ignore[arg-type]
+        assert exc.value.code == "ADMIN_TOKEN_INVALID"
+
+    @pytest.mark.anyio
+    async def test_admin_not_configured_raises_403(self) -> None:
+        req = _FakeRequest(
+            headers={"Authorization": "Bearer anything"},
+            admin_key=None,
+        )
+        with pytest.raises(AppError) as exc:
+            await require_admin(req)  # type: ignore[arg-type]
+        assert exc.value.code == "ADMIN_NOT_CONFIGURED"
+
+    @pytest.mark.anyio
+    async def test_empty_admin_key_raises_403(self) -> None:
+        req = _FakeRequest(
+            headers={"Authorization": "Bearer anything"},
+            admin_key="",
+        )
+        with pytest.raises(AppError) as exc:
+            await require_admin(req)  # type: ignore[arg-type]
+        assert exc.value.code == "ADMIN_NOT_CONFIGURED"
+
+    @pytest.mark.anyio
+    async def test_similar_token_rejected(self) -> None:
+        """Timing-safe comparison rejects near-match tokens."""
+        req = _FakeRequest(headers={"Authorization": "Bearer test-secret-ke"})
+        with pytest.raises(AppError) as exc:
+            await require_admin(req)  # type: ignore[arg-type]
+        assert exc.value.code == "ADMIN_TOKEN_INVALID"

--- a/tests/unit/api/test_app.py
+++ b/tests/unit/api/test_app.py
@@ -79,9 +79,12 @@ class TestRequestIDMiddleware:
         )
         assert resp.headers["x-trace-id"] == "abc-trace-123"
 
-    def test_no_x_trace_id_when_absent(self, client: TestClient) -> None:
+    def test_x_trace_id_falls_back_to_request_id(self, client: TestClient) -> None:
+        """When no X-Trace-Id is sent, the response still has one (from request_id)."""
         resp = client.get("/api/v1/health")
-        assert "x-trace-id" not in resp.headers
+        assert "x-trace-id" in resp.headers
+        assert "x-request-id" in resp.headers
+        assert resp.headers["x-trace-id"] == resp.headers["x-request-id"]
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Wave 13: Metrics Instrumentation & Compliance

### Summary

Instruments 7 Prometheus metrics, adds automated data purge, breach response plan, runtime log-level control, admin auth tests, and X-Trace-Id fix.

### Changes

**Metrics Instrumentation** (S15 FR-15.6/7/8/9, S28 FR-28.10/11)
- LLM: calls, duration, tokens by model/provider in `litellm_client.py`
- Safety: `TURN_SAFETY_FLAGS` by verdict level in `hook.py`
- Sessions: active gauge, turns/duration histograms in `games.py`
- Re-enabled `LLMAPIUnreachable` alert rule

**Automated Data Purge** (S17 FR-17.15)
- `src/tta/privacy/purge.py`: `run_purge()` + `purge_loop()` (24h background)
- Deletes terminal sessions + turns older than retention policy (90 days)
- FastAPI lifespan integration, manual trigger via `POST /admin/purge`

**SECURITY.md** (S17 FR-17.46–50)
- Vulnerability reporting with 48h acknowledgment SLA
- Breach response plan with 72h notification timeline

**Runtime Log Level** (S15 FR-15.4)
- `POST /admin/log-level` with Pydantic validation + audit logging

**Admin Auth Tests** (quality gap)
- 7 test cases: no key, missing header, invalid token, valid token, timing-safe, bearer prefix

**X-Trace-Id Fix** (S15 FR-15.16)
- Always emits X-Trace-Id, falls back to request_id

### Quality Gate
- Tests: 1305 passed, 0 failed
- Pyright: 0 errors | Ruff: 0 errors

### Files Changed (13 files, +546 -29)
