### PR TITLE
feat(s05): Choice & Consequence narrative surfacing, divergence steering, dormant fix

### DIFF
--- a/src/tta/choices/consequence_service.py
+++ b/src/tta/choices/consequence_service.py
@@ -173,6 +173,7 @@ class ConsequenceService(Protocol):
     async def reveal_hidden_entry(
         self,
         entry_id: UUID,
+        turn: int | None = None,
     ) -> ConsequenceEntry | None:
         """Transition a hidden entry to visible. Returns updated entry."""
         ...
@@ -417,6 +418,7 @@ class InMemoryConsequenceService:
     async def reveal_hidden_entry(
         self,
         entry_id: UUID,
+        turn: int | None = None,
     ) -> ConsequenceEntry | None:
         for chains in self._chains.values():
             for chain in chains:
@@ -427,6 +429,8 @@ class InMemoryConsequenceService:
                     ):
                         entry.visibility = ConsequenceVisibility.VISIBLE
                         entry.status = ConsequenceStatus.ACTIVE
+                        if turn is not None:
+                            chain.last_active_turn = turn
                         return entry
         return None
 

--- a/src/tta/choices/consequence_service.py
+++ b/src/tta/choices/consequence_service.py
@@ -159,8 +159,8 @@ class ConsequenceService(Protocol):
         current_turn: int,
         *,
         max_chains: int = MAX_ACTIVE_CHAINS,
-    ) -> list[UUID]:
-        """Prune excess chains. Returns IDs of pruned chains."""
+    ) -> tuple[list[UUID], list[str]]:
+        """Prune excess chains. Returns (pruned IDs, closure descriptions)."""
         ...
 
     async def get_foreshadowing_hints(
@@ -255,7 +255,6 @@ class InMemoryConsequenceService:
         for chain in chains:
             if chain.is_resolved or chain.is_dormant:
                 continue
-            chain.last_active_turn = turn
             changed = False
 
             for entry in chain.entries:
@@ -285,6 +284,7 @@ class InMemoryConsequenceService:
                         continue  # Stay pending until reveal
 
                     entry.status = ConsequenceStatus.ACTIVE
+                    chain.last_active_turn = turn
                     changed = True
                     world_changes.append(
                         WorldChange(
@@ -350,9 +350,11 @@ class InMemoryConsequenceService:
         current_turn: int,
         *,
         max_chains: int = MAX_ACTIVE_CHAINS,
-    ) -> list[UUID]:
+    ) -> tuple[list[UUID], list[str]]:
+        """Prune excess/dormant chains. Returns (pruned IDs, closure descriptions)."""
         chains = self._chains.get(session_id, [])
         pruned_ids: list[UUID] = []
+        closures: list[str] = []
 
         # Mark dormant chains first (50+ turns inactive, S05 FR-8)
         for chain in chains:
@@ -368,11 +370,12 @@ class InMemoryConsequenceService:
                         ConsequenceStatus.ACTIVE,
                     ):
                         entry.status = ConsequenceStatus.DORMANT
+                closures.append(chain.root_trigger)
 
         # Capacity pruning
         active = [c for c in chains if not c.is_resolved and not c.is_dormant]
         if len(active) <= max_chains:
-            return pruned_ids
+            return pruned_ids, closures
 
         scored = sorted(active, key=_chain_prune_score)
         to_prune = len(active) - max_chains
@@ -381,13 +384,14 @@ class InMemoryConsequenceService:
             for entry in chain.entries:
                 entry.status = ConsequenceStatus.PRUNED
             pruned_ids.append(chain.id)
+            closures.append(chain.root_trigger)
             log.debug(
                 "consequence_chain_pruned",
                 chain_id=str(chain.id),
                 reason="over_capacity",
             )
 
-        return pruned_ids
+        return pruned_ids, closures
 
     async def get_foreshadowing_hints(
         self,

--- a/src/tta/models/turn.py
+++ b/src/tta/models/turn.py
@@ -97,3 +97,5 @@ class TurnState(BaseModel):
     choice_classification: ChoiceClassification | None = None
     active_consequences: list[ConsequenceChain] | None = None
     consequence_hints: list[str] | None = None
+    divergence_guidance: str | None = None
+    pruned_chain_closures: list[str] | None = None

--- a/src/tta/pipeline/stages/context.py
+++ b/src/tta/pipeline/stages/context.py
@@ -96,12 +96,20 @@ async def context_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
             )
             if score and score.needs_steering:
                 anchors = await consequence_svc.get_active_anchors(state.session_id)
-                if anchors:
-                    nearest = anchors[0].description
+                # Pick the anchor matching nearest_anchor_id when available
+                nearest_desc: str | None = None
+                if anchors and score.nearest_anchor_id:
+                    for a in anchors:
+                        if a.id == score.nearest_anchor_id:
+                            nearest_desc = a.description
+                            break
+                if nearest_desc is None and anchors:
+                    nearest_desc = anchors[0].description
+                if nearest_desc:
                     divergence_guidance = (
                         f"The story is diverging significantly "
                         f"(divergence {score.score:.1f}). "
-                        f"Gently steer toward: {nearest}"
+                        f"Gently steer toward: {nearest_desc}"
                     )
                 else:
                     divergence_guidance = (

--- a/src/tta/pipeline/stages/context.py
+++ b/src/tta/pipeline/stages/context.py
@@ -79,6 +79,7 @@ async def context_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
 
     # Populate TurnState.active_consequences from chain data
     active_consequence_chains = None
+    divergence_guidance: str | None = None
     consequence_svc = getattr(deps, "consequence_service", None)
     if consequence_svc is not None:
         try:
@@ -87,6 +88,34 @@ async def context_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
                 active_consequence_chains = chains
         except Exception:
             pass  # Already logged in _enrich_consequences
+
+        # Divergence steering (S05 AC-5.10)
+        try:
+            score = await consequence_svc.calculate_divergence(
+                state.session_id, state.turn_number
+            )
+            if score and score.needs_steering:
+                anchors = await consequence_svc.get_active_anchors(state.session_id)
+                if anchors:
+                    nearest = anchors[0].description
+                    divergence_guidance = (
+                        f"The story is diverging significantly "
+                        f"(divergence {score.score:.1f}). "
+                        f"Gently steer toward: {nearest}"
+                    )
+                else:
+                    divergence_guidance = (
+                        f"The story is diverging significantly "
+                        f"(divergence {score.score:.1f}). "
+                        "Introduce narrative elements that reconnect "
+                        "to established story threads."
+                    )
+        except Exception:
+            log.warning(
+                "divergence_calculation_failed",
+                session_id=str(state.session_id),
+                exc_info=True,
+            )
 
     log.debug(
         "context_assembled",
@@ -101,6 +130,8 @@ async def context_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
     }
     if active_consequence_chains is not None:
         update["active_consequences"] = active_consequence_chains
+    if divergence_guidance is not None:
+        update["divergence_guidance"] = divergence_guidance
 
     return state.model_copy(update=update)
 

--- a/src/tta/pipeline/stages/generate.py
+++ b/src/tta/pipeline/stages/generate.py
@@ -20,6 +20,7 @@ from tta.llm.errors import (
     TransientLLMError,
 )
 from tta.llm.roles import ModelRole
+from tta.models.choice import Reversibility
 from tta.models.turn import TurnState, TurnStatus
 from tta.pipeline.llm_guard import guarded_llm_call
 from tta.pipeline.types import PipelineDeps
@@ -134,8 +135,40 @@ def _build_generation_prompt(state: TurnState) -> str:
         parts.append(
             f"\nSubtle foreshadowing (weave naturally, do not state directly): {hints}"
         )
+
+    # Consequence narrative surfacing (S05 AC-5.1)
     if state.active_consequences:
-        parts.append(f"\nActive consequence chains: {len(state.active_consequences)}")
+        descs = [c.root_trigger for c in state.active_consequences if not c.is_resolved]
+        if descs:
+            joined = "; ".join(descs[:5])
+            parts.append(
+                f"\nConsequences manifesting: {joined}. "
+                "Weave these effects naturally into the scene — "
+                "show their impact through environment and character reactions."
+            )
+
+    # Permanent choice signals (S05 AC-5.4)
+    cc = state.choice_classification
+    if cc and cc.reversibility == Reversibility.PERMANENT:
+        parts.append(
+            "\nThis is a PERMANENT, irreversible choice. "
+            "Signal its gravity through the environment: "
+            "a charged atmosphere, NPC reactions that convey finality, "
+            "environmental weight, and irreversible stakes. "
+            "Do NOT narrate the player's internal thoughts or decisions."
+        )
+
+    # Divergence steering (S05 AC-5.10)
+    if state.divergence_guidance:
+        parts.append(f"\n{state.divergence_guidance}")
+
+    # Dormant chain closure hints (S05 AC-5.8)
+    if state.pruned_chain_closures:
+        closure_text = "; ".join(state.pruned_chain_closures[:3])
+        parts.append(
+            f"\nFading story threads to resolve naturally: {closure_text}. "
+            "Briefly acknowledge their conclusion in passing."
+        )
 
     parts.append(f"\nAim for {word_min}-{word_max} words.")
     parts.append("Generate a narrative response.")

--- a/src/tta/pipeline/stages/understand.py
+++ b/src/tta/pipeline/stages/understand.py
@@ -170,6 +170,9 @@ async def understand_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
     # 5. Consequence evaluation (S05 FR-3) — evaluate pending consequences
     classified_state = await _evaluate_consequences(classified_state, deps)
 
+    # 6. Prune dormant/excess chains (S05 AC-5.8)
+    classified_state = await _prune_consequence_chains(classified_state, deps)
+
     return classified_state
 
 
@@ -203,6 +206,22 @@ async def _evaluate_consequences(state: TurnState, deps: PipelineDeps) -> TurnSt
             return state.model_copy(update=updates)
     except Exception:
         log.warning("consequence_evaluation_failed", exc_info=True)
+    return state
+
+
+async def _prune_consequence_chains(state: TurnState, deps: PipelineDeps) -> TurnState:
+    """Prune dormant/excess chains and capture closure descriptions (S05 AC-5.8)."""
+    consequence_svc = getattr(deps, "consequence_service", None)
+    if consequence_svc is None:
+        return state
+    try:
+        _pruned_ids, closures = await consequence_svc.prune_chains(
+            state.session_id, state.turn_number
+        )
+        if closures:
+            return state.model_copy(update={"pruned_chain_closures": closures})
+    except Exception:
+        log.warning("consequence_pruning_failed", exc_info=True)
     return state
 
 

--- a/tests/unit/choices/test_consequence_performance.py
+++ b/tests/unit/choices/test_consequence_performance.py
@@ -52,6 +52,7 @@ async def _populate_service(
         )
 
 
+@pytest.mark.slow
 @pytest.mark.asyncio
 async def test_evaluate_30_chains_under_300ms() -> None:
     """AC-5.6: evaluate() < 300ms for 30 active chains."""
@@ -74,6 +75,7 @@ async def test_evaluate_30_chains_under_300ms() -> None:
     assert median < 300, f"evaluate() median {median:.1f}ms exceeds 300ms"
 
 
+@pytest.mark.slow
 @pytest.mark.asyncio
 async def test_calculate_divergence_under_100ms() -> None:
     """AC-5.6: calculate_divergence() < 100ms."""
@@ -95,6 +97,7 @@ async def test_calculate_divergence_under_100ms() -> None:
     assert median < 100, f"calculate_divergence() median {median:.1f}ms exceeds 100ms"
 
 
+@pytest.mark.slow
 @pytest.mark.asyncio
 async def test_prune_chains_under_100ms() -> None:
     """AC-5.6: prune_chains() < 100ms."""

--- a/tests/unit/choices/test_consequence_performance.py
+++ b/tests/unit/choices/test_consequence_performance.py
@@ -1,0 +1,127 @@
+"""Performance benchmarks for S05 consequence operations (AC-5.6).
+
+NFR targets (S05 L328-336):
+- evaluate() < 300ms for 30 active chains
+- calculate_divergence() < 100ms
+- prune_chains() < 100ms
+"""
+
+from __future__ import annotations
+
+import time
+from uuid import uuid4
+
+import pytest
+
+from tta.choices.consequence_service import InMemoryConsequenceService
+from tta.models.choice import ImpactLevel
+from tta.models.consequence import (
+    MAX_ACTIVE_CHAINS,
+    ConsequenceEntry,
+    ConsequenceTimescale,
+    ConsequenceVisibility,
+)
+
+SID = uuid4()
+WARMUP = 3
+ITERATIONS = 10
+
+
+async def _populate_service(
+    svc: InMemoryConsequenceService,
+    n_chains: int = MAX_ACTIVE_CHAINS,
+    entries_per_chain: int = 4,
+) -> None:
+    for i in range(n_chains):
+        chain_id = uuid4()
+        entries = [
+            ConsequenceEntry(
+                chain_id=chain_id,
+                trigger=f"trigger-{i}-{j}",
+                effect=f"effect-{i}-{j}",
+                timescale=ConsequenceTimescale.SHORT_TERM,
+                visibility=ConsequenceVisibility.VISIBLE,
+            )
+            for j in range(entries_per_chain)
+        ]
+        await svc.create_chain(
+            session_id=SID,
+            root_trigger=f"trigger-{i}",
+            impact_level=ImpactLevel.CONSEQUENTIAL,
+            entries=entries,
+        )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_30_chains_under_300ms() -> None:
+    """AC-5.6: evaluate() < 300ms for 30 active chains."""
+    svc = InMemoryConsequenceService()
+    await _populate_service(svc, n_chains=30)
+
+    # Warmup
+    for _ in range(WARMUP):
+        await svc.evaluate(SID, 5, "test input")
+
+    # Measure
+    times: list[float] = []
+    for _ in range(ITERATIONS):
+        start = time.perf_counter()
+        await svc.evaluate(SID, 5, "the hero opens the chest")
+        elapsed = (time.perf_counter() - start) * 1000
+        times.append(elapsed)
+
+    median = sorted(times)[ITERATIONS // 2]
+    assert median < 300, f"evaluate() median {median:.1f}ms exceeds 300ms"
+
+
+@pytest.mark.asyncio
+async def test_calculate_divergence_under_100ms() -> None:
+    """AC-5.6: calculate_divergence() < 100ms."""
+    svc = InMemoryConsequenceService()
+    await _populate_service(svc, n_chains=30)
+    await svc.add_anchor(SID, "reach the temple", target_turn=20)
+
+    for _ in range(WARMUP):
+        await svc.calculate_divergence(SID, 10)
+
+    times: list[float] = []
+    for _ in range(ITERATIONS):
+        start = time.perf_counter()
+        await svc.calculate_divergence(SID, 10)
+        elapsed = (time.perf_counter() - start) * 1000
+        times.append(elapsed)
+
+    median = sorted(times)[ITERATIONS // 2]
+    assert median < 100, f"calculate_divergence() median {median:.1f}ms exceeds 100ms"
+
+
+@pytest.mark.asyncio
+async def test_prune_chains_under_100ms() -> None:
+    """AC-5.6: prune_chains() < 100ms."""
+    svc = InMemoryConsequenceService()
+    await _populate_service(svc, n_chains=30)
+    # Mark all chains as dormant
+    for chain in svc._chains.get(SID, []):
+        chain.last_active_turn = 0
+
+    for _ in range(WARMUP):
+        await svc.prune_chains(SID, 60)
+        # Re-populate after prune
+        svc._chains[SID] = []
+        await _populate_service(svc, n_chains=30)
+        for chain in svc._chains.get(SID, []):
+            chain.last_active_turn = 0
+
+    times: list[float] = []
+    for _ in range(ITERATIONS):
+        svc._chains[SID] = []
+        await _populate_service(svc, n_chains=30)
+        for chain in svc._chains.get(SID, []):
+            chain.last_active_turn = 0
+        start = time.perf_counter()
+        await svc.prune_chains(SID, 60)
+        elapsed = (time.perf_counter() - start) * 1000
+        times.append(elapsed)
+
+    median = sorted(times)[ITERATIONS // 2]
+    assert median < 100, f"prune_chains() median {median:.1f}ms exceeds 100ms"

--- a/tests/unit/choices/test_consequence_service.py
+++ b/tests/unit/choices/test_consequence_service.py
@@ -238,8 +238,9 @@ class TestPruneChains:
     @pytest.mark.asyncio
     async def test_no_prune_under_limit(self, svc, session_id) -> None:
         await svc.create_chain(session_id, "Only one", turn=0)
-        pruned = await svc.prune_chains(session_id, 10)
-        assert len(pruned) == 0
+        pruned_ids, closures = await svc.prune_chains(session_id, 10)
+        assert len(pruned_ids) == 0
+        assert len(closures) == 0
 
     @pytest.mark.asyncio
     async def test_resolved_pruned_first(self, svc, session_id) -> None:
@@ -252,8 +253,8 @@ class TestPruneChains:
             entry = ConsequenceEntry(chain_id=uuid4(), trigger=f"t{i}", effect=f"e{i}")
             await svc.create_chain(session_id, f"active_{i}", entries=[entry], turn=0)
         # 3 active + 1 resolved. Prune to max 2 active.
-        pruned = await svc.prune_chains(session_id, 10, max_chains=2)
-        assert len(pruned) == 1
+        pruned_ids, closures = await svc.prune_chains(session_id, 10, max_chains=2)
+        assert len(pruned_ids) == 1
 
     @pytest.mark.asyncio
     async def test_dormant_detection(self, svc, session_id) -> None:

--- a/tests/unit/pipeline/test_s05_choice_consequence.py
+++ b/tests/unit/pipeline/test_s05_choice_consequence.py
@@ -166,6 +166,7 @@ class TestDivergenceSteering:
 
     @pytest.mark.asyncio
     async def test_no_anchors_still_provides_guidance(self) -> None:
+        """Without anchors, divergence is 0.0 — guidance should be None."""
         svc = InMemoryConsequenceService()
         for i in range(25):
             await svc.create_chain(
@@ -174,12 +175,11 @@ class TestDivergenceSteering:
                 impact_level=ImpactLevel.DEFINING,
                 entries=[_entry(trigger=f"t-{i}", effect=f"e-{i}")],
             )
-        # No anchors set
+        # No anchors set — divergence returns 0.0 (unmeasurable)
         state = _make_state(turn_number=5)
         deps = _make_deps(consequence_service=svc)
         result = await context_stage(state, deps)
-        if result.divergence_guidance:
-            assert "reconnect" in result.divergence_guidance.lower()
+        assert result.divergence_guidance is None
 
 
 # --- AC-5.8: Dormant Fix + Closure ---

--- a/tests/unit/pipeline/test_s05_choice_consequence.py
+++ b/tests/unit/pipeline/test_s05_choice_consequence.py
@@ -1,0 +1,307 @@
+"""Tests for S05 Choice & Consequence pipeline integration (Wave 25).
+
+Covers: AC-5.4 permanent signals, AC-5.10 divergence steering,
+AC-5.8 dormant fix + closure, AC-5.1 consequence surfacing.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from tta.choices.consequence_service import InMemoryConsequenceService
+from tta.models.choice import (
+    ChoiceClassification,
+    ChoiceType,
+    ImpactLevel,
+    Reversibility,
+)
+from tta.models.consequence import (
+    ConsequenceChain,
+    ConsequenceEntry,
+    ConsequenceStatus,
+    ConsequenceTimescale,
+    ConsequenceVisibility,
+)
+from tta.models.turn import ParsedIntent, TurnState
+from tta.pipeline.stages.context import context_stage
+from tta.pipeline.stages.generate import _build_generation_prompt
+from tta.pipeline.stages.understand import _prune_consequence_chains
+from tta.pipeline.types import PipelineDeps
+
+SID = uuid4()
+_CHAIN_ID = uuid4()
+
+
+def _entry(
+    trigger: str = "trigger",
+    effect: str = "effect",
+    **kw: object,
+) -> ConsequenceEntry:
+    """Create a ConsequenceEntry with required fields filled in."""
+    defaults: dict = {
+        "chain_id": _CHAIN_ID,
+        "trigger": trigger,
+        "effect": effect,
+        "timescale": ConsequenceTimescale.SHORT_TERM,
+        "visibility": ConsequenceVisibility.VISIBLE,
+    }
+    defaults.update(kw)
+    return ConsequenceEntry(**defaults)
+
+
+def _make_state(**overrides: object) -> TurnState:
+    defaults: dict = {
+        "session_id": SID,
+        "turn_number": 5,
+        "player_input": "look around",
+        "game_state": {"location": "tavern", "hp": 100},
+        "parsed_intent": ParsedIntent(intent="examine", confidence=0.9),
+    }
+    defaults.update(overrides)
+    return TurnState(**defaults)
+
+
+def _make_deps(
+    *, consequence_service: InMemoryConsequenceService | None = None
+) -> PipelineDeps:
+    world = AsyncMock()
+    world.get_player_location.side_effect = ValueError("no data")
+    world.get_recent_events.return_value = []
+    return PipelineDeps(
+        llm=AsyncMock(),
+        world=world,
+        session_repo=AsyncMock(),
+        turn_repo=AsyncMock(),
+        safety_pre_input=AsyncMock(),
+        safety_pre_gen=AsyncMock(),
+        safety_post_gen=AsyncMock(),
+        consequence_service=consequence_service,
+    )
+
+
+# --- AC-5.4: Permanent Choice Signals ---
+
+
+class TestPermanentChoiceSignals:
+    def test_permanent_signal_injected(self) -> None:
+        cc = ChoiceClassification(
+            types=[ChoiceType.ACTION],
+            primary_type=ChoiceType.ACTION,
+            reversibility=Reversibility.PERMANENT,
+        )
+        state = _make_state(choice_classification=cc)
+        prompt = _build_generation_prompt(state)
+        assert "PERMANENT" in prompt
+        assert "irreversible" in prompt.lower()
+        assert "charged atmosphere" in prompt.lower()
+
+    def test_non_permanent_omits_signal(self) -> None:
+        cc = ChoiceClassification(
+            types=[ChoiceType.ACTION],
+            primary_type=ChoiceType.ACTION,
+            reversibility=Reversibility.MODERATE,
+        )
+        state = _make_state(choice_classification=cc)
+        prompt = _build_generation_prompt(state)
+        assert "PERMANENT" not in prompt
+
+    def test_missing_classification_safe(self) -> None:
+        state = _make_state(choice_classification=None)
+        prompt = _build_generation_prompt(state)
+        assert "PERMANENT" not in prompt
+        assert "Generate a narrative response" in prompt
+
+
+# --- AC-5.10: Divergence Steering ---
+
+
+class TestDivergenceSteering:
+    @pytest.mark.asyncio
+    async def test_divergence_guidance_injected_when_high(self) -> None:
+        svc = InMemoryConsequenceService()
+        # Create enough high-impact chains to trigger divergence >= 0.7
+        for i in range(25):
+            await svc.create_chain(
+                session_id=SID,
+                root_trigger=f"trigger-{i}",
+                impact_level=ImpactLevel.DEFINING,
+                entries=[_entry(trigger=f"t-{i}", effect=f"e-{i}")],
+            )
+        await svc.add_anchor(
+            session_id=SID,
+            description="reach the mountain temple",
+            target_turn=10,
+        )
+        state = _make_state(turn_number=5)
+        deps = _make_deps(consequence_service=svc)
+        result = await context_stage(state, deps)
+        assert result.divergence_guidance is not None
+        assert "diverging" in result.divergence_guidance.lower()
+        assert "mountain temple" in result.divergence_guidance.lower()
+
+    @pytest.mark.asyncio
+    async def test_divergence_omitted_when_low(self) -> None:
+        svc = InMemoryConsequenceService()
+        await svc.create_chain(
+            session_id=SID,
+            root_trigger="minor event",
+            impact_level=ImpactLevel.ATMOSPHERIC,
+            entries=[_entry(trigger="small", effect="ripple")],
+        )
+        state = _make_state(turn_number=5)
+        deps = _make_deps(consequence_service=svc)
+        result = await context_stage(state, deps)
+        assert result.divergence_guidance is None
+
+    def test_divergence_guidance_in_prompt(self) -> None:
+        state = _make_state(
+            divergence_guidance="The story is diverging. Steer toward: X"
+        )
+        prompt = _build_generation_prompt(state)
+        assert "diverging" in prompt.lower()
+        assert "Steer toward: X" in prompt
+
+    @pytest.mark.asyncio
+    async def test_no_anchors_still_provides_guidance(self) -> None:
+        svc = InMemoryConsequenceService()
+        for i in range(25):
+            await svc.create_chain(
+                session_id=SID,
+                root_trigger=f"trigger-{i}",
+                impact_level=ImpactLevel.DEFINING,
+                entries=[_entry(trigger=f"t-{i}", effect=f"e-{i}")],
+            )
+        # No anchors set
+        state = _make_state(turn_number=5)
+        deps = _make_deps(consequence_service=svc)
+        result = await context_stage(state, deps)
+        if result.divergence_guidance:
+            assert "reconnect" in result.divergence_guidance.lower()
+
+
+# --- AC-5.8: Dormant Fix + Closure ---
+
+
+class TestDormantFixAndClosure:
+    @pytest.mark.asyncio
+    async def test_last_active_turn_only_on_activation(self) -> None:
+        """Bug fix: last_active_turn should only update when chain activates."""
+        svc = InMemoryConsequenceService()
+        chain = await svc.create_chain(
+            session_id=SID,
+            root_trigger="old event",
+            impact_level=ImpactLevel.CONSEQUENTIAL,
+            entries=[
+                _entry(
+                    trigger="delayed effect",
+                    effect="long term consequence",
+                    timescale=ConsequenceTimescale.LONG_TERM,
+                )
+            ],
+        )
+        original_turn = chain.last_active_turn
+        # Evaluate — entry won't activate from unrelated action
+        await svc.evaluate(SID, original_turn + 5, "walk around")
+        chains = await svc.get_active_chains(SID)
+        assert len(chains) == 1
+        # last_active_turn should NOT have changed
+        assert chains[0].last_active_turn == original_turn
+
+    @pytest.mark.asyncio
+    async def test_prune_returns_closures(self) -> None:
+        svc = InMemoryConsequenceService()
+        chain = await svc.create_chain(
+            session_id=SID,
+            root_trigger="forgotten promise",
+            impact_level=ImpactLevel.ATMOSPHERIC,
+            entries=[_entry(trigger="promise made", effect="waiting")],
+        )
+        # Simulate chain being inactive for 50+ turns
+        chain.last_active_turn = 0
+        pruned_ids, closures = await svc.prune_chains(SID, 60)
+        assert "forgotten promise" in closures
+
+    @pytest.mark.asyncio
+    async def test_pruning_wired_in_understand(self) -> None:
+        svc = InMemoryConsequenceService()
+        chain = await svc.create_chain(
+            session_id=SID,
+            root_trigger="ancient vow",
+            impact_level=ImpactLevel.ATMOSPHERIC,
+            entries=[_entry(trigger="vow spoken", effect="binding")],
+        )
+        chain.last_active_turn = 0
+        state = _make_state(turn_number=60)
+        deps = _make_deps(consequence_service=svc)
+        result = await _prune_consequence_chains(state, deps)
+        assert result.pruned_chain_closures is not None
+        assert "ancient vow" in result.pruned_chain_closures
+
+    def test_closure_hints_in_prompt(self) -> None:
+        state = _make_state(
+            pruned_chain_closures=["the broken oath", "the lost artifact"]
+        )
+        prompt = _build_generation_prompt(state)
+        assert "broken oath" in prompt
+        assert "Fading story threads" in prompt
+
+    @pytest.mark.asyncio
+    async def test_no_pruning_safe(self) -> None:
+        svc = InMemoryConsequenceService()
+        state = _make_state(turn_number=5)
+        deps = _make_deps(consequence_service=svc)
+        result = await _prune_consequence_chains(state, deps)
+        assert result.pruned_chain_closures is None
+
+
+# --- AC-5.1: Consequence Narrative Surfacing ---
+
+
+class TestConsequenceSurfacing:
+    def test_consequence_details_in_prompt(self) -> None:
+        chains = [
+            ConsequenceChain(
+                session_id=SID,
+                root_trigger="betrayed the merchant",
+                impact_level=ImpactLevel.PIVOTAL,
+                entries=[],
+            ),
+            ConsequenceChain(
+                session_id=SID,
+                root_trigger="saved the child",
+                impact_level=ImpactLevel.CONSEQUENTIAL,
+                entries=[],
+            ),
+        ]
+        state = _make_state(active_consequences=chains)
+        prompt = _build_generation_prompt(state)
+        assert "betrayed the merchant" in prompt
+        assert "saved the child" in prompt
+        assert "Consequences manifesting" in prompt
+
+    def test_empty_consequences_no_section(self) -> None:
+        state = _make_state(active_consequences=None)
+        prompt = _build_generation_prompt(state)
+        assert "Consequences manifesting" not in prompt
+
+    def test_resolved_chains_excluded(self) -> None:
+        chains = [
+            ConsequenceChain(
+                session_id=SID,
+                root_trigger="resolved event",
+                impact_level=ImpactLevel.ATMOSPHERIC,
+                entries=[
+                    _entry(
+                        trigger="old trigger",
+                        effect="old effect",
+                        status=ConsequenceStatus.RESOLVED,
+                    )
+                ],
+            ),
+        ]
+        state = _make_state(active_consequences=chains)
+        prompt = _build_generation_prompt(state)
+        assert "Consequences manifesting" not in prompt


### PR DESCRIPTION
## Summary
Wave 25: S05 Choice & Consequence remediation (~40% → ~65-70%)

Closes #111

## Changes
- **AC-5.1**: Active consequence narrative surfacing in generation prompt
- **AC-5.4**: Permanent choice external signals (atmosphere, NPC reactions, stakes) — never narrates player thoughts
- **AC-5.8**: Fix dormant detection bug (`last_active_turn` updated every scan, chains never dormant); wire `prune_chains()` into understand_stage; return closure descriptions for narrative hints
- **AC-5.10**: Wire `calculate_divergence()` into context_stage; store prompt-ready `divergence_guidance` on TurnState
- **Performance benchmarks**: evaluate <300ms for 30 chains, divergence <100ms, prune <100ms

## Production Files
| File | Change |
|---|---|
| `consequence_service.py` | Bug fix for `last_active_turn`, `prune_chains()` returns `tuple[list[UUID], list[str]]` |
| `generate.py` | Consequence surfacing, permanent signals, divergence guidance, closure hints |
| `context.py` | Divergence calculation after active chain retrieval |
| `understand.py` | Chain pruning as pipeline step 6 |
| `turn.py` | Add `divergence_guidance` and `pruned_chain_closures` fields |

## Tests
- 18 new tests (15 functional + 3 perf benchmarks) in 2 new files
- 2 existing tests fixed for `prune_chains` return type change
- **1632 unit tests pass**, 0 pyright errors, ruff clean

## Spec Compliance Impact
S05 ACs improved: AC-5.1 (PARTIAL→IMPLEMENTED), AC-5.4 (MISSING→IMPLEMENTED), AC-5.8 (PARTIAL→IMPLEMENTED), AC-5.10 (PARTIAL→IMPLEMENTED)