### PR TITLE
feat: Wave 18 — Observability metrics, input validation, resume recap

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1150,17 +1150,60 @@ Estimated AC coverage: ~45% → ~52%
 - `src/tta/api/app.py` — call signature fixes
 - `src/tta/api/routes/games.py` — suggested_actions SSE wiring
 
-## 21. Wave 18+ Recommendations
+## 21. Wave 18 — Observability Hardening, Input Validation, Resume Recap
 
-### Wave 18 — Production Polish & Observability
+**Branch**: `wave-18/observability-validation-recap`
+**Tests**: 1441 total (26 new), 0 pyright errors
+
+### Completed
+
+1. **Rate limit & abuse metrics** (S15 C1): Added `tta_rate_limit_enforced_total`
+   counter (labels: route) in rate limit middleware, and `tta_abuse_detected_total`
+   counter (labels: pattern) in both InMemory and Redis abuse detectors.
+
+2. **DB query duration & Redis metrics** (S15 §4 C4): Added
+   `tta_db_query_duration_seconds` histogram (labels: database, operation) and
+   `tta_redis_operations_total` counter (labels: operation). Created
+   `src/tta/observability/db_metrics.py` with `observe_db_query()` and
+   `count_redis_op()` context managers. Callsite instrumentation deferred to
+   persistence layer integration wave.
+
+3. **Re-enabled DB pool exhaustion alert** (C5): Uncommented DBPoolExhausted
+   alert in `monitoring/prometheus/alerts.yml`. Pool gauges already instrumented
+   by `pool_metrics.py`.
+
+4. **Input validation hardening** (H5): Added Pydantic `field_validator` to
+   `SubmitTurnRequest` that strips zero-width Unicode characters (U+200B,
+   U+200C, U+200D, U+2060, U+FEFF, U+FFFE). Whitespace-only input correctly
+   triggers nudge flow — no rejection needed.
+
+5. **Resume contextual recap** (FR-5.4): Resume endpoint now returns `recap`
+   field: "When we last left off: {context_summary}" for games with turns,
+   or derives from `world_seed.genesis.narrative_intro` for 0-turn resumes.
+   Returns `None` when no summary available.
+
+### Decisions
+
+- **DB_CONNECTIONS_ACTIVE omitted**: Existing pool gauges (`tta_pg_pool_size`,
+  `tta_pg_pool_checked_out`, etc.) already cover this. Redundant gauge would
+  confuse operators.
+- **Route labels use parameterized patterns** (e.g., `/api/v1/games/{game_id}`)
+  not raw paths, preventing Prometheus cardinality explosion.
+- **Zero-width char stripping, not rejection**: Pydantic validator silently
+  strips invisible chars rather than returning 422, matching existing UX pattern
+  where `input.strip()` normalizes whitespace.
+
+## 22. Wave 19+ Recommendations
+
+### Wave 19 — Production Polish & Observability
 
 1. Alertmanager integration for notification routing (PagerDuty, Slack, email)
 2. Performance load testing and SLO validation against S28 targets
 3. node_exporter for disk usage alerting (S15 FR-15.23)
 4. Session token rotation (security improvement)
 5. Turn history pagination (S12 FR-12.03)
-6. Game resume flow validation (S01 AC-1.7 resume path)
-7. Live character state system (evolving traits beyond genesis)
+6. Live character state system (evolving traits beyond genesis)
+7. Instrument persistence call sites with `observe_db_query()` / `count_redis_op()`
 
 ### Beyond v1
 

--- a/monitoring/prometheus/alerts.yml
+++ b/monitoring/prometheus/alerts.yml
@@ -1,13 +1,14 @@
 # Prometheus alerting rules for TTA
 # Spec ref: S15 FR-15.22/23 (alerting rules)
 #
-# Six conditions monitored:
-#   1. API error rate > 10% over 5 min (Critical) — ACTIVE
-#   2. LLM API unreachable > 2 min (Critical) — ACTIVE
-#   3. Turn processing > 30s p95 (Warning) — ACTIVE
-#   4. Daily LLM cost > threshold (Warning) — ACTIVE (uses cost histogram)
-#   5. DB connection pool exhausted (Critical) — DISABLED (metric not yet instrumented)
-#   6. Disk usage > 80% (deferred — requires node_exporter)
+# Five active conditions:
+#   1. API error rate > 10% over 5 min (Critical)
+#   2. LLM API unreachable > 2 min (Critical)
+#   3. Turn processing > 30s p95 (Warning)
+#   4. Daily LLM cost > threshold (Warning)
+#   5. DB connection pool exhausted (Critical)
+#
+# Deferred: Disk usage > 80% (requires node_exporter)
 #
 # FR-15.24: Dedup is handled at the Alertmanager level (not yet deployed).
 #           Currently, Prometheus evaluates rules only.
@@ -82,16 +83,14 @@ groups:
             Threshold: $50.
 
       # 5. DB connection pool exhausted → Critical
-      # DISABLED: tta_pg_pool_* gauges are not yet instrumented.
-      # TODO: Re-enable after Wave 13 metrics instrumentation.
-      # - alert: DBPoolExhausted
-      #   expr: |
-      #     (tta_pg_pool_checked_out / tta_pg_pool_size) > 0.95
-      #   for: 2m
-      #   labels:
-      #     severity: critical
-      #   annotations:
-      #     summary: "PostgreSQL connection pool near exhaustion"
-      #     description: >-
-      #       {{ $value | humanizePercentage }} of the PG connection pool
-      #       is in use for over 2 minutes.
+      - alert: DBPoolExhausted
+        expr: |
+          (tta_pg_pool_checked_out / tta_pg_pool_size) > 0.95
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "PostgreSQL connection pool near exhaustion"
+          description: >-
+            {{ $value | humanizePercentage }} of the PG connection pool
+            is in use for over 2 minutes.

--- a/src/tta/api/middleware.py
+++ b/src/tta/api/middleware.py
@@ -16,9 +16,11 @@ import structlog
 from starlette.datastructures import State
 from starlette.requests import Request
 from starlette.responses import JSONResponse
+from starlette.routing import Match
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from tta.logging import bind_context, bind_correlation_id, clear_contextvars
+from tta.observability.metrics import RATE_LIMIT_ENFORCED
 from tta.observability.tracing import current_trace_id
 from tta.resilience.anti_abuse import AbuseDetector, AbusePattern
 from tta.resilience.rate_limiter import (
@@ -29,6 +31,20 @@ from tta.resilience.rate_limiter import (
 )
 
 log = structlog.get_logger()
+
+
+def _get_route_pattern_for_scope(request: Request) -> str:
+    """Extract the route pattern (e.g. /api/v1/games/{game_id}).
+
+    Same logic as prometheus_middleware._get_route_pattern — kept local
+    to avoid coupling the two middleware modules.
+    """
+    app = request.app
+    for route in app.routes:
+        match, _ = route.matches(request.scope)
+        if match == Match.FULL:
+            return getattr(route, "path", request.url.path)
+    return "unmatched"
 
 
 class RequestIDMiddleware:
@@ -304,6 +320,8 @@ class RateLimitMiddleware:
             return
 
         if not result.allowed:
+            route_pattern = _get_route_pattern_for_scope(request)
+            RATE_LIMIT_ENFORCED.labels(route=route_pattern).inc()
             log.warning(
                 "rate_limited",
                 key=key,

--- a/src/tta/api/routes/games.py
+++ b/src/tta/api/routes/games.py
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 import structlog
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import JSONResponse, StreamingResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tta.api.deps import get_current_player, get_pg, require_active_player
@@ -422,6 +422,13 @@ class PaginationMeta(BaseModel):
     has_more: bool
 
 
+_ZERO_WIDTH_CHARS = str.maketrans(
+    "",
+    "",
+    "\u200b\u200c\u200d\u2060\ufeff\ufffe",
+)
+
+
 class SubmitTurnRequest(BaseModel):
     input: str = Field(
         ...,
@@ -432,6 +439,12 @@ class SubmitTurnRequest(BaseModel):
         None,
         description="Client-generated UUID for deduplication.",
     )
+
+    @field_validator("input")
+    @classmethod
+    def strip_zero_width_chars(cls, v: str) -> str:
+        """Remove invisible Unicode chars that defeat .strip()."""
+        return v.translate(_ZERO_WIDTH_CHARS)
 
 
 class TurnAccepted(BaseModel):
@@ -1452,6 +1465,19 @@ async def resume_game(
     if summary_stale and recent_turns:
         asyncio.create_task(_regen_summary_bg(request.app.state, game_id))
 
+    # FR-5.4: Build contextual recap for the player
+    recap: str | None = None
+    if turn_count > 0 and context_summary:
+        recap = f"When we last left off: {context_summary}"
+    elif turn_count == 0:
+        # Zero-turn game — derive recap from genesis narrative intro
+        ws = row.world_seed
+        if isinstance(ws, dict):
+            genesis = ws.get("genesis", {})
+            intro = genesis.get("narrative_intro")
+            if intro:
+                recap = str(intro)
+
     # Use actual timestamps — only reflect `now` when we updated.
     resp_updated = now.isoformat() if status_updated else row.updated_at.isoformat()
     resp_last_played = (
@@ -1468,6 +1494,7 @@ async def resume_game(
             "turn_count": turn_count,
             "title": row.title,
             "context_summary": context_summary,
+            "recap": recap,
             "recent_turns": recent_turns,
             "created_at": row.created_at.isoformat(),
             "updated_at": resp_updated,

--- a/src/tta/observability/db_metrics.py
+++ b/src/tta/observability/db_metrics.py
@@ -1,0 +1,43 @@
+"""Database and Redis observability helpers.
+
+Context managers that record query duration and operation counts
+to the Prometheus metrics defined in ``metrics.py``.
+
+Usage::
+
+    async with observe_db_query("postgresql", "get_turn"):
+        result = await session.execute(stmt)
+
+    with count_redis_op("get"):
+        value = await redis.get(key)
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager, contextmanager
+
+from tta.observability.metrics import DB_QUERY_DURATION, REDIS_OPERATIONS
+
+
+@asynccontextmanager
+async def observe_db_query(database: str, operation: str) -> AsyncIterator[None]:
+    """Time an async DB operation and record to histogram."""
+    start = time.monotonic()
+    try:
+        yield
+    finally:
+        elapsed = time.monotonic() - start
+        DB_QUERY_DURATION.labels(database=database, operation=operation).observe(
+            elapsed
+        )
+
+
+@contextmanager
+def count_redis_op(operation: str) -> Iterator[None]:
+    """Increment the Redis operations counter on exit."""
+    try:
+        yield
+    finally:
+        REDIS_OPERATIONS.labels(operation=operation).inc()

--- a/src/tta/observability/metrics.py
+++ b/src/tta/observability/metrics.py
@@ -157,6 +157,39 @@ NEO4J_POOL_ACTIVE = Gauge(
     registry=REGISTRY,
 )
 
+# -- Rate limiting & abuse metrics (S15 §4, S25) ---------------------------
+
+RATE_LIMIT_ENFORCED = Counter(
+    "tta_rate_limit_enforced_total",
+    "Rate limit rejections",
+    ["route"],
+    registry=REGISTRY,
+)
+
+ABUSE_DETECTED = Counter(
+    "tta_abuse_detected_total",
+    "Abuse pattern violations detected",
+    ["pattern"],
+    registry=REGISTRY,
+)
+
+# -- DB & Redis metrics (S15 §4) ------------------------------------------
+
+DB_QUERY_DURATION = Histogram(
+    "tta_db_query_duration_seconds",
+    "Database query duration",
+    ["database", "operation"],
+    buckets=DURATION_BUCKETS,
+    registry=REGISTRY,
+)
+
+REDIS_OPERATIONS = Counter(
+    "tta_redis_operations_total",
+    "Redis operations",
+    ["operation"],
+    registry=REGISTRY,
+)
+
 # -- LLM semaphore metrics (S28 FR-28.11) ---------------------------------
 
 LLM_SEMAPHORE_ACTIVE = Gauge(

--- a/src/tta/resilience/anti_abuse.py
+++ b/src/tta/resilience/anti_abuse.py
@@ -29,6 +29,8 @@ from typing import Protocol
 
 import structlog
 
+from tta.observability.metrics import ABUSE_DETECTED
+
 log = structlog.get_logger()
 
 __all__ = [
@@ -197,6 +199,7 @@ class InMemoryAbuseDetector:
 
         count = len(timestamps)
         if count > config.threshold:
+            ABUSE_DETECTED.labels(pattern=pattern.value).inc()
             cooldown = _calculate_cooldown(count, config, self._max_cooldown)
             self._cooldowns[identity] = (now + cooldown, pattern, count)
             return ViolationResult(
@@ -294,6 +297,7 @@ class RedisAbuseDetector:
         count: int = results[2]
 
         if count > config.threshold:
+            ABUSE_DETECTED.labels(pattern=pattern.value).inc()
             cooldown = _calculate_cooldown(count, config, self._max_cooldown)
             cd_key = f"abuse:cd:{identity}"
             await self._redis.setex(  # type: ignore[union-attr]

--- a/tests/unit/test_wave18.py
+++ b/tests/unit/test_wave18.py
@@ -23,7 +23,29 @@ from tta.observability.metrics import (
     DB_QUERY_DURATION,
     RATE_LIMIT_ENFORCED,
     REDIS_OPERATIONS,
+    REGISTRY,
 )
+
+
+def _sample_value(
+    sample_name: str,
+    labels: dict[str, str],
+) -> float:
+    """Read a specific sample value from the custom REGISTRY by name + labels.
+
+    Iterates all collected metrics and selects by exact sample name
+    (e.g. ``tta_rate_limit_enforced_total``) rather than relying on
+    sample ordering, which is not guaranteed across prometheus_client
+    versions.
+    """
+    for metric in REGISTRY.collect():
+        for sample in metric.samples:
+            if sample.name == sample_name and all(
+                sample.labels.get(k) == v for k, v in labels.items()
+            ):
+                return sample.value
+    return 0.0
+
 
 # ---------------------------------------------------------------------------
 # Task 1: Rate limit & abuse metric counters
@@ -37,9 +59,10 @@ class TestRateLimitEnforcedCounter:
         assert RATE_LIMIT_ENFORCED._labelnames == ("route",)
 
     def test_counter_increments(self) -> None:
-        before = RATE_LIMIT_ENFORCED.labels(route="/test").collect()[0].samples[0].value
+        labels = {"route": "/test"}
+        before = _sample_value("tta_rate_limit_enforced_total", labels)
         RATE_LIMIT_ENFORCED.labels(route="/test").inc()
-        after = RATE_LIMIT_ENFORCED.labels(route="/test").collect()[0].samples[0].value
+        after = _sample_value("tta_rate_limit_enforced_total", labels)
         assert after == before + 1
 
 
@@ -50,13 +73,10 @@ class TestAbuseDetectedCounter:
         assert ABUSE_DETECTED._labelnames == ("pattern",)
 
     def test_counter_increments_for_rapid_fire(self) -> None:
-        before = (
-            ABUSE_DETECTED.labels(pattern="rapid_fire").collect()[0].samples[0].value
-        )
+        labels = {"pattern": "rapid_fire"}
+        before = _sample_value("tta_abuse_detected_total", labels)
         ABUSE_DETECTED.labels(pattern="rapid_fire").inc()
-        after = (
-            ABUSE_DETECTED.labels(pattern="rapid_fire").collect()[0].samples[0].value
-        )
+        after = _sample_value("tta_abuse_detected_total", labels)
         assert after == before + 1
 
 
@@ -70,17 +90,14 @@ class TestAbuseDetectorEmitsMetric:
         detector = InMemoryAbuseDetector(max_cooldown=86400)
         key = f"ip:{uuid4()}"
 
-        before = (
-            ABUSE_DETECTED.labels(pattern="rapid_fire").collect()[0].samples[0].value
-        )
+        labels = {"pattern": "rapid_fire"}
+        before = _sample_value("tta_abuse_detected_total", labels)
 
         # Push past threshold (3)
         for _ in range(4):
             await detector.record_violation(key, AbusePattern.RAPID_FIRE)
 
-        after = (
-            ABUSE_DETECTED.labels(pattern="rapid_fire").collect()[0].samples[0].value
-        )
+        after = _sample_value("tta_abuse_detected_total", labels)
         assert after > before
 
 
@@ -96,33 +113,27 @@ class TestObserveDbQuery:
     async def test_records_duration(self) -> None:
         from tta.observability.db_metrics import observe_db_query
 
-        before = DB_QUERY_DURATION.labels(
-            database="postgresql", operation="test_op"
-        )._sum.get()
+        labels = {"database": "postgresql", "operation": "test_op"}
+        before = _sample_value("tta_db_query_duration_seconds_sum", labels)
 
         async with observe_db_query("postgresql", "test_op"):
             await asyncio.sleep(0.01)
 
-        after = DB_QUERY_DURATION.labels(
-            database="postgresql", operation="test_op"
-        )._sum.get()
+        after = _sample_value("tta_db_query_duration_seconds_sum", labels)
         assert after > before
 
     @pytest.mark.asyncio
     async def test_records_on_exception(self) -> None:
         from tta.observability.db_metrics import observe_db_query
 
-        before = DB_QUERY_DURATION.labels(
-            database="postgresql", operation="err_op"
-        )._sum.get()
+        labels = {"database": "postgresql", "operation": "err_op"}
+        before = _sample_value("tta_db_query_duration_seconds_sum", labels)
 
         with pytest.raises(ValueError, match="boom"):
             async with observe_db_query("postgresql", "err_op"):
                 raise ValueError("boom")
 
-        after = DB_QUERY_DURATION.labels(
-            database="postgresql", operation="err_op"
-        )._sum.get()
+        after = _sample_value("tta_db_query_duration_seconds_sum", labels)
         assert after > before
 
 
@@ -132,12 +143,13 @@ class TestCountRedisOp:
     def test_increments_counter(self) -> None:
         from tta.observability.db_metrics import count_redis_op
 
-        before = REDIS_OPERATIONS.labels(operation="get").collect()[0].samples[0].value
+        labels = {"operation": "get"}
+        before = _sample_value("tta_redis_operations_total", labels)
 
         with count_redis_op("get"):
             pass
 
-        after = REDIS_OPERATIONS.labels(operation="get").collect()[0].samples[0].value
+        after = _sample_value("tta_redis_operations_total", labels)
         assert after == before + 1
 
 

--- a/tests/unit/test_wave18.py
+++ b/tests/unit/test_wave18.py
@@ -1,0 +1,419 @@
+"""Tests for Wave 18: observability metrics, input validation, resume recap.
+
+Covers:
+  - Task 1: RATE_LIMIT_ENFORCED / ABUSE_DETECTED counters
+  - Task 2: DB query duration / Redis operations helpers
+  - Task 4: Zero-width character stripping in SubmitTurnRequest
+  - Task 5: FR-5.4 resume contextual recap
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from tta.observability.metrics import (
+    ABUSE_DETECTED,
+    DB_QUERY_DURATION,
+    RATE_LIMIT_ENFORCED,
+    REDIS_OPERATIONS,
+)
+
+# ---------------------------------------------------------------------------
+# Task 1: Rate limit & abuse metric counters
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitEnforcedCounter:
+    """RATE_LIMIT_ENFORCED increments when a request is rate-limited."""
+
+    def test_counter_registered_with_route_label(self) -> None:
+        assert RATE_LIMIT_ENFORCED._labelnames == ("route",)
+
+    def test_counter_increments(self) -> None:
+        before = RATE_LIMIT_ENFORCED.labels(route="/test").collect()[0].samples[0].value
+        RATE_LIMIT_ENFORCED.labels(route="/test").inc()
+        after = RATE_LIMIT_ENFORCED.labels(route="/test").collect()[0].samples[0].value
+        assert after == before + 1
+
+
+class TestAbuseDetectedCounter:
+    """ABUSE_DETECTED increments when violations exceed threshold."""
+
+    def test_counter_registered_with_pattern_label(self) -> None:
+        assert ABUSE_DETECTED._labelnames == ("pattern",)
+
+    def test_counter_increments_for_rapid_fire(self) -> None:
+        before = (
+            ABUSE_DETECTED.labels(pattern="rapid_fire").collect()[0].samples[0].value
+        )
+        ABUSE_DETECTED.labels(pattern="rapid_fire").inc()
+        after = (
+            ABUSE_DETECTED.labels(pattern="rapid_fire").collect()[0].samples[0].value
+        )
+        assert after == before + 1
+
+
+class TestAbuseDetectorEmitsMetric:
+    """InMemoryAbuseDetector.record_violation increments ABUSE_DETECTED."""
+
+    @pytest.mark.asyncio
+    async def test_counter_fires_on_threshold_breach(self) -> None:
+        from tta.resilience.anti_abuse import AbusePattern, InMemoryAbuseDetector
+
+        detector = InMemoryAbuseDetector(max_cooldown=86400)
+        key = f"ip:{uuid4()}"
+
+        before = (
+            ABUSE_DETECTED.labels(pattern="rapid_fire").collect()[0].samples[0].value
+        )
+
+        # Push past threshold (3)
+        for _ in range(4):
+            await detector.record_violation(key, AbusePattern.RAPID_FIRE)
+
+        after = (
+            ABUSE_DETECTED.labels(pattern="rapid_fire").collect()[0].samples[0].value
+        )
+        assert after > before
+
+
+# ---------------------------------------------------------------------------
+# Task 2: DB query duration & Redis operations helpers
+# ---------------------------------------------------------------------------
+
+
+class TestObserveDbQuery:
+    """observe_db_query records duration to histogram."""
+
+    @pytest.mark.asyncio
+    async def test_records_duration(self) -> None:
+        from tta.observability.db_metrics import observe_db_query
+
+        before = DB_QUERY_DURATION.labels(
+            database="postgresql", operation="test_op"
+        )._sum.get()
+
+        async with observe_db_query("postgresql", "test_op"):
+            await asyncio.sleep(0.01)
+
+        after = DB_QUERY_DURATION.labels(
+            database="postgresql", operation="test_op"
+        )._sum.get()
+        assert after > before
+
+    @pytest.mark.asyncio
+    async def test_records_on_exception(self) -> None:
+        from tta.observability.db_metrics import observe_db_query
+
+        before = DB_QUERY_DURATION.labels(
+            database="postgresql", operation="err_op"
+        )._sum.get()
+
+        with pytest.raises(ValueError, match="boom"):
+            async with observe_db_query("postgresql", "err_op"):
+                raise ValueError("boom")
+
+        after = DB_QUERY_DURATION.labels(
+            database="postgresql", operation="err_op"
+        )._sum.get()
+        assert after > before
+
+
+class TestCountRedisOp:
+    """count_redis_op increments the Redis operations counter."""
+
+    def test_increments_counter(self) -> None:
+        from tta.observability.db_metrics import count_redis_op
+
+        before = REDIS_OPERATIONS.labels(operation="get").collect()[0].samples[0].value
+
+        with count_redis_op("get"):
+            pass
+
+        after = REDIS_OPERATIONS.labels(operation="get").collect()[0].samples[0].value
+        assert after == before + 1
+
+
+class TestDbQueryDurationMetric:
+    """DB_QUERY_DURATION histogram has correct labels and buckets."""
+
+    def test_labels(self) -> None:
+        assert DB_QUERY_DURATION._labelnames == ("database", "operation")
+
+    def test_uses_duration_buckets(self) -> None:
+        from tta.observability.metrics import DURATION_BUCKETS
+
+        # Upper bounds include +Inf; the user-defined ones match DURATION_BUCKETS
+        assert tuple(DB_QUERY_DURATION._upper_bounds) == (
+            *DURATION_BUCKETS,
+            float("inf"),
+        )
+
+
+class TestRedisOperationsMetric:
+    """REDIS_OPERATIONS counter has correct labels."""
+
+    def test_labels(self) -> None:
+        assert REDIS_OPERATIONS._labelnames == ("operation",)
+
+
+# ---------------------------------------------------------------------------
+# Task 4: Zero-width character stripping
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitTurnRequestValidation:
+    """SubmitTurnRequest strips zero-width Unicode characters."""
+
+    def _make(self, text: str) -> Any:
+        from tta.api.routes.games import SubmitTurnRequest
+
+        return SubmitTurnRequest(input=text)
+
+    def test_normal_text_unchanged(self) -> None:
+        req = self._make("go north")
+        assert req.input == "go north"
+
+    def test_strips_zero_width_space(self) -> None:
+        req = self._make("go\u200bnorth")
+        assert req.input == "gonorth"
+
+    def test_strips_bom(self) -> None:
+        req = self._make("\ufeffhello")
+        assert req.input == "hello"
+
+    def test_strips_zero_width_joiner(self) -> None:
+        req = self._make("a\u200db")
+        assert req.input == "ab"
+
+    def test_strips_zero_width_non_joiner(self) -> None:
+        req = self._make("a\u200cb")
+        assert req.input == "ab"
+
+    def test_strips_word_joiner(self) -> None:
+        req = self._make("a\u2060b")
+        assert req.input == "ab"
+
+    def test_strips_multiple_zero_width(self) -> None:
+        req = self._make("\u200b\u200c\u200d\u2060\ufefftest\ufffe")
+        assert req.input == "test"
+
+    def test_empty_string_allowed(self) -> None:
+        req = self._make("")
+        assert req.input == ""
+
+    def test_whitespace_only_passes_through(self) -> None:
+        """Whitespace-only input is valid (triggers nudge, not LLM call)."""
+        req = self._make("   ")
+        assert req.input == "   "
+
+    def test_only_zero_width_chars_becomes_empty(self) -> None:
+        req = self._make("\u200b\u200c\u200d")
+        assert req.input == ""
+
+
+# ---------------------------------------------------------------------------
+# Task 5: Resume contextual recap (FR-5.4)
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+_PLAYER_ID = uuid4()
+_GAME_ID = uuid4()
+
+
+def _settings() -> Any:
+    from tta.config import Settings
+
+    return Settings(
+        database_url="postgresql://test@localhost/test",
+        neo4j_password="test",
+    )
+
+
+def _make_result(
+    rows: list[dict[str, Any]] | None = None,
+    *,
+    scalar: Any = None,
+) -> MagicMock:
+    result = MagicMock()
+    if rows is not None:
+        objs = [SimpleNamespace(**r) for r in rows]
+        result.one_or_none.return_value = objs[0] if objs else None
+        result.all.return_value = objs
+    else:
+        result.one_or_none.return_value = None
+        result.all.return_value = []
+    if scalar is not None:
+        result.scalar_one.return_value = scalar
+    return result
+
+
+def _game_row(
+    *,
+    status: str = "active",
+    title: str | None = None,
+    summary: str | None = None,
+    last_played_at: datetime | None = _NOW,
+    world_seed: Any = "{}",
+    turn_count: int = 0,
+    needs_recovery: bool = False,
+    summary_generated_at: datetime | None = None,
+    deleted_at: datetime | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": _GAME_ID,
+        "player_id": _PLAYER_ID,
+        "status": status,
+        "world_seed": world_seed,
+        "title": title,
+        "summary": summary,
+        "turn_count": turn_count,
+        "needs_recovery": needs_recovery,
+        "summary_generated_at": summary_generated_at,
+        "created_at": _NOW,
+        "updated_at": _NOW,
+        "last_played_at": last_played_at,
+        "deleted_at": deleted_at,
+    }
+
+
+class TestResumeRecap:
+    """FR-5.4: Resume provides contextual recap."""
+
+    @pytest.fixture()
+    def pg(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture()
+    def app(self, pg: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> Any:
+
+        from tta.api.app import create_app
+        from tta.api.deps import get_current_player, get_pg
+        from tta.models.player import Player
+
+        settings = _settings()
+        monkeypatch.setattr("tta.api.routes.games.get_settings", lambda: settings)
+        a = create_app(settings=settings)
+
+        player = Player(id=_PLAYER_ID, handle="Tester", created_at=_NOW)
+
+        async def _pg():
+            yield pg
+
+        a.dependency_overrides[get_pg] = _pg
+        a.dependency_overrides[get_current_player] = lambda: player
+        return a
+
+    @pytest.fixture()
+    def client(self, app: Any) -> Any:
+        from fastapi.testclient import TestClient
+
+        return TestClient(app)
+
+    def test_recap_with_summary_and_turns(self, client: Any, pg: AsyncMock) -> None:
+        """Games with turns and summary get 'When we last left off:' recap."""
+        recent = datetime.now(UTC)
+        pg.execute = AsyncMock(
+            side_effect=[
+                _make_result(
+                    [
+                        _game_row(
+                            status="active",
+                            summary="Lost in the woods",
+                            last_played_at=recent,
+                            summary_generated_at=recent,
+                        )
+                    ]
+                ),
+                _make_result([]),  # recent turns
+                _make_result(scalar=5),  # turn count
+            ]
+        )
+
+        resp = client.post(f"/api/v1/games/{_GAME_ID}/resume")
+
+        assert resp.status_code == 200
+        body = resp.json()["data"]
+        assert body["recap"] == "When we last left off: Lost in the woods"
+
+    def test_recap_zero_turns_with_genesis(self, client: Any, pg: AsyncMock) -> None:
+        """Zero-turn games derive recap from genesis narrative_intro."""
+        ws = {
+            "genesis": {
+                "world_id": "w1",
+                "narrative_intro": "You awaken in a dark forest.",
+            }
+        }
+        pg.execute = AsyncMock(
+            side_effect=[
+                _make_result([_game_row(status="paused", world_seed=ws)]),
+                _make_result(),  # UPDATE status
+                _make_result([]),  # recent turns
+                _make_result(scalar=0),  # turn count
+            ]
+        )
+        pg.commit = AsyncMock()
+
+        resp = client.post(f"/api/v1/games/{_GAME_ID}/resume")
+
+        assert resp.status_code == 200
+        body = resp.json()["data"]
+        assert body["recap"] == "You awaken in a dark forest."
+
+    def test_recap_none_when_no_summary_and_turns(
+        self, client: Any, pg: AsyncMock
+    ) -> None:
+        """Games with turns but no summary have no recap."""
+        pg.execute = AsyncMock(
+            side_effect=[
+                _make_result([_game_row(status="active", summary=None)]),
+                _make_result([]),  # recent turns
+                _make_result(scalar=3),  # turn count
+            ]
+        )
+
+        resp = client.post(f"/api/v1/games/{_GAME_ID}/resume")
+
+        assert resp.status_code == 200
+        body = resp.json()["data"]
+        assert body["recap"] is None
+
+    def test_recap_none_zero_turns_no_genesis(self, client: Any, pg: AsyncMock) -> None:
+        """Zero-turn games without genesis have no recap."""
+        pg.execute = AsyncMock(
+            side_effect=[
+                _make_result([_game_row(status="paused", world_seed="{}")]),
+                _make_result(),  # UPDATE status
+                _make_result([]),  # recent turns
+                _make_result(scalar=0),  # turn count
+            ]
+        )
+        pg.commit = AsyncMock()
+
+        resp = client.post(f"/api/v1/games/{_GAME_ID}/resume")
+
+        assert resp.status_code == 200
+        body = resp.json()["data"]
+        assert body["recap"] is None
+
+    def test_recap_field_present_in_response(self, client: Any, pg: AsyncMock) -> None:
+        """The recap field always appears in the response dict."""
+        pg.execute = AsyncMock(
+            side_effect=[
+                _make_result([_game_row(status="active")]),
+                _make_result([]),  # recent turns
+                _make_result(scalar=0),  # turn count
+            ]
+        )
+
+        resp = client.post(f"/api/v1/games/{_GAME_ID}/resume")
+
+        assert resp.status_code == 200
+        assert "recap" in resp.json()["data"]


### PR DESCRIPTION
## Summary

Closes spec gaps identified in S15, S01, S25 gap analysis (Waves 12–17 post-mortem).

### Changes

**Observability (S15)**
- `tta_rate_limit_enforced_total` counter with route labels in rate limit middleware
- `tta_abuse_detected_total` counter with pattern labels in both abuse detector backends
- `tta_db_query_duration_seconds` histogram with database/operation labels and spec-compliant buckets
- `tta_redis_operations_total` counter with operation labels
- `db_metrics.py` helper context managers (`observe_db_query`, `count_redis_op`)
- Re-enabled DBPoolExhausted alert (pool gauges already instrumented)

**Input Validation (S25)**
- Zero-width Unicode character stripping on `SubmitTurnRequest` (U+200B, U+200C, U+200D, U+2060, U+FEFF, U+FFFE)
- Whitespace-only input correctly triggers nudge flow (no rejection needed)

**Resume Recap (FR-5.4)**
- `recap` field in resume response: "When we last left off: {summary}"
- 0-turn fallback uses `world_seed.genesis.narrative_intro`
- Returns `None` when no summary available

### Key Decisions
- `DB_CONNECTIONS_ACTIVE` gauge omitted — redundant with existing pool gauges
- Route labels use parameterized patterns (not raw paths) to prevent cardinality explosion
- Zero-width chars stripped silently, matching existing strip() UX pattern

### Testing
- 26 new unit tests in `tests/unit/test_wave18.py`
- 1441 total tests passing (baseline: 1415)
- 0 pyright errors, 0 ruff errors