### PR TITLE
feat(narrative): S03 Narrative Engine compliance remediation

### DIFF
--- a/src/tta/pipeline/stages/context.py
+++ b/src/tta/pipeline/stages/context.py
@@ -65,6 +65,12 @@ async def context_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
         }
         context_partial = True
 
+    # Inject tone/genre from world seed (S03 FR-6.1)
+    world_context = _inject_tone(world_context, state)
+
+    # Inject existing session summary (S03 FR-3.2)
+    world_context = _inject_summary(world_context, state)
+
     # Enrich with NPC dialogue contexts (S06 FR-6)
     world_context = await _enrich_npc_dialogue(world_context, state, deps)
 
@@ -97,6 +103,31 @@ async def context_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
         update["active_consequences"] = active_consequence_chains
 
     return state.model_copy(update=update)
+
+
+def _inject_tone(world_context: dict, state: TurnState) -> dict:
+    """Add tone from world seed to context (S03 FR-6.1)."""
+    world_seed = state.game_state.get("world_seed")
+    if isinstance(world_seed, dict):
+        tone = world_seed.get("tone")
+        if tone:
+            world_context["tone"] = tone
+        genre = world_seed.get("genre")
+        if genre:
+            world_context["genre"] = genre
+    return world_context
+
+
+def _inject_summary(world_context: dict, state: TurnState) -> dict:
+    """Add existing session summary to context (S03 FR-3.2).
+
+    Reuses the summary already persisted by ContextSummaryService
+    via the game routes — no new persistence path.
+    """
+    summary = state.game_state.get("summary")
+    if summary:
+        world_context["session_summary"] = summary
+    return world_context
 
 
 async def _enrich_npc_dialogue(

--- a/src/tta/pipeline/stages/generate.py
+++ b/src/tta/pipeline/stages/generate.py
@@ -92,10 +92,17 @@ _EXTRACTION_SYSTEM_PROMPT = (
 )
 
 
+_CONTEXT_META_KEYS = {"tone", "genre", "session_summary"}
+
+
 def _build_generation_prompt(state: TurnState) -> str:
     """Build the user prompt from pipeline state."""
     intent = state.parsed_intent.intent if state.parsed_intent else "unknown"
-    context_str = json.dumps(state.world_context or {}, default=str)
+
+    # Exclude meta keys from JSON dump to avoid duplication
+    wc = state.world_context or {}
+    context_data = {k: v for k, v in wc.items() if k not in _CONTEXT_META_KEYS}
+    context_str = json.dumps(context_data, default=str)
 
     # Adaptive word count from intent (S03 FR-4.2)
     word_min, word_max = INTENT_WORD_RANGES.get(intent, _DEFAULT_WORD_RANGE)
@@ -107,7 +114,6 @@ def _build_generation_prompt(state: TurnState) -> str:
     ]
 
     # Tone/genre injection (S03 FR-6.1)
-    wc = state.world_context or {}
     tone = wc.get("tone")
     genre = wc.get("genre")
     if tone or genre:
@@ -178,8 +184,8 @@ async def generate_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
         narrative = response.content
     except (BudgetExceededError, AppError, PermanentLLMError):
         raise  # Non-transient — propagate immediately
-    except Exception:
-        # All retries exhausted — use fallback narrative
+    except (TransientLLMError, AllTiersFailedError):
+        # All retries exhausted — use graceful in-world fallback
         log.warning(
             "generation_fallback_activated",
             session_id=str(state.session_id),
@@ -267,6 +273,18 @@ def _resolve_system_prompt(deps: PipelineDeps) -> str:
     return _GENERATION_SYSTEM_PROMPT
 
 
+def _simplify_prompt(state: TurnState) -> str:
+    """Build a shorter prompt without world context JSON for retry tier 2."""
+    intent = state.parsed_intent.intent if state.parsed_intent else "unknown"
+    word_min, word_max = INTENT_WORD_RANGES.get(intent, _DEFAULT_WORD_RANGE)
+    return (
+        f"Player action: {state.player_input}\n"
+        f"Intent: {intent}\n"
+        f"Aim for {word_min}-{word_max} words.\n"
+        "Generate a narrative response."
+    )
+
+
 async def _llm_with_retries(
     messages: list[Message],
     deps: PipelineDeps,
@@ -275,7 +293,7 @@ async def _llm_with_retries(
     """Call LLM with retry cascade for transient failures (S03 FR-8).
 
     Tier 1: retry with same messages
-    Tier 2: retry with simplified context (system + user only)
+    Tier 2: retry with simplified prompt (no world context JSON)
     Raises on non-transient or all-tiers-exhausted errors.
     """
     last_exc: Exception | None = None
@@ -291,10 +309,14 @@ async def _llm_with_retries(
                 session_id=str(state.session_id),
                 error=str(exc),
             )
-            # Tier 2: simplify context on second retry
-            if attempt == 0 and len(messages) > 2:
-                messages = [messages[0], messages[-1]]
-        except (BudgetExceededError, AppError):
+            # Tier 2: simplify prompt on second retry
+            if attempt == 0:
+                simplified = _simplify_prompt(state)
+                messages = [
+                    messages[0],
+                    Message(role=MessageRole.USER, content=simplified),
+                ]
+        except (BudgetExceededError, AppError, PermanentLLMError):
             raise
         except Exception as exc:
             # Classify unknown exceptions
@@ -312,8 +334,9 @@ async def _llm_with_retries(
                 continue
             raise
 
-    # All retries exhausted
-    raise last_exc or RuntimeError("All generation retries exhausted")
+    # All retries exhausted — wrap as AllTiersFailedError for consistent handling
+    errors = [last_exc] if last_exc else []
+    raise AllTiersFailedError(ModelRole.GENERATION, errors)
 
 
 async def _extract_world_changes(

--- a/src/tta/pipeline/stages/generate.py
+++ b/src/tta/pipeline/stages/generate.py
@@ -11,7 +11,14 @@ import json
 
 import structlog
 
-from tta.llm.client import Message, MessageRole
+from tta.api.errors import AppError
+from tta.llm.client import LLMResponse, Message, MessageRole
+from tta.llm.errors import (
+    AllTiersFailedError,
+    BudgetExceededError,
+    PermanentLLMError,
+    TransientLLMError,
+)
 from tta.llm.roles import ModelRole
 from tta.models.turn import TurnState, TurnStatus
 from tta.pipeline.llm_guard import guarded_llm_call
@@ -19,12 +26,57 @@ from tta.pipeline.types import PipelineDeps
 
 log = structlog.get_logger()
 
+# --- Narrator prompt: hard constraints vs soft guidance (S03 FR-1, FR-4) ---
+
+_NARRATOR_CONSTRAINTS = (
+    "Hard constraints (never violate):\n"
+    "- Write in second person present tense\n"
+    "- Never break the fourth wall or reference being an AI/game\n"
+    "- Never expose game mechanics, stats, or dice rolls\n"
+    "- Maintain consistency with established world facts\n"
+    "- Never narrate player thoughts or decisions for them"
+)
+
+_NARRATOR_GUIDANCE = (
+    "Narrative quality guidance:\n"
+    "- Engage at least two senses per scene (sight + sound/smell/touch)\n"
+    "- Prefer active voice and concrete verbs over passive constructions\n"
+    "- Show, don't tell — reveal character through action, not exposition\n"
+    "- Avoid purple prose — favor clarity over ornate descriptions\n"
+    "- Avoid info-dumping — weave world details naturally into action"
+)
+
 _GENERATION_SYSTEM_PROMPT = (
     "You are a narrative game engine. "
     "Write immersive second-person prose responding to the player's "
-    "action within the current world context. "
-    "Keep responses concise (2-4 paragraphs)."
+    "action within the current world context.\n\n"
+    f"{_NARRATOR_CONSTRAINTS}\n\n"
+    f"{_NARRATOR_GUIDANCE}"
 )
+
+# --- Adaptive word counts by intent (S03 FR-4.2, AC-3.8) ---
+
+INTENT_WORD_RANGES: dict[str, tuple[int, int]] = {
+    "move": (80, 150),
+    "examine": (150, 300),
+    "talk": (100, 250),
+    "use": (80, 200),
+    "meta": (50, 100),
+    "other": (100, 200),
+}
+
+_DEFAULT_WORD_RANGE = (100, 200)
+
+# --- Graceful fallback narrative (S03 FR-8.1, FR-8.2) ---
+
+_FALLBACK_NARRATIVE = (
+    "A strange stillness settles over the world around you. "
+    "The air shimmers briefly, as though reality itself drew a breath. "
+    "After a moment, everything steadies — "
+    "the world is still here, waiting for your next move."
+)
+
+_MAX_TRANSIENT_RETRIES = 2
 
 _EXTRACTION_SYSTEM_PROMPT = (
     "Extract world state changes and suggested actions from the narrative. "
@@ -44,11 +96,33 @@ def _build_generation_prompt(state: TurnState) -> str:
     """Build the user prompt from pipeline state."""
     intent = state.parsed_intent.intent if state.parsed_intent else "unknown"
     context_str = json.dumps(state.world_context or {}, default=str)
+
+    # Adaptive word count from intent (S03 FR-4.2)
+    word_min, word_max = INTENT_WORD_RANGES.get(intent, _DEFAULT_WORD_RANGE)
+
     parts = [
         f"Player action: {state.player_input}",
         f"Intent: {intent}",
         f"World context: {context_str}",
     ]
+
+    # Tone/genre injection (S03 FR-6.1)
+    wc = state.world_context or {}
+    tone = wc.get("tone")
+    genre = wc.get("genre")
+    if tone or genre:
+        style_parts = []
+        if tone:
+            style_parts.append(f"tone: {tone}")
+        if genre:
+            style_parts.append(f"genre: {genre}")
+        parts.append(f"\nNarrative style: {', '.join(style_parts)}")
+
+    # Session summary for long-game continuity (S03 FR-3.2)
+    summary = wc.get("session_summary")
+    if summary:
+        parts.append(f"\nStory so far: {summary}")
+
     if state.consequence_hints:
         hints = "; ".join(state.consequence_hints)
         parts.append(
@@ -56,12 +130,19 @@ def _build_generation_prompt(state: TurnState) -> str:
         )
     if state.active_consequences:
         parts.append(f"\nActive consequence chains: {len(state.active_consequences)}")
-    parts.append("\nGenerate a narrative response.")
+
+    parts.append(f"\nAim for {word_min}-{word_max} words.")
+    parts.append("Generate a narrative response.")
     return "\n".join(parts)
 
 
 async def generate_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
-    """Generate narrative and extract world changes."""
+    """Generate narrative and extract world changes.
+
+    Implements a 3-tier retry cascade for transient LLM failures
+    (S03 FR-8.1, FR-8.2). Non-transient failures (safety, budget,
+    moderation) are never retried.
+    """
     # 1. Build generation prompt
     prompt = _build_generation_prompt(state)
     state = state.model_copy(update={"generation_prompt": prompt})
@@ -81,50 +162,50 @@ async def generate_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
             }
         )
 
-    # 3. Call LLM for narrative generation
-    # Use prompt registry for SYSTEM message if available.
-    # Keep SYSTEM message free of user input to reduce prompt-injection risk.
-    gen_system = _GENERATION_SYSTEM_PROMPT
-    if deps.prompt_registry and deps.prompt_registry.has("narrative.generate"):
-        try:
-            rendered = deps.prompt_registry.render("narrative.generate", {})
-            gen_system = rendered.text
-        except (KeyError, ValueError):
-            log.warning("generation_template_render_failed", exc_info=True)
-
+    # 3. Call LLM with transient-failure retry cascade
+    gen_system = _resolve_system_prompt(deps)
     messages = [
         Message(role=MessageRole.SYSTEM, content=gen_system),
         Message(role=MessageRole.USER, content=prompt),
     ]
-    response = await guarded_llm_call(deps, ModelRole.GENERATION, messages)
+
+    narrative: str | None = None
+    degraded = False
+    response: LLMResponse | None = None
+
+    try:
+        response = await _llm_with_retries(messages, deps, state)
+        narrative = response.content
+    except (BudgetExceededError, AppError, PermanentLLMError):
+        raise  # Non-transient — propagate immediately
+    except Exception:
+        # All retries exhausted — use fallback narrative
+        log.warning(
+            "generation_fallback_activated",
+            session_id=str(state.session_id),
+            exc_info=True,
+        )
+        narrative = _FALLBACK_NARRATIVE
+        degraded = True
 
     # 4. Post-generation safety check
-    safety_post = await deps.safety_post_gen.post_generation_check(
-        response.content, state
-    )
+    safety_post = await deps.safety_post_gen.post_generation_check(narrative, state)
     if not safety_post.safe:
         log.warning(
             "safety_blocked_post_gen",
             session_id=str(state.session_id),
             flags=safety_post.flags,
         )
-        # Buffer-then-stream moderation: the full LLM output is
-        # moderated before any SSE events are sent to the client.
-        # On block the redirect narrative replaces the original
-        # content (AC-24.2) and the SSE layer emits a ModerationEvent.
         if safety_post.modified_content:
             import hashlib
 
-            content_hash = hashlib.sha256(response.content.encode()).hexdigest()
-            # Log content_hash for audit correlation (FR-24.14).
-            # Raw content is stored only in moderation_records DB
-            # via ModerationRecorder, not in general logs.
+            content_hash = hashlib.sha256(narrative.encode()).hexdigest()
             log.warning(
                 "moderation_blocked_output",
                 session_id=str(state.session_id),
                 flags=safety_post.flags,
                 content_hash=content_hash,
-                blocked_content_length=len(response.content),
+                blocked_content_length=len(narrative),
             )
             return state.model_copy(
                 update={
@@ -140,26 +221,99 @@ async def generate_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
             }
         )
 
-    narrative = safety_post.modified_content or response.content
+    narrative = safety_post.modified_content or narrative
 
-    # 5. Extract world changes + suggested actions via LLM
+    # 5. Extract world changes (skip on degraded turns)
+    if degraded:
+        log.info(
+            "extraction_skipped_degraded",
+            session_id=str(state.session_id),
+        )
+        return state.model_copy(
+            update={
+                "narrative_output": narrative,
+                "model_used": "fallback",
+                "world_state_updates": list(state.world_state_updates or []),
+                "suggested_actions": None,
+            }
+        )
+
     world_updates, suggestions = await _extract_world_changes(
         narrative, state.player_input, deps
     )
 
-    # Merge consequence-originated updates with extraction-originated ones
     prior = list(state.world_state_updates or [])
     merged = prior + (world_updates or [])
 
     return state.model_copy(
         update={
             "narrative_output": narrative,
-            "model_used": response.model_used,
-            "token_count": response.token_count,
+            "model_used": response.model_used if response else "fallback",
+            "token_count": response.token_count if response else None,
             "world_state_updates": merged if merged else [],
             "suggested_actions": suggestions or None,
         }
     )
+
+
+def _resolve_system_prompt(deps: PipelineDeps) -> str:
+    """Resolve generation system prompt from registry or default."""
+    if deps.prompt_registry and deps.prompt_registry.has("narrative.generate"):
+        try:
+            rendered = deps.prompt_registry.render("narrative.generate", {})
+            return rendered.text
+        except (KeyError, ValueError):
+            log.warning("generation_template_render_failed", exc_info=True)
+    return _GENERATION_SYSTEM_PROMPT
+
+
+async def _llm_with_retries(
+    messages: list[Message],
+    deps: PipelineDeps,
+    state: TurnState,
+) -> LLMResponse:
+    """Call LLM with retry cascade for transient failures (S03 FR-8).
+
+    Tier 1: retry with same messages
+    Tier 2: retry with simplified context (system + user only)
+    Raises on non-transient or all-tiers-exhausted errors.
+    """
+    last_exc: Exception | None = None
+    for attempt in range(_MAX_TRANSIENT_RETRIES + 1):
+        try:
+            return await guarded_llm_call(deps, ModelRole.GENERATION, messages)
+        except (TransientLLMError, AllTiersFailedError) as exc:
+            last_exc = exc
+            log.warning(
+                "generation_retry",
+                attempt=attempt + 1,
+                max_retries=_MAX_TRANSIENT_RETRIES,
+                session_id=str(state.session_id),
+                error=str(exc),
+            )
+            # Tier 2: simplify context on second retry
+            if attempt == 0 and len(messages) > 2:
+                messages = [messages[0], messages[-1]]
+        except (BudgetExceededError, AppError):
+            raise
+        except Exception as exc:
+            # Classify unknown exceptions
+            from tta.llm.errors import classify_error
+
+            err_cls = classify_error(exc)
+            if err_cls is TransientLLMError:
+                last_exc = exc
+                log.warning(
+                    "generation_retry_classified",
+                    attempt=attempt + 1,
+                    session_id=str(state.session_id),
+                    error=str(exc),
+                )
+                continue
+            raise
+
+    # All retries exhausted
+    raise last_exc or RuntimeError("All generation retries exhausted")
 
 
 async def _extract_world_changes(

--- a/tests/unit/pipeline/test_context_narrative.py
+++ b/tests/unit/pipeline/test_context_narrative.py
@@ -1,0 +1,100 @@
+"""Wave 24 tests for context stage tone/summary injection (S03)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from tta.models.turn import TurnState
+from tta.pipeline.stages.context import _inject_summary, _inject_tone
+
+
+def _make_state(**overrides: object) -> TurnState:
+    defaults: dict = {
+        "session_id": uuid4(),
+        "turn_number": 1,
+        "player_input": "look around",
+        "game_state": {"location": "tavern"},
+    }
+    defaults.update(overrides)
+    return TurnState(**defaults)
+
+
+# ===================================================================
+# Tone injection (S03 FR-6.1)
+# ===================================================================
+
+
+class TestInjectTone:
+    """_inject_tone extracts tone/genre from world_seed."""
+
+    def test_tone_injected_from_world_seed(self) -> None:
+        state = _make_state(
+            game_state={
+                "world_seed": {"tone": "mysterious", "genre": "noir"},
+            }
+        )
+        ctx: dict = {}
+        result = _inject_tone(ctx, state)
+        assert result["tone"] == "mysterious"
+        assert result["genre"] == "noir"
+
+    def test_no_world_seed_no_crash(self) -> None:
+        state = _make_state(game_state={})
+        ctx: dict = {}
+        result = _inject_tone(ctx, state)
+        assert "tone" not in result
+        assert "genre" not in result
+
+    def test_partial_world_seed_tone_only(self) -> None:
+        state = _make_state(game_state={"world_seed": {"tone": "whimsical"}})
+        ctx: dict = {}
+        result = _inject_tone(ctx, state)
+        assert result["tone"] == "whimsical"
+        assert "genre" not in result
+
+    def test_empty_tone_not_injected(self) -> None:
+        state = _make_state(game_state={"world_seed": {"tone": "", "genre": ""}})
+        ctx: dict = {}
+        result = _inject_tone(ctx, state)
+        assert "tone" not in result
+        assert "genre" not in result
+
+    def test_world_seed_not_dict(self) -> None:
+        state = _make_state(game_state={"world_seed": "invalid"})
+        ctx: dict = {}
+        result = _inject_tone(ctx, state)
+        assert "tone" not in result
+
+
+# ===================================================================
+# Summary injection (S03 FR-3.2)
+# ===================================================================
+
+
+class TestInjectSummary:
+    """_inject_summary reads existing session summary."""
+
+    def test_summary_injected_when_present(self) -> None:
+        state = _make_state(game_state={"summary": "The hero found a magic sword."})
+        ctx: dict = {}
+        result = _inject_summary(ctx, state)
+        assert result["session_summary"] == "The hero found a magic sword."
+
+    def test_no_summary_no_injection(self) -> None:
+        state = _make_state(game_state={})
+        ctx: dict = {}
+        result = _inject_summary(ctx, state)
+        assert "session_summary" not in result
+
+    def test_empty_summary_not_injected(self) -> None:
+        state = _make_state(game_state={"summary": ""})
+        ctx: dict = {}
+        result = _inject_summary(ctx, state)
+        assert "session_summary" not in result
+
+    def test_preserves_existing_context(self) -> None:
+        state = _make_state(game_state={"summary": "Previously..."})
+        ctx = {"location": "tavern", "npcs_present": []}
+        result = _inject_summary(ctx, state)
+        assert result["session_summary"] == "Previously..."
+        assert result["location"] == "tavern"

--- a/tests/unit/pipeline/test_generate_narrative.py
+++ b/tests/unit/pipeline/test_generate_narrative.py
@@ -1,0 +1,292 @@
+"""Wave 24 tests for narrative engine enhancements (S03).
+
+Tests adaptive word counts, narrator constraints, retry cascade,
+graceful fallback, and prompt registry resolution.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from tta.llm.errors import (
+    AllTiersFailedError,
+    BudgetExceededError,
+    PermanentLLMError,
+    TransientLLMError,
+)
+from tta.models.turn import ParsedIntent, TurnState
+from tta.pipeline.stages.generate import (
+    _FALLBACK_NARRATIVE,
+    _GENERATION_SYSTEM_PROMPT,
+    _NARRATOR_CONSTRAINTS,
+    INTENT_WORD_RANGES,
+    _build_generation_prompt,
+    _resolve_system_prompt,
+    generate_stage,
+)
+from tta.safety.hooks import SafetyResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_state(**overrides: object) -> TurnState:
+    defaults: dict = {
+        "session_id": uuid4(),
+        "turn_number": 1,
+        "player_input": "look around",
+        "game_state": {},
+        "parsed_intent": ParsedIntent(intent="examine", confidence=0.9),
+        "world_context": {"game_state": {}, "intent": "examine"},
+    }
+    defaults.update(overrides)
+    return TurnState(**defaults)
+
+
+def _safe() -> SafetyResult:
+    return SafetyResult(safe=True)
+
+
+def _make_deps(
+    *,
+    llm: AsyncMock | None = None,
+    prompt_registry: MagicMock | None = None,
+) -> MagicMock:
+    deps = MagicMock()
+    deps.llm = llm or AsyncMock()
+    deps.world = AsyncMock()
+    deps.session_repo = AsyncMock()
+    deps.turn_repo = AsyncMock()
+    deps.safety_pre_input = AsyncMock()
+    deps.safety_pre_gen = MagicMock()
+    deps.safety_pre_gen.pre_generation_check = AsyncMock(return_value=_safe())
+    deps.safety_post_gen = MagicMock()
+    deps.safety_post_gen.post_generation_check = AsyncMock(return_value=_safe())
+    deps.prompt_registry = prompt_registry
+    return deps
+
+
+# ===================================================================
+# 1. Adaptive word counts per intent (S03 FR-4.2, AC-3.8)
+# ===================================================================
+
+
+class TestAdaptiveWordCounts:
+    """_build_generation_prompt includes intent-specific word guidance."""
+
+    @pytest.mark.parametrize(
+        "intent,expected_range",
+        list(INTENT_WORD_RANGES.items()),
+    )
+    def test_word_range_injected_per_intent(
+        self, intent: str, expected_range: tuple[int, int]
+    ) -> None:
+        state = _make_state(
+            parsed_intent=ParsedIntent(intent=intent, confidence=0.9),
+            world_context={"game_state": {}, "intent": intent},
+        )
+        prompt = _build_generation_prompt(state)
+        word_min, word_max = expected_range
+        assert f"{word_min}-{word_max} words" in prompt
+
+    def test_unknown_intent_uses_default_range(self) -> None:
+        state = _make_state(
+            parsed_intent=ParsedIntent(intent="unknown", confidence=0.5),
+            world_context={"game_state": {}, "intent": "unknown"},
+        )
+        prompt = _build_generation_prompt(state)
+        assert "100-200 words" in prompt
+
+
+# ===================================================================
+# 2. Narrator constraints in system prompt (S03 FR-1.4, FR-4.1)
+# ===================================================================
+
+
+class TestNarratorConstraints:
+    """System prompt includes hard constraints and quality guidance."""
+
+    def test_constraints_in_system_prompt(self) -> None:
+        assert "fourth wall" in _NARRATOR_CONSTRAINTS.lower()
+        assert "AI" in _NARRATOR_CONSTRAINTS or "ai" in _NARRATOR_CONSTRAINTS.lower()
+
+    def test_system_prompt_includes_constraints(self) -> None:
+        assert _NARRATOR_CONSTRAINTS in _GENERATION_SYSTEM_PROMPT
+
+
+# ===================================================================
+# 3. Tone/genre injection in prompt (S03 FR-6.1)
+# ===================================================================
+
+
+class TestToneGenreInjection:
+    """_build_generation_prompt surfaces tone when available."""
+
+    def test_tone_present_in_prompt(self) -> None:
+        state = _make_state(
+            world_context={
+                "game_state": {},
+                "intent": "examine",
+                "tone": "dark and foreboding",
+            },
+        )
+        prompt = _build_generation_prompt(state)
+        assert "dark and foreboding" in prompt
+
+    def test_genre_present_in_prompt(self) -> None:
+        state = _make_state(
+            world_context={
+                "game_state": {},
+                "intent": "talk",
+                "genre": "steampunk",
+            },
+        )
+        prompt = _build_generation_prompt(state)
+        assert "steampunk" in prompt
+
+    def test_no_tone_no_crash(self) -> None:
+        state = _make_state(
+            world_context={"game_state": {}, "intent": "move"},
+        )
+        prompt = _build_generation_prompt(state)
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+
+
+# ===================================================================
+# 4. Summary injection in prompt (S03 FR-3.2)
+# ===================================================================
+
+
+class TestSummaryInjection:
+    """_build_generation_prompt includes session summary if available."""
+
+    def test_summary_present_in_prompt(self) -> None:
+        state = _make_state(
+            world_context={
+                "game_state": {},
+                "intent": "examine",
+                "session_summary": (
+                    "The hero entered the dark forest and found a sword."
+                ),
+            },
+        )
+        prompt = _build_generation_prompt(state)
+        assert "The hero entered the dark forest" in prompt
+
+    def test_no_summary_no_crash(self) -> None:
+        state = _make_state(
+            world_context={"game_state": {}, "intent": "move"},
+        )
+        prompt = _build_generation_prompt(state)
+        assert isinstance(prompt, str)
+
+
+# ===================================================================
+# 5. Prompt registry resolution (S03 FR-4.3)
+# ===================================================================
+
+
+class TestPromptRegistryResolution:
+    """_resolve_system_prompt uses registry when available."""
+
+    def test_uses_registry_when_template_exists(self) -> None:
+        registry = MagicMock()
+        registry.has.return_value = True
+        rendered = MagicMock()
+        rendered.text = "Custom system prompt from registry"
+        registry.render.return_value = rendered
+
+        deps = _make_deps(prompt_registry=registry)
+        result = _resolve_system_prompt(deps)
+        assert result == "Custom system prompt from registry"
+
+    def test_falls_back_when_no_registry(self) -> None:
+        deps = _make_deps(prompt_registry=None)
+        result = _resolve_system_prompt(deps)
+        assert result == _GENERATION_SYSTEM_PROMPT
+
+    def test_falls_back_when_template_missing(self) -> None:
+        registry = MagicMock()
+        registry.has.return_value = False
+        deps = _make_deps(prompt_registry=registry)
+        result = _resolve_system_prompt(deps)
+        assert result == _GENERATION_SYSTEM_PROMPT
+
+
+# ===================================================================
+# 6. Graceful fallback on transient errors (S03 FR-8.1, FR-8.2)
+# ===================================================================
+
+
+class TestGracefulFallback:
+    """Transient LLM failures trigger in-world fallback narrative."""
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_transient_error(self) -> None:
+        deps = _make_deps()
+        # guarded_llm_call always raises transient → exhausts retries
+        import tta.pipeline.stages.generate as gen_mod
+
+        original = gen_mod.guarded_llm_call
+        gen_mod.guarded_llm_call = AsyncMock(side_effect=TransientLLMError("timeout"))
+        try:
+            state = _make_state()
+            result = await generate_stage(state, deps)
+            assert result.narrative_output == _FALLBACK_NARRATIVE
+            assert result.suggested_actions is None
+            assert result.model_used == "fallback"
+        finally:
+            gen_mod.guarded_llm_call = original
+
+    @pytest.mark.asyncio
+    async def test_budget_error_propagates(self) -> None:
+        deps = _make_deps()
+        import tta.pipeline.stages.generate as gen_mod
+
+        original = gen_mod.guarded_llm_call
+        gen_mod.guarded_llm_call = AsyncMock(
+            side_effect=BudgetExceededError("over budget")
+        )
+        try:
+            state = _make_state()
+            with pytest.raises(BudgetExceededError):
+                await generate_stage(state, deps)
+        finally:
+            gen_mod.guarded_llm_call = original
+
+    @pytest.mark.asyncio
+    async def test_permanent_error_propagates(self) -> None:
+        deps = _make_deps()
+        import tta.pipeline.stages.generate as gen_mod
+
+        original = gen_mod.guarded_llm_call
+        gen_mod.guarded_llm_call = AsyncMock(
+            side_effect=PermanentLLMError("auth failed")
+        )
+        try:
+            state = _make_state()
+            with pytest.raises(PermanentLLMError):
+                await generate_stage(state, deps)
+        finally:
+            gen_mod.guarded_llm_call = original
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_all_tiers_failed(self) -> None:
+        deps = _make_deps()
+        import tta.pipeline.stages.generate as gen_mod
+
+        original = gen_mod.guarded_llm_call
+        gen_mod.guarded_llm_call = AsyncMock(
+            side_effect=AllTiersFailedError("generation", [RuntimeError("tier failed")])
+        )
+        try:
+            state = _make_state()
+            result = await generate_stage(state, deps)
+            assert result.narrative_output == _FALLBACK_NARRATIVE
+        finally:
+            gen_mod.guarded_llm_call = original

--- a/tests/unit/pipeline/test_s23_graceful_degradation.py
+++ b/tests/unit/pipeline/test_s23_graceful_degradation.py
@@ -74,8 +74,12 @@ class TestLLMFailureGracefulDegradation:
 
         assert result.status == TurnStatus.failed
 
-    async def test_llm_runtime_error_returns_failed(self) -> None:
-        """Any runtime error from LLM provider is caught gracefully."""
+    async def test_llm_runtime_error_returns_degraded(self) -> None:
+        """Runtime error triggers fallback narrative (degraded but complete).
+
+        Wave 24 added graceful in-world fallback for transient LLM errors,
+        so RuntimeError now produces a degraded narrative instead of failed.
+        """
         llm = MockLLMClient()
         llm.generate = AsyncMock(  # type: ignore[method-assign]
             side_effect=RuntimeError("provider unavailable"),
@@ -85,10 +89,15 @@ class TestLLMFailureGracefulDegradation:
 
         result = await run_pipeline(state, deps)
 
-        assert result.status == TurnStatus.failed
+        assert result.status == TurnStatus.complete
+        assert result.narrative_output is not None
 
-    async def test_llm_timeout_returns_failed(self) -> None:
-        """LLM timeout within generate stage produces failed status."""
+    async def test_llm_timeout_returns_degraded(self) -> None:
+        """LLM timeout triggers fallback narrative (degraded but complete).
+
+        Wave 24 added graceful in-world fallback for transient LLM errors,
+        so TimeoutError now produces a degraded narrative instead of failed.
+        """
         llm = MockLLMClient()
         llm.generate = AsyncMock(  # type: ignore[method-assign]
             side_effect=TimeoutError("LLM call timed out"),
@@ -98,7 +107,8 @@ class TestLLMFailureGracefulDegradation:
 
         result = await run_pipeline(state, deps)
 
-        assert result.status == TurnStatus.failed
+        assert result.status == TurnStatus.complete
+        assert result.narrative_output is not None
 
     async def test_llm_queue_full_returns_failed(self) -> None:
         """When LLM semaphore is full, pipeline fails gracefully."""
@@ -117,8 +127,8 @@ class TestLLMFailureGracefulDegradation:
 
         assert result.status == TurnStatus.failed
 
-    async def test_original_state_preserved_on_failure(self) -> None:
-        """Failure doesn't corrupt session_id or player_input."""
+    async def test_original_state_preserved_on_degraded(self) -> None:
+        """Degraded fallback doesn't corrupt session_id or player_input."""
         llm = MockLLMClient()
         llm.generate = AsyncMock(  # type: ignore[method-assign]
             side_effect=RuntimeError("boom"),
@@ -129,7 +139,7 @@ class TestLLMFailureGracefulDegradation:
 
         result = await run_pipeline(state, deps)
 
-        assert result.status == TurnStatus.failed
+        assert result.status == TurnStatus.complete
         assert result.session_id == sid
         assert result.player_input == "test input"
 


### PR DESCRIPTION
## Summary
Enhance S03 Narrative Engine compliance (Wave 24).

Closes #109

## Changes
- **Adaptive word counts**: Intent-aware ranges (move→80-150, examine→150-300, etc.)
- **Enhanced narrator prompt**: Hard constraints (no fourth-wall, no AI refs) + soft guidance (sensory detail, active voice)
- **Graceful fallback**: 3-tier retry cascade for transient failures → in-world pause narrative
- **Summary context**: Inject session summary and tone/genre into generation context

## Files Changed
- `src/tta/pipeline/stages/generate.py` — Major rewrite: narrator prompt, word counts, fallback
- `src/tta/pipeline/stages/context.py` — Tone + summary injection helpers
- `tests/unit/pipeline/test_generate_narrative.py` — 18 new tests
- `tests/unit/pipeline/test_context_narrative.py` — 9 new tests
- `tests/unit/pipeline/test_s23_graceful_degradation.py` — Updated for new fallback behavior

## Testing
- 30 new tests, 1625 total passing
- `make quality`: ruff check ✅, ruff format ✅, pyright 0 errors ✅