### PR TITLE
feat: character commands, lifecycle job, GDPR deletion (Wave 16)

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1046,9 +1046,64 @@ no turn_count pollution. Client distinguishes by status code: 202 = go to SSE,
 - Pyright: 0 errors
 - Ruff: 0 errors
 
-## 19. Wave 16+ Recommendations
+## 19. Wave 16 — Character Commands & Session Lifecycle
 
-### Wave 16 — Gameplay Polish
+**Branch**: `wave-16/character-commands-lifecycle`
+**Specs**: S01, S06, S11, S12
+**Tests**: 1404 passing (+26 over Wave 15 baseline of 1378)
+
+### What shipped
+
+1. **`/character` command** (S06-AC-6.1) — Displays player character name, concept,
+   and tone from `world_seed` JSON. Graceful fallback for pre-genesis games.
+
+2. **`/relationships` command** (S06-AC-6.3) — Shows template NPCs with roles and
+   dispositions, loaded from `WorldTemplate.npcs` via `template_registry`.
+
+3. **`/end` command** (S01-AC-1.6) — Transitions game from `active` → `ended`,
+   returns epilogue-style message with prompt to start a new game.
+
+4. **Lifecycle background job** (S11-AC-11.05-08) — New `src/tta/lifecycle/` module:
+   - Rule 1: `active` + 0 turns + age > 24h → `abandoned`
+   - Rule 2: `paused` + last_played > 30 days → `expired`
+   - Runs every 1h alongside existing `purge_loop`
+
+5. **GDPR account deletion** (S12-AC-12.03) — Replaced stub with real implementation:
+   - Tombstones player: `status='pending_deletion'`, `handle='deleted-{id}'`
+   - Ends all active/paused game sessions
+   - NULLs PII: `turns.player_input`, `turns.narrative_output`,
+     `game_sessions.world_seed`, `game_sessions.summary`
+   - Deletes all `player_sessions` (session tokens)
+   - Single transaction, immediate erasure (v1 simplicity)
+   - Migration 006: adds `deletion_requested_at` to `players`
+
+### Files added
+- `src/tta/lifecycle/__init__.py`, `src/tta/lifecycle/cleanup.py`
+- `tests/unit/lifecycle/__init__.py`, `tests/unit/lifecycle/test_cleanup.py`
+- `migrations/postgres/versions/006_gdpr_deletion.py`
+
+### Files modified
+- `src/tta/api/routes/games.py` — 3 new commands + `deleted_at IS NULL` filter
+- `src/tta/api/routes/players.py` — real GDPR deletion endpoint
+- `src/tta/api/app.py` — lifecycle_loop wired into lifespan
+- `src/tta/models/player.py` — `deletion_requested_at` field
+- `tests/unit/api/test_commands.py` — 24 command tests (rewritten)
+- `tests/unit/privacy/test_gdpr_endpoints.py` — 10 deletion tests (rewritten)
+
+### Known v1 limitations
+- `/character` shows static genesis data, not evolving traits (no live character state system)
+- `/relationships` shows template NPCs, not live relationship state
+- `/end` unreachable from paused games (submit_turn rejects non-active); use PATCH endpoint
+- S11-AC-11.09/11.10 deferred (require email/password auth, not anonymous handles)
+
+### AC coverage impact
+- S06-AC-6.1 ✓, S06-AC-6.3 ✓, S01-AC-1.6 ✓
+- S11-AC-11.06 ✓, S11-AC-11.08 ✓, S12-AC-12.03 ✓
+- Estimated: ~35% → ~45% overall AC coverage
+
+## 20. Wave 17+ Recommendations
+
+### Wave 17 — Gameplay Polish & Observability
 
 1. Alertmanager integration for notification routing (PagerDuty, Slack, email)
 2. Performance load testing and SLO validation against S28 targets
@@ -1056,6 +1111,8 @@ no turn_count pollution. Client distinguishes by status code: 202 = go to SSE,
 4. Session token rotation (security improvement)
 5. Turn history pagination (S12 FR-12.03)
 6. Game resume flow validation (S01 AC-1.7)
+7. Live character state system (evolving traits beyond genesis)
+8. Neo4j world data cleanup on game/account deletion (S17 multi-store erasure)
 
 ### Beyond v1
 

--- a/migrations/postgres/versions/006_gdpr_deletion.py
+++ b/migrations/postgres/versions/006_gdpr_deletion.py
@@ -1,0 +1,28 @@
+"""Add deletion_requested_at to players for GDPR erasure (S17 FR-17.10).
+
+Revision ID: 006
+Revises: 005
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "006"
+down_revision = "005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "players",
+        sa.Column(
+            "deletion_requested_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("players", "deletion_requested_at")

--- a/src/tta/api/app.py
+++ b/src/tta/api/app.py
@@ -278,12 +278,16 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         redis=settings.redis_url,
     )
 
-    # Start background purge loop (S17 FR-17.15)
+    # Start background loops
     import asyncio
 
+    from tta.lifecycle.cleanup import lifecycle_loop
     from tta.privacy.purge import purge_loop
 
     purge_task = asyncio.create_task(purge_loop(session_factory, interval_hours=24))
+    lifecycle_task = asyncio.create_task(
+        lifecycle_loop(session_factory, interval_hours=1)
+    )
 
     # Start pool metrics sampler (S28 FR-28.10)
     from tta.observability.pool_metrics import start_pool_metrics_sampler
@@ -296,6 +300,11 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     metrics_task.cancel()
     try:
         await metrics_task
+    except asyncio.CancelledError:
+        pass
+    lifecycle_task.cancel()
+    try:
+        await lifecycle_task
     except asyncio.CancelledError:
         pass
     purge_task.cancel()

--- a/src/tta/api/routes/games.py
+++ b/src/tta/api/routes/games.py
@@ -379,7 +379,7 @@ _PUBLIC_STATE_MAP: dict[str, str] = {
     "active": "active",
     "paused": "active",
     "completed": "completed",
-    "ended": "abandoned",
+    "ended": "completed",
     "expired": "abandoned",
     "abandoned": "abandoned",
 }
@@ -485,13 +485,25 @@ _NUDGE_PHRASES = (
     "The scene invites a choice. What feels right to do next?",
 )
 
-_KNOWN_COMMANDS = frozenset({"help", "save", "status"})
+_KNOWN_COMMANDS = frozenset(
+    {
+        "help",
+        "save",
+        "status",
+        "character",
+        "relationships",
+        "end",
+    }
+)
 
 _HELP_TEXT = (
     "Available commands:\n"
-    "  /help   \u2014 Show this list of commands\n"
-    "  /save   \u2014 Save your current progress\n"
-    "  /status \u2014 View your game session info\n"
+    "  /help          \u2014 Show this list of commands\n"
+    "  /save          \u2014 Save your current progress\n"
+    "  /status        \u2014 View your game session info\n"
+    "  /character     \u2014 View your character details\n"
+    "  /relationships \u2014 See the people you've met\n"
+    "  /end           \u2014 End your story and see your epilogue\n"
     "\nOr simply type what you'd like to do in the world."
 )
 
@@ -512,6 +524,8 @@ async def _execute_command(
     game_id: UUID,
     row: object,
     pg: AsyncSession,
+    *,
+    template_registry: object | None = None,
 ) -> dict:
     """Execute a known slash command and return response payload."""
     if cmd == "help":
@@ -548,7 +562,124 @@ async def _execute_command(
         )
         return {"type": "command", "command": "status", "message": msg}
 
+    if cmd == "character":
+        return _build_character_response(row)
+
+    if cmd == "relationships":
+        return _build_relationships_response(row, template_registry=template_registry)
+
+    if cmd == "end":
+        return await _execute_end_command(game_id, row, pg)
+
     return {"type": "command", "command": "help", "message": _HELP_TEXT}
+
+
+def _build_character_response(row: object) -> dict:
+    """Build response for /character command from persisted world_seed dict."""
+    ws_raw = getattr(row, "world_seed", None)
+    if not ws_raw or not isinstance(ws_raw, dict):
+        return {
+            "type": "command",
+            "command": "character",
+            "message": "Your character hasn't been created yet. "
+            "Play a turn to begin your story.",
+        }
+    prefs = ws_raw.get("preferences", {})
+    name = prefs.get("character_name") or "Unknown"
+    concept = prefs.get("character_concept") or "A wanderer with no known past"
+    tone = prefs.get("tone")
+    parts = [f"Character: {name}", f"  {concept}"]
+    if tone:
+        parts.append(f"  Tone: {tone}")
+    return {
+        "type": "command",
+        "command": "character",
+        "message": "\n".join(parts),
+    }
+
+
+def _build_relationships_response(
+    row: object,
+    *,
+    template_registry: object | None = None,
+) -> dict:
+    """Build response for /relationships command using template NPCs."""
+    ws_raw = getattr(row, "world_seed", None)
+    if not ws_raw or not isinstance(ws_raw, dict):
+        return {
+            "type": "command",
+            "command": "relationships",
+            "message": "You haven't met anyone yet.",
+        }
+    template_key = ws_raw.get("genesis", {}).get("template_key")
+    if not template_key or not template_registry:
+        return {
+            "type": "command",
+            "command": "relationships",
+            "message": "You haven't met anyone yet.",
+        }
+    try:
+        template = template_registry.get(template_key)  # type: ignore[union-attr]
+    except (KeyError, AttributeError):
+        return {
+            "type": "command",
+            "command": "relationships",
+            "message": "Relationship details are unavailable.",
+        }
+    npcs = getattr(template, "npcs", None) or []
+    if not npcs:
+        return {
+            "type": "command",
+            "command": "relationships",
+            "message": "You haven't met anyone yet.",
+        }
+    lines = ["People you know:"]
+    for npc in npcs:
+        name = npc.key.replace("_", " ").title()
+        role_label = npc.role.value if hasattr(npc.role, "value") else str(npc.role)
+        lines.append(f"  {name} — {role_label}, {npc.disposition}")
+    return {
+        "type": "command",
+        "command": "relationships",
+        "message": "\n".join(lines),
+    }
+
+
+async def _execute_end_command(
+    game_id: UUID,
+    row: object,
+    pg: AsyncSession,
+) -> dict:
+    """End the current game and return an epilogue message."""
+    status = getattr(row, "status", None)
+    if status in ("ended", "completed", "abandoned"):
+        return {
+            "type": "command",
+            "command": "end",
+            "message": "This story has already concluded.",
+        }
+    now = datetime.now(UTC)
+    await pg.execute(
+        sa.text(
+            "UPDATE game_sessions SET status = 'ended', "
+            "updated_at = :now WHERE id = :id"
+        ),
+        {"id": game_id, "now": now},
+    )
+    await pg.commit()
+    turn_count = await _get_turn_count(pg, game_id)
+    name = "Traveler"
+    ws_raw = getattr(row, "world_seed", None)
+    if isinstance(ws_raw, dict):
+        name = ws_raw.get("preferences", {}).get("character_name") or name
+    msg = (
+        f"The story of {name} comes to a close.\n"
+        f"Over {turn_count} turn{'s' if turn_count != 1 else ''}, "
+        "you shaped this world with your choices.\n\n"
+        "Thank you for playing. "
+        "Start a new game whenever you're ready for another adventure."
+    )
+    return {"type": "command", "command": "end", "message": msg}
 
 
 # --- Helper functions ---
@@ -562,7 +693,7 @@ async def _get_owned_game(pg: AsyncSession, game_id: UUID, player: Player) -> sa
             "title, summary, turn_count, last_played_at, "
             "deleted_at, needs_recovery, summary_generated_at, "
             "created_at, updated_at "
-            "FROM game_sessions WHERE id = :id"
+            "FROM game_sessions WHERE id = :id AND deleted_at IS NULL"
         ),
         {"id": game_id},
     )
@@ -954,7 +1085,14 @@ async def submit_turn(
     if normalized.startswith("/") and len(normalized) > 1:
         known_cmd = _parse_slash_command(normalized)
         if known_cmd:
-            payload = await _execute_command(known_cmd, game_id, row, pg)
+            reg = getattr(request.app.state, "template_registry", None)
+            payload = await _execute_command(
+                known_cmd,
+                game_id,
+                row,
+                pg,
+                template_registry=reg,
+            )
         else:
             payload = {
                 "type": "command",

--- a/src/tta/api/routes/players.py
+++ b/src/tta/api/routes/players.py
@@ -199,7 +199,7 @@ class DataExportResponse(BaseModel):
 
 class AccountDeletionResponse(BaseModel):
     status: str = "accepted"
-    message: str = "Account deletion scheduled. Data will be erased within 30 days."
+    message: str = "Account deleted. All personal data has been erased."
 
 
 @router.get("/me/data-export", status_code=202)
@@ -218,11 +218,69 @@ async def request_data_export(
 @router.delete("/me", status_code=202)
 async def request_account_deletion(
     player: Player = Depends(get_current_player),
+    pg: AsyncSession = Depends(get_pg),
 ) -> dict:
-    """Request account and data erasure (GDPR Art. 17).
+    """Erase account and all personal data (GDPR Art. 17, S17 FR-17.10).
 
-    Stub — full 30-day erasure pipeline deferred to post-v1.
+    Performs immediate PII removal:
+    1. Marks player as pending_deletion with tombstone handle
+    2. Ends all active/paused game sessions
+    3. Scrubs PII from turns and game sessions
+    4. Invalidates all session tokens
     """
+    now = datetime.now(UTC)
+    pid = player.id
+
+    # 1. Tombstone the player record
+    await pg.execute(
+        sa.text(
+            "UPDATE players SET "
+            "status = 'pending_deletion', "
+            "handle = :tombstone, "
+            "deletion_requested_at = :now, "
+            "updated_at = :now "
+            "WHERE id = :pid"
+        ),
+        {"tombstone": f"deleted-{pid}", "now": now, "pid": pid},
+    )
+
+    # 2. End all active/paused game sessions
+    await pg.execute(
+        sa.text(
+            "UPDATE game_sessions SET status = 'ended', updated_at = :now "
+            "WHERE player_id = :pid AND status IN ('active', 'paused')"
+        ),
+        {"pid": pid, "now": now},
+    )
+
+    # 3. Scrub PII from turns (player_input, narrative_output)
+    await pg.execute(
+        sa.text(
+            "UPDATE turns SET player_input = NULL, narrative_output = NULL "
+            "WHERE session_id IN "
+            "(SELECT id FROM game_sessions WHERE player_id = :pid)"
+        ),
+        {"pid": pid},
+    )
+
+    # 4. Scrub PII from game sessions (world_seed, summary)
+    await pg.execute(
+        sa.text(
+            "UPDATE game_sessions "
+            "SET world_seed = NULL, summary = NULL "
+            "WHERE player_id = :pid"
+        ),
+        {"pid": pid},
+    )
+
+    # 5. Invalidate all session tokens
+    await pg.execute(
+        sa.text("DELETE FROM player_sessions WHERE player_id = :pid"),
+        {"pid": pid},
+    )
+
+    await pg.commit()
+
     data = AccountDeletionResponse().model_dump()
-    data["player_id"] = str(player.id)
+    data["player_id"] = str(pid)
     return {"data": data}

--- a/src/tta/api/routes/players.py
+++ b/src/tta/api/routes/players.py
@@ -199,7 +199,7 @@ class DataExportResponse(BaseModel):
 
 class AccountDeletionResponse(BaseModel):
     status: str = "accepted"
-    message: str = "Account deleted. All personal data has been erased."
+    message: str = "Account deletion accepted. Personal data has been erased."
 
 
 @router.get("/me/data-export", status_code=202)
@@ -248,7 +248,8 @@ async def request_account_deletion(
     await pg.execute(
         sa.text(
             "UPDATE game_sessions SET status = 'ended', updated_at = :now "
-            "WHERE player_id = :pid AND status IN ('active', 'paused')"
+            "WHERE player_id = :pid "
+            "AND status IN ('created', 'active', 'paused')"
         ),
         {"pid": pid, "now": now},
     )
@@ -256,7 +257,8 @@ async def request_account_deletion(
     # 3. Scrub PII from turns (player_input, narrative_output)
     await pg.execute(
         sa.text(
-            "UPDATE turns SET player_input = NULL, narrative_output = NULL "
+            "UPDATE turns "
+            "SET player_input = '[redacted]', narrative_output = NULL "
             "WHERE session_id IN "
             "(SELECT id FROM game_sessions WHERE player_id = :pid)"
         ),
@@ -267,7 +269,7 @@ async def request_account_deletion(
     await pg.execute(
         sa.text(
             "UPDATE game_sessions "
-            "SET world_seed = NULL, summary = NULL "
+            "SET world_seed = '{}'::jsonb, summary = NULL "
             "WHERE player_id = :pid"
         ),
         {"pid": pid},

--- a/src/tta/lifecycle/__init__.py
+++ b/src/tta/lifecycle/__init__.py
@@ -1,0 +1,1 @@
+"""Game lifecycle management — background cleanup and state transitions."""

--- a/src/tta/lifecycle/cleanup.py
+++ b/src/tta/lifecycle/cleanup.py
@@ -1,7 +1,7 @@
 """Automated game-session lifecycle transitions (S11 FR-11.41–45).
 
 Transitions enforced:
-  - ``active``  + 0 turns + age > 24 h  →  ``abandoned``
+  - ``created``/``active``  + 0 turns + age > 24 h  →  ``abandoned``
   - ``paused``  + last_played > 30 days  →  ``expired``
 
 Usage:
@@ -40,12 +40,12 @@ async def run_lifecycle_pass(
     expire_cutoff = now - timedelta(days=expire_days)
 
     async with session_factory() as pg:
-        # Rule 1: active + 0 turns + older than 24 h → abandoned
+        # Rule 1: created/active + 0 turns + older than 24 h → abandoned
         abandon_result = await pg.execute(
             sa.text(
                 "UPDATE game_sessions "
                 "SET status = 'abandoned', updated_at = :now "
-                "WHERE status = 'active' "
+                "WHERE status IN ('created', 'active') "
                 "AND turn_count = 0 "
                 "AND created_at < :cutoff "
                 "AND deleted_at IS NULL"

--- a/src/tta/lifecycle/cleanup.py
+++ b/src/tta/lifecycle/cleanup.py
@@ -1,0 +1,95 @@
+"""Automated game-session lifecycle transitions (S11 FR-11.41–45).
+
+Transitions enforced:
+  - ``active``  + 0 turns + age > 24 h  →  ``abandoned``
+  - ``paused``  + last_played > 30 days  →  ``expired``
+
+Usage:
+  - Background: started automatically by the FastAPI lifespan.
+  - Manual: import ``run_lifecycle_pass`` for one-off execution.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import sqlalchemy as sa
+import structlog
+
+log = structlog.get_logger()
+
+# Thresholds (match spec S11 FR-11.41–45)
+ABANDON_HOURS = 24
+EXPIRE_DAYS = 30
+
+
+async def run_lifecycle_pass(
+    session_factory: Any,
+    *,
+    abandon_hours: int = ABANDON_HOURS,
+    expire_days: int = EXPIRE_DAYS,
+) -> dict[str, int]:
+    """Execute a single lifecycle-transition pass.
+
+    Returns a summary dict with counts of affected rows.
+    """
+    now = datetime.now(UTC)
+    abandon_cutoff = now - timedelta(hours=abandon_hours)
+    expire_cutoff = now - timedelta(days=expire_days)
+
+    async with session_factory() as pg:
+        # Rule 1: active + 0 turns + older than 24 h → abandoned
+        abandon_result = await pg.execute(
+            sa.text(
+                "UPDATE game_sessions "
+                "SET status = 'abandoned', updated_at = :now "
+                "WHERE status = 'active' "
+                "AND turn_count = 0 "
+                "AND created_at < :cutoff "
+                "AND deleted_at IS NULL"
+            ),
+            {"now": now, "cutoff": abandon_cutoff},
+        )
+        abandoned = abandon_result.rowcount or 0
+
+        # Rule 2: paused + last_played > 30 days → expired
+        expire_result = await pg.execute(
+            sa.text(
+                "UPDATE game_sessions "
+                "SET status = 'expired', updated_at = :now "
+                "WHERE status = 'paused' "
+                "AND last_played_at < :cutoff "
+                "AND deleted_at IS NULL"
+            ),
+            {"now": now, "cutoff": expire_cutoff},
+        )
+        expired = expire_result.rowcount or 0
+
+        if abandoned or expired:
+            await pg.commit()
+
+        log.info(
+            "lifecycle_pass",
+            abandoned=abandoned,
+            expired=expired,
+        )
+        return {"abandoned": abandoned, "expired": expired}
+
+
+async def lifecycle_loop(
+    session_factory: Any,
+    *,
+    interval_hours: int = 1,
+) -> None:
+    """Run lifecycle passes on a timer until cancelled."""
+    log.info("lifecycle_loop_started", interval_hours=interval_hours)
+    while True:
+        try:
+            await run_lifecycle_pass(session_factory)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception("lifecycle_pass_failed")
+        await asyncio.sleep(interval_hours * 3600)

--- a/src/tta/models/player.py
+++ b/src/tta/models/player.py
@@ -13,6 +13,7 @@ class Player(BaseModel):
     handle: str
     status: str = "active"
     suspended_reason: str | None = None
+    deletion_requested_at: datetime | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
 

--- a/tests/unit/api/test_commands.py
+++ b/tests/unit/api/test_commands.py
@@ -39,12 +39,13 @@ def _game_row(
     template_id: str = "enchanted-forest",
     last_played_at: datetime | None = _NOW,
     needs_recovery: bool = False,
+    world_seed: Any = "{}",
 ) -> dict[str, Any]:
     return {
         "id": game_id or _GAME_ID,
         "player_id": player_id or _PLAYER_ID,
         "status": status,
-        "world_seed": "{}",
+        "world_seed": world_seed,
         "title": None,
         "summary": None,
         "turn_count": turn_count,
@@ -243,3 +244,205 @@ class TestCommandOnInactiveGame:
         pg.execute.return_value = _make_result([_game_row(status="ended")])
         resp = client.post(f"/api/v1/games/{_GAME_ID}/turns", json={"input": "/help"})
         assert resp.status_code == 409
+
+
+# --- World seed fixture for character/relationships tests ---
+
+_WORLD_SEED_DICT: dict[str, Any] = {
+    "world_id": "test-world",
+    "preferences": {
+        "character_name": "Elara",
+        "character_concept": "A wandering herbalist seeking lost knowledge",
+        "tone": "whimsical",
+    },
+    "genesis": {
+        "world_id": "test-world",
+        "player_location_id": "clearing",
+        "template_key": "enchanted-forest",
+        "narrative_intro": "The mist parts before you...",
+    },
+}
+
+
+# --- /character command tests (S06-AC-6.1) ---
+
+
+class TestCharacterCommand:
+    def test_character_returns_details(self, client: TestClient, pg: AsyncMock) -> None:
+        pg.execute.return_value = _make_result([_game_row(world_seed=_WORLD_SEED_DICT)])
+        resp = client.post(
+            f"/api/v1/games/{_GAME_ID}/turns", json={"input": "/character"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["command"] == "character"
+        assert "Elara" in data["message"]
+        assert "herbalist" in data["message"]
+
+    def test_character_includes_tone(self, client: TestClient, pg: AsyncMock) -> None:
+        pg.execute.return_value = _make_result([_game_row(world_seed=_WORLD_SEED_DICT)])
+        resp = client.post(
+            f"/api/v1/games/{_GAME_ID}/turns", json={"input": "/character"}
+        )
+        data = resp.json()["data"]
+        assert "whimsical" in data["message"].lower()
+
+    def test_character_no_world_seed(self, client: TestClient, pg: AsyncMock) -> None:
+        pg.execute.return_value = _make_result([_game_row(world_seed=None)])
+        resp = client.post(
+            f"/api/v1/games/{_GAME_ID}/turns", json={"input": "/character"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["command"] == "character"
+        assert "hasn't been created" in data["message"]
+
+    def test_character_invalid_world_seed(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        pg.execute.return_value = _make_result([_game_row(world_seed="not-json")])
+        resp = client.post(
+            f"/api/v1/games/{_GAME_ID}/turns", json={"input": "/character"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["command"] == "character"
+        assert "hasn't been created" in data["message"].lower()
+
+
+# --- /relationships command tests (S06-AC-6.3) ---
+
+
+class TestRelationshipsCommand:
+    def _mock_npc(self, key: str, role: str, disposition: str) -> MagicMock:
+        npc = MagicMock()
+        npc.key = key
+        npc.role = MagicMock(value=role)
+        npc.disposition = disposition
+        return npc
+
+    def test_relationships_lists_npcs(
+        self, client: TestClient, app: FastAPI, pg: AsyncMock
+    ) -> None:
+        template = MagicMock()
+        template.npcs = [
+            self._mock_npc("old_sage", "quest_giver", "friendly"),
+            self._mock_npc("shadow_fox", "merchant", "wary"),
+        ]
+        registry = MagicMock()
+        registry.get.return_value = template
+        app.state.template_registry = registry
+
+        pg.execute.return_value = _make_result([_game_row(world_seed=_WORLD_SEED_DICT)])
+        resp = client.post(
+            f"/api/v1/games/{_GAME_ID}/turns", json={"input": "/relationships"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["command"] == "relationships"
+        assert "Old Sage" in data["message"]
+        assert "Shadow Fox" in data["message"]
+        assert "friendly" in data["message"]
+        assert "wary" in data["message"]
+
+    def test_relationships_no_world_seed(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        pg.execute.return_value = _make_result([_game_row(world_seed=None)])
+        resp = client.post(
+            f"/api/v1/games/{_GAME_ID}/turns", json={"input": "/relationships"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert "haven't met anyone" in data["message"]
+
+    def test_relationships_empty_npcs(
+        self, client: TestClient, app: FastAPI, pg: AsyncMock
+    ) -> None:
+        template = MagicMock()
+        template.npcs = []
+        registry = MagicMock()
+        registry.get.return_value = template
+        app.state.template_registry = registry
+
+        pg.execute.return_value = _make_result([_game_row(world_seed=_WORLD_SEED_DICT)])
+        resp = client.post(
+            f"/api/v1/games/{_GAME_ID}/turns", json={"input": "/relationships"}
+        )
+        data = resp.json()["data"]
+        assert "haven't met anyone" in data["message"]
+
+
+# --- /end command tests (S01-AC-1.6) ---
+
+
+class TestEndCommand:
+    def test_end_transitions_to_ended(self, client: TestClient, pg: AsyncMock) -> None:
+        pg.execute.side_effect = [
+            _make_result([_game_row(world_seed=_WORLD_SEED_DICT)]),
+            MagicMock(),  # UPDATE
+            _make_result(scalar=10),  # turn count
+        ]
+        resp = client.post(f"/api/v1/games/{_GAME_ID}/turns", json={"input": "/end"})
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["command"] == "end"
+        assert "Elara" in data["message"]
+        assert "10 turns" in data["message"]
+        assert "new game" in data["message"].lower()
+
+    def test_end_already_ended(self, client: TestClient, pg: AsyncMock) -> None:
+        """Ending an already-ended game returns 409 (status check before routing)."""
+        pg.execute.return_value = _make_result(
+            [_game_row(status="ended", world_seed=_WORLD_SEED_DICT)]
+        )
+        resp = client.post(f"/api/v1/games/{_GAME_ID}/turns", json={"input": "/end"})
+        assert resp.status_code == 409
+
+    def test_end_without_character_name(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        seed: dict[str, Any] = {
+            "world_id": "test-world",
+            "preferences": {"tone": "dark"},
+            "genesis": {
+                "world_id": "test-world",
+                "player_location_id": "void",
+                "template_key": "test-template",
+                "narrative_intro": "...",
+            },
+        }
+        pg.execute.side_effect = [
+            _make_result([_game_row(world_seed=seed)]),
+            MagicMock(),  # UPDATE
+            _make_result(scalar=3),  # turn count
+        ]
+        resp = client.post(f"/api/v1/games/{_GAME_ID}/turns", json={"input": "/end"})
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert "Traveler" in data["message"]
+        assert "3 turns" in data["message"]
+
+    def test_end_singular_turn(self, client: TestClient, pg: AsyncMock) -> None:
+        pg.execute.side_effect = [
+            _make_result([_game_row(world_seed=_WORLD_SEED_DICT)]),
+            MagicMock(),  # UPDATE
+            _make_result(scalar=1),  # turn count
+        ]
+        resp = client.post(f"/api/v1/games/{_GAME_ID}/turns", json={"input": "/end"})
+        data = resp.json()["data"]
+        assert "1 turn," in data["message"]
+        assert "1 turns" not in data["message"]
+
+
+# --- Help text includes new commands ---
+
+
+class TestHelpTextUpdated:
+    def test_help_includes_character(self, client: TestClient, pg: AsyncMock) -> None:
+        _setup_active_game(pg)
+        resp = client.post(f"/api/v1/games/{_GAME_ID}/turns", json={"input": "/help"})
+        data = resp.json()["data"]
+        assert "/character" in data["message"]
+        assert "/relationships" in data["message"]
+        assert "/end" in data["message"]

--- a/tests/unit/lifecycle/test_cleanup.py
+++ b/tests/unit/lifecycle/test_cleanup.py
@@ -1,0 +1,158 @@
+"""Tests for game-session lifecycle transitions (S11 FR-11.41–45)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tta.lifecycle.cleanup import run_lifecycle_pass
+
+
+def _make_pg(*, abandon_rowcount: int = 0, expire_rowcount: int = 0) -> AsyncMock:
+    """Build a mock PG session that returns the given rowcounts."""
+    pg = AsyncMock()
+    abandon_result = SimpleNamespace(rowcount=abandon_rowcount)
+    expire_result = SimpleNamespace(rowcount=expire_rowcount)
+    pg.execute = AsyncMock(side_effect=[abandon_result, expire_result])
+    pg.commit = AsyncMock()
+    return pg
+
+
+def _make_factory(pg: AsyncMock):  # noqa: ANN201
+    """Wrap a mock PG session in an async context-manager factory."""
+
+    @asynccontextmanager
+    async def factory() -> AsyncIterator[AsyncMock]:
+        yield pg
+
+    return factory
+
+
+class TestAbandonRule:
+    """active + 0 turns + >24h → abandoned."""
+
+    @pytest.mark.anyio
+    async def test_abandons_stale_active_games(self) -> None:
+        pg = _make_pg(abandon_rowcount=3)
+        factory = _make_factory(pg)
+
+        result = await run_lifecycle_pass(factory)
+
+        assert result["abandoned"] == 3
+        abandon_call = pg.execute.call_args_list[0]
+        sql_text = str(abandon_call.args[0].text)
+        assert "status = 'active'" in sql_text
+        assert "turn_count = 0" in sql_text
+        assert "deleted_at IS NULL" in sql_text
+        pg.commit.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_no_abandoned_means_no_commit(self) -> None:
+        pg = _make_pg(abandon_rowcount=0, expire_rowcount=0)
+        factory = _make_factory(pg)
+
+        result = await run_lifecycle_pass(factory)
+
+        assert result["abandoned"] == 0
+        assert result["expired"] == 0
+        pg.commit.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_abandon_cutoff_is_24h(self) -> None:
+        pg = _make_pg(abandon_rowcount=1)
+        factory = _make_factory(pg)
+
+        await run_lifecycle_pass(factory, abandon_hours=24)
+
+        params = pg.execute.call_args_list[0].args[1]
+        cutoff = params["cutoff"]
+        expected = datetime.now(UTC) - timedelta(hours=24)
+        assert abs((cutoff - expected).total_seconds()) < 5
+
+
+class TestExpireRule:
+    """paused + last_played > 30 days → expired."""
+
+    @pytest.mark.anyio
+    async def test_expires_stale_paused_games(self) -> None:
+        pg = _make_pg(expire_rowcount=5)
+        factory = _make_factory(pg)
+
+        result = await run_lifecycle_pass(factory)
+
+        assert result["expired"] == 5
+        expire_call = pg.execute.call_args_list[1]
+        sql_text = str(expire_call.args[0].text)
+        assert "status = 'paused'" in sql_text
+        assert "last_played_at" in sql_text
+        assert "deleted_at IS NULL" in sql_text
+        pg.commit.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_expire_cutoff_is_30_days(self) -> None:
+        pg = _make_pg(expire_rowcount=1)
+        factory = _make_factory(pg)
+
+        await run_lifecycle_pass(factory, expire_days=30)
+
+        params = pg.execute.call_args_list[1].args[1]
+        cutoff = params["cutoff"]
+        expected = datetime.now(UTC) - timedelta(days=30)
+        assert abs((cutoff - expected).total_seconds()) < 5
+
+
+class TestMixedTransitions:
+    """Both rules fire in a single pass."""
+
+    @pytest.mark.anyio
+    async def test_both_rules_apply(self) -> None:
+        pg = _make_pg(abandon_rowcount=2, expire_rowcount=3)
+        factory = _make_factory(pg)
+
+        result = await run_lifecycle_pass(factory)
+
+        assert result["abandoned"] == 2
+        assert result["expired"] == 3
+        pg.commit.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_custom_thresholds(self) -> None:
+        pg = _make_pg(abandon_rowcount=1, expire_rowcount=1)
+        factory = _make_factory(pg)
+
+        await run_lifecycle_pass(factory, abandon_hours=48, expire_days=60)
+
+        abandon_params = pg.execute.call_args_list[0].args[1]
+        expire_params = pg.execute.call_args_list[1].args[1]
+        now = datetime.now(UTC)
+        assert (
+            abs(
+                (abandon_params["cutoff"] - (now - timedelta(hours=48))).total_seconds()
+            )
+            < 5
+        )
+        assert (
+            abs((expire_params["cutoff"] - (now - timedelta(days=60))).total_seconds())
+            < 5
+        )
+
+
+class TestErrorHandling:
+    """Lifecycle pass handles DB errors gracefully."""
+
+    @pytest.mark.anyio
+    async def test_db_error_propagates(self) -> None:
+        pg = AsyncMock()
+        pg.execute = AsyncMock(side_effect=RuntimeError("connection lost"))
+
+        @asynccontextmanager
+        async def factory() -> AsyncIterator[AsyncMock]:
+            yield pg
+
+        with pytest.raises(RuntimeError, match="connection lost"):
+            await run_lifecycle_pass(factory)

--- a/tests/unit/lifecycle/test_cleanup.py
+++ b/tests/unit/lifecycle/test_cleanup.py
@@ -34,7 +34,7 @@ def _make_factory(pg: AsyncMock):  # noqa: ANN201
 
 
 class TestAbandonRule:
-    """active + 0 turns + >24h → abandoned."""
+    """created/active + 0 turns + >24h → abandoned."""
 
     @pytest.mark.anyio
     async def test_abandons_stale_active_games(self) -> None:
@@ -46,7 +46,7 @@ class TestAbandonRule:
         assert result["abandoned"] == 3
         abandon_call = pg.execute.call_args_list[0]
         sql_text = str(abandon_call.args[0].text)
-        assert "status = 'active'" in sql_text
+        assert "IN ('created', 'active')" in sql_text
         assert "turn_count = 0" in sql_text
         assert "deleted_at IS NULL" in sql_text
         pg.commit.assert_awaited_once()

--- a/tests/unit/privacy/test_gdpr_endpoints.py
+++ b/tests/unit/privacy/test_gdpr_endpoints.py
@@ -98,7 +98,7 @@ class TestAccountDeletionEndpoint:
         authed_client: TestClient,
         pg_mock: AsyncMock,
     ) -> None:
-        """All active/paused game sessions ended."""
+        """All created/active/paused game sessions ended."""
         authed_client.delete("/api/v1/players/me")
 
         second_call = pg_mock.execute.call_args_list[1]
@@ -107,7 +107,7 @@ class TestAccountDeletionEndpoint:
 
         assert "game_sessions" in sql_text
         assert "status = 'ended'" in sql_text
-        assert "('active', 'paused')" in sql_text
+        assert "('created', 'active', 'paused')" in sql_text
         assert params["pid"] == _PLAYER_ID
 
     def test_scrubs_turn_pii(
@@ -115,13 +115,13 @@ class TestAccountDeletionEndpoint:
         authed_client: TestClient,
         pg_mock: AsyncMock,
     ) -> None:
-        """Turn player_input and narrative_output NULLed."""
+        """Turn player_input tombstoned, narrative_output NULLed."""
         authed_client.delete("/api/v1/players/me")
 
         third_call = pg_mock.execute.call_args_list[2]
         sql_text = str(third_call.args[0].text)
 
-        assert "player_input = NULL" in sql_text
+        assert "player_input = '[redacted]'" in sql_text
         assert "narrative_output = NULL" in sql_text
         assert "turns" in sql_text
 
@@ -130,13 +130,13 @@ class TestAccountDeletionEndpoint:
         authed_client: TestClient,
         pg_mock: AsyncMock,
     ) -> None:
-        """Game session world_seed and summary NULLed."""
+        """Game session world_seed tombstoned (NOT NULL col), summary NULLed."""
         authed_client.delete("/api/v1/players/me")
 
         fourth_call = pg_mock.execute.call_args_list[3]
         sql_text = str(fourth_call.args[0].text)
 
-        assert "world_seed = NULL" in sql_text
+        assert "world_seed = '{}'::jsonb" in sql_text
         assert "summary = NULL" in sql_text
 
     def test_deletes_session_tokens(
@@ -160,5 +160,5 @@ class TestAccountDeletionEndpoint:
         """All operations committed in a single transaction."""
         authed_client.delete("/api/v1/players/me")
 
-        pg_mock.commit.assert_called_once()
+        pg_mock.commit.assert_awaited_once()
         assert pg_mock.execute.call_count == 5

--- a/tests/unit/privacy/test_gdpr_endpoints.py
+++ b/tests/unit/privacy/test_gdpr_endpoints.py
@@ -1,4 +1,4 @@
-"""Tests for GDPR stub endpoints (S17 §3 FR-17.6, FR-17.9)."""
+"""Tests for GDPR endpoints (S17 §3 FR-17.6, FR-17.9, FR-17.10)."""
 
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock
@@ -13,7 +13,8 @@ from tta.config import Settings
 from tta.models.player import Player
 
 _NOW = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
-_PLAYER = Player(id=uuid4(), handle="TestPlayer", created_at=_NOW)
+_PLAYER_ID = uuid4()
+_PLAYER = Player(id=_PLAYER_ID, handle="TestPlayer", created_at=_NOW)
 
 
 def _settings() -> Settings:
@@ -24,9 +25,14 @@ def _settings() -> Settings:
 
 
 @pytest.fixture()
-def authed_client() -> TestClient:
+def pg_mock() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture()
+def authed_client(pg_mock: AsyncMock) -> TestClient:
     app = create_app(_settings())
-    app.dependency_overrides[get_pg] = lambda: AsyncMock()
+    app.dependency_overrides[get_pg] = lambda: pg_mock
     app.dependency_overrides[get_current_player] = lambda: _PLAYER
     return TestClient(app, raise_server_exceptions=False)
 
@@ -53,14 +59,106 @@ class TestDataExportEndpoint:
 
 
 class TestAccountDeletionEndpoint:
-    """DELETE /api/v1/players/me → 202."""
+    """DELETE /api/v1/players/me → 202 with real PII erasure."""
 
-    def test_returns_202_accepted(self, authed_client: TestClient) -> None:
+    def test_returns_202_accepted(
+        self,
+        authed_client: TestClient,
+        pg_mock: AsyncMock,
+    ) -> None:
         resp = authed_client.delete("/api/v1/players/me")
         assert resp.status_code == 202
         body = resp.json()
-        assert "data" in body
+        assert body["data"]["status"] == "accepted"
+        assert body["data"]["player_id"] == str(_PLAYER_ID)
 
     def test_unauthenticated_rejected(self, anon_client: TestClient) -> None:
         resp = anon_client.delete("/api/v1/players/me")
         assert resp.status_code == 401
+
+    def test_tombstones_player(
+        self,
+        authed_client: TestClient,
+        pg_mock: AsyncMock,
+    ) -> None:
+        """Player status set to pending_deletion, handle anonymised."""
+        authed_client.delete("/api/v1/players/me")
+
+        first_call = pg_mock.execute.call_args_list[0]
+        sql_text = str(first_call.args[0].text)
+        params = first_call.args[1]
+
+        assert "status = 'pending_deletion'" in sql_text
+        assert "deletion_requested_at" in sql_text
+        assert params["tombstone"] == f"deleted-{_PLAYER_ID}"
+        assert params["pid"] == _PLAYER_ID
+
+    def test_ends_active_game_sessions(
+        self,
+        authed_client: TestClient,
+        pg_mock: AsyncMock,
+    ) -> None:
+        """All active/paused game sessions ended."""
+        authed_client.delete("/api/v1/players/me")
+
+        second_call = pg_mock.execute.call_args_list[1]
+        sql_text = str(second_call.args[0].text)
+        params = second_call.args[1]
+
+        assert "game_sessions" in sql_text
+        assert "status = 'ended'" in sql_text
+        assert "('active', 'paused')" in sql_text
+        assert params["pid"] == _PLAYER_ID
+
+    def test_scrubs_turn_pii(
+        self,
+        authed_client: TestClient,
+        pg_mock: AsyncMock,
+    ) -> None:
+        """Turn player_input and narrative_output NULLed."""
+        authed_client.delete("/api/v1/players/me")
+
+        third_call = pg_mock.execute.call_args_list[2]
+        sql_text = str(third_call.args[0].text)
+
+        assert "player_input = NULL" in sql_text
+        assert "narrative_output = NULL" in sql_text
+        assert "turns" in sql_text
+
+    def test_scrubs_game_session_pii(
+        self,
+        authed_client: TestClient,
+        pg_mock: AsyncMock,
+    ) -> None:
+        """Game session world_seed and summary NULLed."""
+        authed_client.delete("/api/v1/players/me")
+
+        fourth_call = pg_mock.execute.call_args_list[3]
+        sql_text = str(fourth_call.args[0].text)
+
+        assert "world_seed = NULL" in sql_text
+        assert "summary = NULL" in sql_text
+
+    def test_deletes_session_tokens(
+        self,
+        authed_client: TestClient,
+        pg_mock: AsyncMock,
+    ) -> None:
+        """All player_sessions rows deleted."""
+        authed_client.delete("/api/v1/players/me")
+
+        fifth_call = pg_mock.execute.call_args_list[4]
+        sql_text = str(fifth_call.args[0].text)
+
+        assert "DELETE FROM player_sessions" in sql_text
+
+    def test_commits_transaction(
+        self,
+        authed_client: TestClient,
+        pg_mock: AsyncMock,
+    ) -> None:
+        """All operations committed in a single transaction."""
+        authed_client.delete("/api/v1/players/me")
+
+        pg_mock.commit.assert_called_once()
+        assert pg_mock.execute.call_count == 5


### PR DESCRIPTION
## Wave 16 — Character Commands & Session Lifecycle

**Specs**: S01-AC-1.6, S06-AC-6.1, S06-AC-6.3, S11-AC-11.05-08, S12-AC-12.03
**Tests**: 1404 passing (+26 over baseline), 0 pyright errors, 0 ruff errors

### Changes

1. **`/character` command** — Shows player name, concept, and tone from world_seed
2. **`/relationships` command** — Lists template NPCs with roles and dispositions
3. **`/end` command** — Transitions active games to ended with epilogue message
4. **Lifecycle background job** — Hourly cleanup: abandoned (24h idle) + expired (30d paused)
5. **GDPR account deletion** — Real PII erasure replacing the stub endpoint
6. **Migration 006** — Adds `deletion_requested_at` to players table

### Files (12 changed, +868/-22)

| Category | Files |
|---|---|
| New modules | `src/tta/lifecycle/`, `migrations/.../006_gdpr_deletion.py` |
| Commands | `src/tta/api/routes/games.py` (+3 commands, deleted_at filter) |
| GDPR | `src/tta/api/routes/players.py` (5-step PII erasure) |
| Model | `src/tta/models/player.py` (deletion_requested_at field) |
| App | `src/tta/api/app.py` (lifecycle_loop in lifespan) |
| Tests | `test_commands.py` (24), `test_cleanup.py` (8), `test_gdpr_endpoints.py` (10) |
| Docs | `NEXT_STEPS.md` §19 |

### Known v1 limitations
- `/character` shows static genesis data (no live character state system yet)
- `/relationships` shows template NPCs (relationship service not wired globally)
- `/end` unreachable from paused games (use PATCH endpoint instead)
- S11-AC-11.09/11.10 deferred (require email/password auth)