### PR TITLE
feat(auth): S11 Anonymous Auth & Session Lifecycle

### DIFF
--- a/migrations/postgres/versions/009_auth_sessions_and_jwt.py
+++ b/migrations/postgres/versions/009_auth_sessions_and_jwt.py
@@ -1,0 +1,152 @@
+"""Add JWT auth infrastructure (S11 Player Identity & Sessions).
+
+Adds auth columns to players table, creates auth_sessions (session families)
+and refresh_tokens tables for JWT-based authentication.
+
+Revision ID: 009
+Revises: 008
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "009"
+down_revision = "008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # New columns on players table
+    op.add_column(
+        "players",
+        sa.Column("email", sa.String(320), nullable=True),
+    )
+    op.add_column(
+        "players",
+        sa.Column("password_hash", sa.String(128), nullable=True),
+    )
+    op.add_column(
+        "players",
+        sa.Column(
+            "is_anonymous",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+    op.add_column(
+        "players",
+        sa.Column(
+            "display_name",
+            sa.String(50),
+            nullable=False,
+            server_default=sa.text("'Adventurer'"),
+        ),
+    )
+    op.add_column(
+        "players",
+        sa.Column(
+            "role",
+            sa.String(20),
+            nullable=False,
+            server_default=sa.text("'player'"),
+        ),
+    )
+    op.add_column(
+        "players",
+        sa.Column("last_login_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_players_email",
+        "players",
+        ["email"],
+        unique=True,
+        postgresql_where=sa.text("email IS NOT NULL"),
+    )
+
+    # Auth sessions (session families for token rotation)
+    op.create_table(
+        "auth_sessions",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("player_id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "is_anonymous",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(["player_id"], ["players.id"], ondelete="CASCADE"),
+    )
+    op.create_index(
+        "ix_auth_sessions_player_id",
+        "auth_sessions",
+        ["player_id"],
+    )
+
+    # Refresh tokens tied to session families
+    op.create_table(
+        "refresh_tokens",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("session_id", sa.Uuid(), nullable=False),
+        sa.Column("player_id", sa.Uuid(), nullable=False),
+        sa.Column("token_jti", sa.String(64), nullable=False, unique=True),
+        sa.Column(
+            "used",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["session_id"], ["auth_sessions.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["player_id"], ["players.id"], ondelete="CASCADE"),
+    )
+    op.create_index(
+        "ix_refresh_tokens_token_jti",
+        "refresh_tokens",
+        ["token_jti"],
+    )
+    op.create_index(
+        "ix_refresh_tokens_session_id",
+        "refresh_tokens",
+        ["session_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("refresh_tokens")
+    op.drop_table("auth_sessions")
+    op.drop_index("ix_players_email", table_name="players")
+    op.drop_column("players", "last_login_at")
+    op.drop_column("players", "role")
+    op.drop_column("players", "display_name")
+    op.drop_column("players", "is_anonymous")
+    op.drop_column("players", "password_hash")
+    op.drop_column("players", "email")

--- a/plans/api-and-sessions.md
+++ b/plans/api-and-sessions.md
@@ -10,6 +10,31 @@
 
 ---
 
+## 0. Resolved Conflicts and Normative Decisions
+
+### 0.1 — JWT Auth Replaces Opaque Tokens (S11 vs Plan §2.1)
+
+**Decision**: v1 uses **JWT-based authentication** as specified in S11.
+
+The original plan §2.1 stated "v1 auth is anonymous handles only, no JWT." S11
+specifies JWT access+refresh token pairs with anonymous-first flow. Per SDD rules,
+specs are source of truth — S11 wins.
+
+### 0.2 — Token Lifetimes Follow Spec (FR-11.29)
+
+**Decision**: Access token TTLs follow S11 FR-11.29: **1 hour registered, 24 hours
+anonymous**. Refresh tokens: 30 days registered, 7 days anonymous.
+
+Security best practice recommends shorter access tokens (≤15 min). This is noted as a
+**v2 hardening candidate** — shorter TTLs can be adopted when the refresh flow is
+battle-tested and client retry logic is robust. No spec amendment needed; a future spec
+or plan update can tighten these values.
+
+### 0.3 — UUID vs ULID for Identifiers
+
+S11 references ULID-style identifiers. The codebase uses UUID4 throughout. Keeping
+UUID4 for consistency; ULID migration deferred to a future spec if needed.
+
 ## 1. FastAPI Application Structure
 
 ### 1.1 — Application Factory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     "opentelemetry-api>=1.40.0",
     "opentelemetry-sdk>=1.40.0",
     "opentelemetry-exporter-otlp-proto-grpc>=1.40.0",
+    "pyjwt>=2.9",
+    "bcrypt>=4.2",
 ]
 
 [dependency-groups]

--- a/src/tta/api/app.py
+++ b/src/tta/api/app.py
@@ -301,6 +301,7 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
             session_factory,
             interval_seconds=900,
             idle_timeout_minutes=settings.idle_timeout_minutes,
+            anon_cleanup_days=settings.anon_cleanup_days,
         )
     )
 

--- a/src/tta/api/app.py
+++ b/src/tta/api/app.py
@@ -28,6 +28,7 @@ from tta.api.middleware import (
 )
 from tta.api.prometheus_middleware import PrometheusMiddleware
 from tta.api.routes.admin import router as admin_router
+from tta.api.routes.auth import router as auth_router
 from tta.api.routes.games import router as games_router
 from tta.api.routes.metrics import router as metrics_router
 from tta.api.routes.players import router as players_router
@@ -415,6 +416,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(health_router, prefix="/api/v1")
     app.include_router(players_router, prefix="/api/v1")
     app.include_router(games_router, prefix="/api/v1")
+    app.include_router(auth_router, prefix="/api/v1")
     app.include_router(admin_router, prefix="/admin")
 
     from tta.api.routes.disclaimer import router as disclaimer_router

--- a/src/tta/api/deps.py
+++ b/src/tta/api/deps.py
@@ -1,16 +1,17 @@
-"""FastAPI dependency injection (plan §1.3)."""
+"""FastAPI dependency injection (plan §1.3, S11 JWT auth)."""
 
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from datetime import UTC, datetime
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 import sqlalchemy as sa
 from fastapi import Depends, Request
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tta.api.errors import AppError
+from tta.auth.jwt import TokenError, decode_token, is_token_denied
 from tta.config import CURRENT_CONSENT_VERSION, REQUIRED_CONSENT_CATEGORIES
 from tta.errors import ErrorCategory
 from tta.models.player import Player
@@ -33,11 +34,13 @@ async def get_redis(request: Request) -> Redis:
 async def get_current_player(
     request: Request,
     pg: AsyncSession = Depends(get_pg),
+    redis: Redis = Depends(get_redis),
 ) -> Player:
-    """Validate session token and return the authenticated Player.
+    """Decode JWT access token and return the authenticated Player.
 
     Token lookup: cookie first, then Authorization: Bearer header.
-    Raises 401 if missing/invalid/expired.
+    Validates token signature, expiry, type, and deny-list.
+    Raises 401 if missing/invalid/expired/denied.
     """
     token = _extract_token(request)
     if token is None:
@@ -47,36 +50,40 @@ async def get_current_player(
             "No session token provided.",
         )
 
-    result = await pg.execute(
-        sa.text(
-            "SELECT player_id, token, expires_at, created_at "
-            "FROM player_sessions WHERE token = :token"
-        ),
-        {"token": token},
-    )
-    row = result.one_or_none()
-    if row is None or row.expires_at < datetime.now(UTC):
+    try:
+        claims = decode_token(token, expected_type="access")
+    except TokenError:
         raise AppError(
             ErrorCategory.AUTH_REQUIRED,
             "AUTH_TOKEN_INVALID",
             "Session token is invalid or expired.",
+        ) from None
+
+    jti = claims.get("jti", "")
+    if await is_token_denied(redis, jti):
+        raise AppError(
+            ErrorCategory.AUTH_REQUIRED,
+            "AUTH_TOKEN_INVALID",
+            "Session token has been revoked.",
         )
 
+    player_id = UUID(claims["sub"])
     player_result = await pg.execute(
         sa.text(
             "SELECT id, handle, status, suspended_reason, created_at, "
+            "email, is_anonymous, display_name, role, last_login_at, "
             "consent_version, consent_accepted_at, consent_categories, "
             "age_confirmed_at, consent_ip_hash "
             "FROM players WHERE id = :id"
         ),
-        {"id": row.player_id},
+        {"id": player_id},
     )
     player_row = player_result.one_or_none()
     if player_row is None:
         raise AppError(
             ErrorCategory.AUTH_REQUIRED,
             "AUTH_TOKEN_INVALID",
-            "Session token is invalid or expired.",
+            "Player not found.",
         )
 
     return Player(
@@ -85,6 +92,11 @@ async def get_current_player(
         status=player_row.status,
         suspended_reason=player_row.suspended_reason,
         created_at=player_row.created_at,
+        email=player_row.email,
+        is_anonymous=player_row.is_anonymous,
+        display_name=player_row.display_name,
+        role=player_row.role,
+        last_login_at=player_row.last_login_at,
         consent_version=player_row.consent_version,
         consent_accepted_at=player_row.consent_accepted_at,
         consent_categories=player_row.consent_categories,

--- a/src/tta/api/deps.py
+++ b/src/tta/api/deps.py
@@ -12,7 +12,11 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tta.api.errors import AppError
 from tta.auth.jwt import TokenError, decode_token, is_token_denied
-from tta.config import CURRENT_CONSENT_VERSION, REQUIRED_CONSENT_CATEGORIES
+from tta.config import (
+    CURRENT_CONSENT_VERSION,
+    REQUIRED_CONSENT_CATEGORIES,
+    get_settings,
+)
 from tta.errors import ErrorCategory
 from tta.models.player import Player
 
@@ -158,6 +162,39 @@ async def require_consent(
                 "You must accept the current consent agreement before playing.",
             )
 
+    return player
+
+
+async def require_anonymous_game_limit(
+    player: Player = Depends(require_consent),
+    pg: AsyncSession = Depends(get_pg),
+) -> Player:
+    """Enforce FR-11.56: anonymous players limited to 1 active game.
+
+    Raises 403 if the anonymous player already has an active game.
+    Registered players pass through unchecked.
+    """
+    if not player.is_anonymous:
+        return player
+
+    settings = get_settings()
+    result = await pg.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM game_sessions "
+            "WHERE player_id = :pid "
+            "AND status IN ('created', 'active') "
+            "AND deleted_at IS NULL"
+        ),
+        {"pid": player.id},
+    )
+    count = result.scalar() or 0
+    if count >= settings.anon_max_active_games:
+        raise AppError(
+            ErrorCategory.FORBIDDEN,
+            "ANON_GAME_LIMIT",
+            "Anonymous players are limited to 1 active game. "
+            "Finish or abandon your current game, or upgrade your account.",
+        )
     return player
 
 

--- a/src/tta/api/routes/auth.py
+++ b/src/tta/api/routes/auth.py
@@ -1,0 +1,507 @@
+"""Authentication routes for S11 Player Identity & Sessions.
+
+v1 endpoints: anonymous, refresh, logout, upgrade.
+Register and login are deferred per S11 §14 Out of Scope.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import sqlalchemy as sa
+import structlog
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+from redis.asyncio import Redis
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from tta.api.deps import get_current_player, get_pg, get_redis
+from tta.api.errors import AppError
+from tta.auth.jwt import (
+    TokenError,
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    deny_token,
+    is_token_denied,
+)
+from tta.auth.passwords import hash_password
+from tta.config import get_settings
+from tta.errors import ErrorCategory
+from tta.models.player import Player
+
+log = structlog.get_logger()
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+# FR-11.16: password rules returned in error details
+_PASSWORD_MIN = 8
+_PASSWORD_MAX = 128
+_PASSWORD_RE = re.compile(r"(?=.*[a-zA-Z])(?=.*\d)")
+
+
+# ── Request / Response schemas ──────────────────────────────────
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "Bearer"
+    expires_in: int
+    player_id: str
+    is_anonymous: bool
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
+
+class UpgradeRequest(BaseModel):
+    email: str = Field(
+        ..., min_length=3, max_length=254, pattern=r"^[^@\s]+@[^@\s]+\.[^@\s]+$"
+    )
+    password: str = Field(..., min_length=_PASSWORD_MIN, max_length=_PASSWORD_MAX)
+    display_name: str | None = Field(None, max_length=50)
+
+
+# ── Helpers ─────────────────────────────────────────────────────
+
+
+def _validate_password(password: str) -> None:
+    """Validate password against FR-11.16 rules."""
+    errors: list[str] = []
+    if len(password) < _PASSWORD_MIN:
+        errors.append(f"Password must be at least {_PASSWORD_MIN} characters.")
+    if len(password) > _PASSWORD_MAX:
+        errors.append(f"Password must be at most {_PASSWORD_MAX} characters.")
+    if not _PASSWORD_RE.search(password):
+        errors.append("Password must contain at least one letter and one number.")
+    if errors:
+        raise AppError(
+            ErrorCategory.INPUT_INVALID,
+            "PASSWORD_INVALID",
+            "Password does not meet requirements.",
+            details={"rules": errors},
+        )
+
+
+async def _issue_token_pair(
+    pg: AsyncSession,
+    player_id: UUID,
+    *,
+    is_anonymous: bool,
+    role: str = "player",
+) -> tuple[str, str, int, UUID]:
+    """Create auth session + JWT pair.
+
+    Returns (access, refresh, expires_in, session_id).
+    """
+    settings = get_settings()
+    now = datetime.now(UTC)
+    session_id = uuid4()
+
+    # Session family TTL matches refresh token
+    refresh_ttl = (
+        settings.anon_refresh_token_ttl if is_anonymous else settings.refresh_token_ttl
+    )
+    session_expires = now + timedelta(seconds=refresh_ttl)
+
+    await pg.execute(
+        sa.text(
+            "INSERT INTO auth_sessions "
+            "(id, player_id, is_anonymous, expires_at, last_used_at, created_at) "
+            "VALUES (:id, :pid, :anon, :exp, :now, :now)"
+        ),
+        {
+            "id": session_id,
+            "pid": player_id,
+            "anon": is_anonymous,
+            "exp": session_expires,
+            "now": now,
+        },
+    )
+
+    access = create_access_token(
+        player_id,
+        role=role,
+        is_anonymous=is_anonymous,
+        session_family_id=session_id,
+    )
+
+    refresh, jti = create_refresh_token(
+        player_id,
+        session_family_id=session_id,
+        is_anonymous=is_anonymous,
+    )
+
+    # Persist refresh token for rotation tracking (FR-11.20)
+    await pg.execute(
+        sa.text(
+            "INSERT INTO refresh_tokens "
+            "(id, session_id, player_id, token_jti, used, expires_at, created_at) "
+            "VALUES (:id, :sid, :pid, :jti, false, :exp, :now)"
+        ),
+        {
+            "id": uuid4(),
+            "sid": session_id,
+            "pid": player_id,
+            "jti": jti,
+            "exp": now + timedelta(seconds=refresh_ttl),
+            "now": now,
+        },
+    )
+
+    expires_in = (
+        settings.anon_access_token_ttl if is_anonymous else settings.access_token_ttl
+    )
+    return access, refresh, expires_in, session_id
+
+
+def _set_auth_cookie(response: JSONResponse, access_token: str, ttl: int) -> None:
+    """Set the tta_session cookie with the access token."""
+    settings = get_settings()
+    response.set_cookie(
+        key="tta_session",
+        value=access_token,
+        httponly=True,
+        secure=settings.environment != "development",
+        samesite="lax",
+        path="/",
+        max_age=ttl,
+    )
+
+
+# ── POST /auth/anonymous (FR-11.10-12) ─────────────────────────
+
+
+@router.post("/anonymous", status_code=201)
+async def create_anonymous(
+    pg: AsyncSession = Depends(get_pg),
+) -> JSONResponse:
+    """Create an anonymous player and issue JWT token pair."""
+    player_id = uuid4()
+    now = datetime.now(UTC)
+    handle = f"anon-{player_id.hex[:8]}"
+
+    # FR-11.10: each call creates a new anonymous player
+    await pg.execute(
+        sa.text(
+            "INSERT INTO players (id, handle, is_anonymous, display_name, created_at) "
+            "VALUES (:id, :handle, true, 'Adventurer', :now)"
+        ),
+        {"id": player_id, "handle": handle, "now": now},
+    )
+
+    access, refresh, expires_in, _ = await _issue_token_pair(
+        pg, player_id, is_anonymous=True
+    )
+    await pg.commit()
+
+    body = TokenResponse(
+        access_token=access,
+        refresh_token=refresh,
+        expires_in=expires_in,
+        player_id=str(player_id),
+        is_anonymous=True,
+    )
+    response = JSONResponse(status_code=201, content={"data": body.model_dump()})
+    _set_auth_cookie(response, access, expires_in)
+    log.info("anonymous_player_created", player_id=str(player_id))
+    return response
+
+
+# ── POST /auth/refresh (FR-11.20-22) ───────────────────────────
+
+
+@router.post("/refresh")
+async def refresh_tokens(
+    body: RefreshRequest,
+    pg: AsyncSession = Depends(get_pg),
+    redis: Redis = Depends(get_redis),
+) -> JSONResponse:
+    """Exchange a refresh token for a new token pair (rotation)."""
+    # Decode refresh token
+    try:
+        claims = decode_token(body.refresh_token, expected_type="refresh")
+    except TokenError as exc:
+        raise AppError(
+            ErrorCategory.AUTH_REQUIRED,
+            "REFRESH_TOKEN_INVALID",
+            str(exc),
+        ) from exc
+
+    jti = claims["jti"]
+    player_id = UUID(claims["sub"])
+    session_family_id = UUID(claims["sfid"])
+
+    # Check deny-list
+    if await is_token_denied(redis, jti):
+        raise AppError(
+            ErrorCategory.AUTH_REQUIRED,
+            "REFRESH_TOKEN_INVALID",
+            "Token has been revoked.",
+        )
+
+    # FR-11.20: single-use check
+    row = await pg.execute(
+        sa.text(
+            "SELECT id, used FROM refresh_tokens "
+            "WHERE token_jti = :jti AND session_id = :sid"
+        ),
+        {"jti": jti, "sid": session_family_id},
+    )
+    token_record = row.one_or_none()
+
+    if token_record is None:
+        raise AppError(
+            ErrorCategory.AUTH_REQUIRED,
+            "REFRESH_TOKEN_INVALID",
+            "Refresh token not found.",
+        )
+
+    # FR-11.22: reuse detection — if already used, invalidate entire family
+    if token_record.used:
+        log.warning(
+            "refresh_token_reuse_detected",
+            jti=jti,
+            session_id=str(session_family_id),
+            player_id=str(player_id),
+        )
+        await pg.execute(
+            sa.text(
+                "UPDATE auth_sessions SET revoked_at = :now "
+                "WHERE id = :sid AND revoked_at IS NULL"
+            ),
+            {"now": datetime.now(UTC), "sid": session_family_id},
+        )
+        await pg.commit()
+        raise AppError(
+            ErrorCategory.AUTH_REQUIRED,
+            "SESSION_REVOKED",
+            "Suspicious token reuse detected. All sessions revoked.",
+        )
+
+    # Check session family is still active
+    sess_row = await pg.execute(
+        sa.text("SELECT is_anonymous, revoked_at FROM auth_sessions WHERE id = :sid"),
+        {"sid": session_family_id},
+    )
+    sess = sess_row.one_or_none()
+    if sess is None or sess.revoked_at is not None:
+        raise AppError(
+            ErrorCategory.AUTH_REQUIRED,
+            "SESSION_REVOKED",
+            "Session has been revoked.",
+        )
+
+    # Load player for role
+    player_row = await pg.execute(
+        sa.text("SELECT role, is_anonymous FROM players WHERE id = :id"),
+        {"id": player_id},
+    )
+    player = player_row.one_or_none()
+    if player is None:
+        raise AppError(
+            ErrorCategory.AUTH_REQUIRED,
+            "REFRESH_TOKEN_INVALID",
+            "Player not found.",
+        )
+
+    is_anon = player.is_anonymous
+
+    # FR-11.20: mark old token as used
+    await pg.execute(
+        sa.text("UPDATE refresh_tokens SET used = true WHERE id = :id"),
+        {"id": token_record.id},
+    )
+
+    # Issue new pair (FR-11.21: rotation returns new refresh)
+    access = create_access_token(
+        player_id,
+        role=player.role,
+        is_anonymous=is_anon,
+        session_family_id=session_family_id,
+    )
+    new_refresh, new_jti = create_refresh_token(
+        player_id,
+        session_family_id=session_family_id,
+        is_anonymous=is_anon,
+    )
+
+    settings = get_settings()
+    refresh_ttl = (
+        settings.anon_refresh_token_ttl if is_anon else settings.refresh_token_ttl
+    )
+    now = datetime.now(UTC)
+
+    await pg.execute(
+        sa.text(
+            "INSERT INTO refresh_tokens "
+            "(id, session_id, player_id, token_jti, used, expires_at, created_at) "
+            "VALUES (:id, :sid, :pid, :jti, false, :exp, :now)"
+        ),
+        {
+            "id": uuid4(),
+            "sid": session_family_id,
+            "pid": player_id,
+            "jti": new_jti,
+            "exp": now + timedelta(seconds=refresh_ttl),
+            "now": now,
+        },
+    )
+
+    # Update session last_used_at
+    await pg.execute(
+        sa.text("UPDATE auth_sessions SET last_used_at = :now WHERE id = :sid"),
+        {"now": now, "sid": session_family_id},
+    )
+
+    await pg.commit()
+
+    expires_in = (
+        settings.anon_access_token_ttl if is_anon else settings.access_token_ttl
+    )
+
+    resp_body = TokenResponse(
+        access_token=access,
+        refresh_token=new_refresh,
+        expires_in=expires_in,
+        player_id=str(player_id),
+        is_anonymous=is_anon,
+    )
+    response = JSONResponse(content={"data": resp_body.model_dump()})
+    _set_auth_cookie(response, access, expires_in)
+    return response
+
+
+# ── POST /auth/logout (FR-11.23) ───────────────────────────────
+
+
+@router.post("/logout", status_code=204)
+async def logout(
+    request: Request,
+    pg: AsyncSession = Depends(get_pg),
+    redis: Redis = Depends(get_redis),
+) -> JSONResponse:
+    """Invalidate the current access token and associated session."""
+    # Extract and decode access token
+    token = request.cookies.get("tta_session")
+    auth_header = request.headers.get("Authorization", "")
+    if not token and auth_header.startswith("Bearer "):
+        token = auth_header[7:]
+
+    if not token:
+        raise AppError(
+            ErrorCategory.AUTH_REQUIRED,
+            "AUTH_TOKEN_MISSING",
+            "No token provided.",
+        )
+
+    try:
+        claims = decode_token(token, expected_type="access")
+    except TokenError as exc:
+        raise AppError(
+            ErrorCategory.AUTH_REQUIRED,
+            "AUTH_TOKEN_INVALID",
+            str(exc),
+        ) from exc
+
+    # FR-11.23: deny the access token
+    exp = datetime.fromtimestamp(claims["exp"], tz=UTC)
+    await deny_token(redis, claims["jti"], exp)
+
+    # Revoke the session family if present
+    sfid = claims.get("sfid")
+    if sfid:
+        await pg.execute(
+            sa.text(
+                "UPDATE auth_sessions SET revoked_at = :now "
+                "WHERE id = :sid AND revoked_at IS NULL"
+            ),
+            {"now": datetime.now(UTC), "sid": UUID(sfid)},
+        )
+        await pg.commit()
+
+    response = JSONResponse(status_code=204, content=None)
+    response.delete_cookie(key="tta_session", path="/")
+    log.info("player_logged_out", player_id=claims["sub"])
+    return response
+
+
+# ── POST /auth/upgrade (FR-11.24-28) ───────────────────────────
+
+
+@router.post("/upgrade")
+async def upgrade_anonymous(
+    body: UpgradeRequest,
+    player: Player = Depends(get_current_player),
+    pg: AsyncSession = Depends(get_pg),
+    redis: Redis = Depends(get_redis),
+) -> JSONResponse:
+    """Convert an anonymous player to a registered account."""
+    # Must be anonymous to upgrade
+    if not player.is_anonymous:
+        raise AppError(
+            ErrorCategory.INPUT_INVALID,
+            "ALREADY_REGISTERED",
+            "This account is already registered.",
+        )
+
+    # FR-11.16: validate password
+    _validate_password(body.password)
+
+    # FR-11.28: check email uniqueness
+    existing = await pg.execute(
+        sa.text("SELECT id FROM players WHERE email = :email"),
+        {"email": body.email.lower()},
+    )
+    if existing.one_or_none() is not None:
+        raise AppError(
+            ErrorCategory.CONFLICT,
+            "EMAIL_ALREADY_REGISTERED",
+            "This email is already registered.",
+        )
+
+    now = datetime.now(UTC)
+    display = body.display_name or player.display_name
+
+    # FR-11.14: bcrypt hash, FR-11.15: no raw password in logs/responses
+    pw_hash = hash_password(body.password)
+
+    # FR-11.24: preserve player_id, FR-11.26: set is_anonymous=false
+    await pg.execute(
+        sa.text(
+            "UPDATE players SET "
+            "email = :email, password_hash = :pw, is_anonymous = false, "
+            "display_name = :dn, last_login_at = :now "
+            "WHERE id = :id"
+        ),
+        {
+            "email": body.email.lower(),
+            "pw": pw_hash,
+            "dn": display,
+            "now": now,
+            "id": player.id,
+        },
+    )
+
+    # FR-11.27: issue new token set reflecting upgraded identity
+    access, refresh, expires_in, _ = await _issue_token_pair(
+        pg, player.id, is_anonymous=False, role=player.role
+    )
+    await pg.commit()
+
+    resp_body = TokenResponse(
+        access_token=access,
+        refresh_token=refresh,
+        expires_in=expires_in,
+        player_id=str(player.id),
+        is_anonymous=False,
+    )
+    response = JSONResponse(content={"data": resp_body.model_dump()})
+    _set_auth_cookie(response, access, expires_in)
+    log.info("anonymous_player_upgraded", player_id=str(player.id))
+    return response

--- a/src/tta/api/routes/auth.py
+++ b/src/tta/api/routes/auth.py
@@ -12,7 +12,7 @@ from uuid import UUID, uuid4
 
 import sqlalchemy as sa
 import structlog
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, Response
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 from redis.asyncio import Redis
@@ -312,11 +312,30 @@ async def refresh_tokens(
 
     is_anon = player.is_anonymous
 
-    # FR-11.20: mark old token as used
-    await pg.execute(
-        sa.text("UPDATE refresh_tokens SET used = true WHERE id = :id"),
+    # FR-11.20: atomically mark old token as used (prevents race)
+    mark_result = await pg.execute(
+        sa.text(
+            "UPDATE refresh_tokens SET used = true WHERE id = :id AND used = false"
+        ),
         {"id": token_record.id},
     )
+    if mark_result.rowcount == 0:  # type: ignore[union-attr]
+        # Another concurrent request already consumed this token —
+        # possible replay / theft. Invalidate the whole session family.
+        await pg.execute(
+            sa.text(
+                "UPDATE refresh_tokens SET used = true "
+                "WHERE session_family_id = :sfid AND used = false"
+            ),
+            {"sfid": str(session_family_id)},
+        )
+        await pg.commit()
+        raise AppError(
+            ErrorCategory.AUTH_REQUIRED,
+            "REFRESH_TOKEN_REUSED",
+            "Refresh token already consumed. All tokens in this "
+            "session family have been revoked for security.",
+        )
 
     # Issue new pair (FR-11.21: rotation returns new refresh)
     access = create_access_token(
@@ -385,7 +404,7 @@ async def logout(
     request: Request,
     pg: AsyncSession = Depends(get_pg),
     redis: Redis = Depends(get_redis),
-) -> JSONResponse:
+) -> Response:
     """Invalidate the current access token and associated session."""
     # Extract and decode access token
     token = request.cookies.get("tta_session")
@@ -425,7 +444,7 @@ async def logout(
         )
         await pg.commit()
 
-    response = JSONResponse(status_code=204, content=None)
+    response = Response(status_code=204)
     response.delete_cookie(key="tta_session", path="/")
     log.info("player_logged_out", player_id=claims["sub"])
     return response

--- a/src/tta/api/routes/games.py
+++ b/src/tta/api/routes/games.py
@@ -21,6 +21,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from tta.api.deps import (
     get_current_player,
     get_pg,
+    require_anonymous_game_limit,
     require_consent,
 )
 from tta.api.errors import AppError
@@ -917,7 +918,7 @@ async def _get_max_turn_number(pg: AsyncSession, game_id: UUID) -> int:
 # --- Routes ---
 
 
-@router.post("", status_code=201, dependencies=[Depends(require_consent)])
+@router.post("", status_code=201, dependencies=[Depends(require_anonymous_game_limit)])
 async def create_game(
     body: CreateGameRequest,
     request: Request,

--- a/src/tta/api/routes/players.py
+++ b/src/tta/api/routes/players.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-import secrets
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from uuid import uuid4
 
 import sqlalchemy as sa
@@ -18,6 +17,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tta.api.deps import get_current_player, get_pg, get_redis
 from tta.api.errors import AppError
+from tta.auth.jwt import create_access_token
 from tta.config import (
     CURRENT_CONSENT_VERSION,
     REQUIRED_CONSENT_CATEGORIES,
@@ -175,22 +175,12 @@ async def register_player(
         },
     )
 
-    # Create session token
+    # Issue JWT access token (S11 migration: replaced opaque token)
     settings = get_settings()
-    token = secrets.token_hex(32)
-    expires_at = now + timedelta(seconds=settings.session_token_ttl)
-    await pg.execute(
-        sa.text(
-            "INSERT INTO player_sessions "
-            "(player_id, token, expires_at, created_at) "
-            "VALUES (:player_id, :token, :expires_at, :created_at)"
-        ),
-        {
-            "player_id": player_id,
-            "token": token,
-            "expires_at": expires_at,
-            "created_at": now,
-        },
+    token = create_access_token(
+        player_id=player_id,
+        role="player",
+        is_anonymous=True,
     )
 
     await pg.commit()
@@ -213,7 +203,7 @@ async def register_player(
         secure=settings.environment != "development",
         samesite="lax",
         path="/",
-        max_age=settings.session_token_ttl,
+        max_age=settings.anon_access_token_ttl,
     )
     return response
 

--- a/src/tta/auth/__init__.py
+++ b/src/tta/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Authentication infrastructure for TTA (S11)."""

--- a/src/tta/auth/jwt.py
+++ b/src/tta/auth/jwt.py
@@ -1,0 +1,154 @@
+"""JWT token creation, validation, and deny-list (S11 FR-11.14-19).
+
+Tokens include a ``typ`` claim ("access" or "refresh") to prevent
+confusion attacks where a refresh token is used as an access token.
+"""
+
+from __future__ import annotations
+
+import secrets
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import jwt
+import structlog
+from redis.asyncio import Redis
+
+from tta.config import Environment, get_settings
+
+log = structlog.get_logger()
+
+_DENY_PREFIX = "tta:deny:"
+
+
+class TokenError(Exception):
+    """Raised when a token is invalid, expired, or denied."""
+
+
+# ── Token creation ──────────────────────────────────────────────
+
+
+def create_access_token(
+    player_id: UUID,
+    *,
+    role: str = "player",
+    is_anonymous: bool = True,
+    session_family_id: UUID | None = None,
+) -> str:
+    """Create a signed JWT access token (typ=access)."""
+    settings = get_settings()
+    now = datetime.now(UTC)
+    ttl = settings.anon_access_token_ttl if is_anonymous else settings.access_token_ttl
+    claims = {
+        "sub": str(player_id),
+        "role": role,
+        "anon": is_anonymous,
+        "typ": "access",
+        "iat": now,
+        "exp": now + timedelta(seconds=ttl),
+        "jti": secrets.token_hex(16),
+    }
+    if session_family_id:
+        claims["sfid"] = str(session_family_id)
+    return jwt.encode(claims, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+
+
+def create_refresh_token(
+    player_id: UUID,
+    *,
+    session_family_id: UUID,
+    is_anonymous: bool = True,
+) -> tuple[str, str]:
+    """Create a signed JWT refresh token (typ=refresh).
+
+    Returns (encoded_token, jti) so the caller can persist the jti.
+    """
+    settings = get_settings()
+    now = datetime.now(UTC)
+    ttl = (
+        settings.anon_refresh_token_ttl if is_anonymous else settings.refresh_token_ttl
+    )
+    jti = secrets.token_hex(16)
+    claims = {
+        "sub": str(player_id),
+        "typ": "refresh",
+        "jti": jti,
+        "sfid": str(session_family_id),
+        "iat": now,
+        "exp": now + timedelta(seconds=ttl),
+    }
+    token = jwt.encode(claims, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+    return token, jti
+
+
+# ── Token validation ────────────────────────────────────────────
+
+
+def decode_token(
+    token: str,
+    *,
+    expected_type: str = "access",
+) -> dict:
+    """Decode and validate a JWT token.
+
+    Raises ``TokenError`` on invalid/expired/wrong-type tokens.
+    """
+    settings = get_settings()
+    try:
+        claims = jwt.decode(
+            token,
+            settings.jwt_secret,
+            algorithms=[settings.jwt_algorithm],
+            options={"require": ["sub", "typ", "exp", "iat", "jti"]},
+        )
+    except jwt.ExpiredSignatureError as exc:
+        raise TokenError("Token has expired") from exc
+    except jwt.InvalidTokenError as exc:
+        raise TokenError(f"Invalid token: {exc}") from exc
+
+    if claims.get("typ") != expected_type:
+        raise TokenError(
+            f"Expected token type '{expected_type}', got '{claims.get('typ')}'"
+        )
+
+    return claims
+
+
+# ── Deny-list (Redis-backed) ───────────────────────────────────
+
+
+async def deny_token(
+    redis: Redis | None,
+    jti: str,
+    expires_at: datetime,
+) -> None:
+    """Add a token JTI to the deny-list with auto-expiry."""
+    remaining = int((expires_at - datetime.now(UTC)).total_seconds())
+    if remaining <= 0:
+        return  # already expired, no need to deny
+
+    settings = get_settings()
+    if redis is None:
+        if settings.environment == Environment.PRODUCTION:
+            raise RuntimeError("Redis is required for auth deny-list in production")
+        log.warning("deny_token_no_redis", jti=jti)
+        return
+
+    key = f"{_DENY_PREFIX}{jti}"
+    await redis.setex(key, remaining, "1")
+    log.info("token_denied", jti=jti, ttl=remaining)
+
+
+async def is_token_denied(
+    redis: Redis | None,
+    jti: str,
+) -> bool:
+    """Check whether a token JTI is on the deny-list."""
+    settings = get_settings()
+    if redis is None:
+        if settings.environment == Environment.PRODUCTION:
+            raise RuntimeError("Redis is required for auth deny-list in production")
+        return False
+
+    key = f"{_DENY_PREFIX}{jti}"
+    return bool(await redis.exists(key))

--- a/src/tta/auth/jwt.py
+++ b/src/tta/auth/jwt.py
@@ -134,9 +134,16 @@ async def deny_token(
         log.warning("deny_token_no_redis", jti=jti)
         return
 
-    key = f"{_DENY_PREFIX}{jti}"
-    await redis.setex(key, remaining, "1")
-    log.info("token_denied", jti=jti, ttl=remaining)
+    try:
+        key = f"{_DENY_PREFIX}{jti}"
+        await redis.setex(key, remaining, "1")
+        log.info("token_denied", jti=jti, ttl=remaining)
+    except (ConnectionError, TimeoutError, OSError) as exc:
+        if settings.environment == Environment.PRODUCTION:
+            raise RuntimeError(
+                "Redis connection failed for deny-list in production"
+            ) from exc
+        log.warning("deny_token_redis_error", jti=jti, error=str(exc))
 
 
 async def is_token_denied(
@@ -150,5 +157,13 @@ async def is_token_denied(
             raise RuntimeError("Redis is required for auth deny-list in production")
         return False
 
-    key = f"{_DENY_PREFIX}{jti}"
-    return bool(await redis.exists(key))
+    try:
+        key = f"{_DENY_PREFIX}{jti}"
+        return bool(await redis.exists(key))
+    except (ConnectionError, TimeoutError, OSError) as exc:
+        if settings.environment == Environment.PRODUCTION:
+            raise RuntimeError(
+                "Redis connection failed for deny-list in production"
+            ) from exc
+        log.warning("is_token_denied_redis_error", jti=jti, error=str(exc))
+        return False

--- a/src/tta/auth/passwords.py
+++ b/src/tta/auth/passwords.py
@@ -19,5 +19,11 @@ def hash_password(plain: str) -> str:
 
 
 def verify_password(plain: str, hashed: str) -> bool:
-    """Verify a plaintext password against a bcrypt hash."""
-    return bcrypt.checkpw(plain.encode(), hashed.encode())
+    """Verify a plaintext password against a bcrypt hash.
+
+    Returns False for malformed hashes instead of raising.
+    """
+    try:
+        return bcrypt.checkpw(plain.encode(), hashed.encode())
+    except (ValueError, TypeError, RuntimeError):
+        return False

--- a/src/tta/auth/passwords.py
+++ b/src/tta/auth/passwords.py
@@ -1,0 +1,23 @@
+"""Password hashing and verification using bcrypt (S11 FR-11.24-28).
+
+Used for the anonymous→registered upgrade flow where players
+set an email and password to preserve their game history.
+"""
+
+from __future__ import annotations
+
+import bcrypt
+
+from tta.config import get_settings
+
+
+def hash_password(plain: str) -> str:
+    """Hash a plaintext password with bcrypt."""
+    settings = get_settings()
+    salt = bcrypt.gensalt(rounds=settings.bcrypt_cost)
+    return bcrypt.hashpw(plain.encode(), salt).decode()
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    """Verify a plaintext password against a bcrypt hash."""
+    return bcrypt.checkpw(plain.encode(), hashed.encode())

--- a/src/tta/config.py
+++ b/src/tta/config.py
@@ -202,7 +202,7 @@ class Settings(BaseSettings):
         return v
 
     # JWT / Auth (S11, FR-11.29 lifetimes)
-    jwt_secret: str = "CHANGE-ME-IN-PRODUCTION"
+    jwt_secret: str = "CHANGE-ME-IN-PRODUCTION-minimum-32-bytes"
     jwt_algorithm: str = "HS256"
     access_token_ttl: int = 3_600  # 1 h registered (FR-11.29)
     anon_access_token_ttl: int = 86_400  # 24 h anonymous (FR-11.29)

--- a/src/tta/config.py
+++ b/src/tta/config.py
@@ -201,8 +201,19 @@ class Settings(BaseSettings):
             raise ValueError(msg)
         return v
 
+    # JWT / Auth (S11, FR-11.29 lifetimes)
+    jwt_secret: str = "CHANGE-ME-IN-PRODUCTION"
+    jwt_algorithm: str = "HS256"
+    access_token_ttl: int = 3_600  # 1 h registered (FR-11.29)
+    anon_access_token_ttl: int = 86_400  # 24 h anonymous (FR-11.29)
+    refresh_token_ttl: int = 2_592_000  # 30 d registered (FR-11.29)
+    anon_refresh_token_ttl: int = 604_800  # 7 d anonymous (FR-11.29)
+    bcrypt_cost: int = 12
+    anon_max_active_games: int = 1
+    anon_cleanup_days: int = 30
+
     # Application
-    session_token_ttl: int = 86400
+    session_token_ttl: int = 86400  # legacy, kept for compat
     max_active_games: int = 5
     game_listing_default_size: int = 10
     game_listing_max_size: int = 50

--- a/src/tta/config.py
+++ b/src/tta/config.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 from functools import lru_cache
 from typing import Any
 
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, EnvSettingsSource, SettingsConfigDict
 
 # S17 FR-17.22 — consent version & required categories
@@ -211,6 +211,19 @@ class Settings(BaseSettings):
     bcrypt_cost: int = 12
     anon_max_active_games: int = 1
     anon_cleanup_days: int = 30
+
+    @model_validator(mode="after")
+    def _reject_default_jwt_secret_in_prod(self) -> Settings:
+        if (
+            self.environment == Environment.PRODUCTION
+            and self.jwt_secret == "CHANGE-ME-IN-PRODUCTION-minimum-32-bytes"
+        ):
+            msg = (
+                "jwt_secret must be changed from the default "
+                "before running in production"
+            )
+            raise ValueError(msg)
+        return self
 
     # Application
     session_token_ttl: int = 86400  # legacy, kept for compat

--- a/src/tta/lifecycle/cleanup.py
+++ b/src/tta/lifecycle/cleanup.py
@@ -4,6 +4,8 @@ Transitions enforced:
   - ``created``/``active``  + 0 turns + age > 24 h  →  ``abandoned``
   - ``paused``  + last_played > 30 days  →  ``expired``
   - ``active``  + turn_count > 0 + idle > 30 min  →  ``paused``  (AC-1.7)
+  - Anonymous players with no active games + 30 d old  →  soft-deleted
+    (FR-11.12, FR-11.59)
 
 Usage:
   - Background: started automatically by the FastAPI lifespan.
@@ -25,6 +27,7 @@ log = structlog.get_logger()
 ABANDON_HOURS = 24
 EXPIRE_DAYS = 30
 IDLE_TIMEOUT_MINUTES = 30
+ANON_CLEANUP_DAYS = 30
 
 
 async def run_lifecycle_pass(
@@ -33,6 +36,7 @@ async def run_lifecycle_pass(
     abandon_hours: int = ABANDON_HOURS,
     expire_days: int = EXPIRE_DAYS,
     idle_timeout_minutes: int = IDLE_TIMEOUT_MINUTES,
+    anon_cleanup_days: int = ANON_CLEANUP_DAYS,
 ) -> dict[str, int]:
     """Execute a single lifecycle-transition pass.
 
@@ -42,6 +46,7 @@ async def run_lifecycle_pass(
     abandon_cutoff = now - timedelta(hours=abandon_hours)
     expire_cutoff = now - timedelta(days=expire_days)
     idle_cutoff = now - timedelta(minutes=idle_timeout_minutes)
+    anon_cutoff = now - timedelta(days=anon_cleanup_days)
 
     async with session_factory() as pg:
         # Rule 1: created/active + 0 turns + older than 24 h → abandoned
@@ -72,8 +77,6 @@ async def run_lifecycle_pass(
         expired = expire_result.rowcount or 0
 
         # Rule 3 (AC-1.7): active + turn_count > 0 + idle > 30 min → paused
-        # Guard: turn_count > 0 prevents newly-created games from being
-        # paused before the player takes their first action.
         idle_result = await pg.execute(
             sa.text(
                 "UPDATE game_sessions "
@@ -87,7 +90,27 @@ async def run_lifecycle_pass(
         )
         idle_paused = idle_result.rowcount or 0
 
-        if abandoned or expired or idle_paused:
+        # Rule 4 (FR-11.12, FR-11.59): anonymous players with no active
+        # games and older than 30 days → soft-delete
+        anon_result = await pg.execute(
+            sa.text(
+                "UPDATE players "
+                "SET status = 'deleted', updated_at = :now "
+                "WHERE is_anonymous = true "
+                "AND status != 'deleted' "
+                "AND created_at < :cutoff "
+                "AND NOT EXISTS ("
+                "  SELECT 1 FROM game_sessions gs "
+                "  WHERE gs.player_id = players.id "
+                "  AND gs.status IN ('created', 'active', 'paused') "
+                "  AND gs.deleted_at IS NULL"
+                ")"
+            ),
+            {"now": now, "cutoff": anon_cutoff},
+        )
+        anon_cleaned = anon_result.rowcount or 0
+
+        if abandoned or expired or idle_paused or anon_cleaned:
             await pg.commit()
 
         log.info(
@@ -95,11 +118,13 @@ async def run_lifecycle_pass(
             abandoned=abandoned,
             expired=expired,
             idle_paused=idle_paused,
+            anon_cleaned=anon_cleaned,
         )
         return {
             "abandoned": abandoned,
             "expired": expired,
             "idle_paused": idle_paused,
+            "anon_cleaned": anon_cleaned,
         }
 
 

--- a/src/tta/lifecycle/cleanup.py
+++ b/src/tta/lifecycle/cleanup.py
@@ -133,18 +133,21 @@ async def lifecycle_loop(
     *,
     interval_seconds: int = 900,
     idle_timeout_minutes: int = IDLE_TIMEOUT_MINUTES,
+    anon_cleanup_days: int = ANON_CLEANUP_DAYS,
 ) -> None:
     """Run lifecycle passes on a timer until cancelled."""
     log.info(
         "lifecycle_loop_started",
         interval_seconds=interval_seconds,
         idle_timeout_minutes=idle_timeout_minutes,
+        anon_cleanup_days=anon_cleanup_days,
     )
     while True:
         try:
             await run_lifecycle_pass(
                 session_factory,
                 idle_timeout_minutes=idle_timeout_minutes,
+                anon_cleanup_days=anon_cleanup_days,
             )
         except asyncio.CancelledError:
             raise

--- a/src/tta/models/player.py
+++ b/src/tta/models/player.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 
 
 class Player(BaseModel):
-    """Registered player identity."""
+    """Player identity — anonymous or registered."""
 
     id: UUID = Field(default_factory=uuid4)
     handle: str
@@ -15,6 +15,14 @@ class Player(BaseModel):
     suspended_reason: str | None = None
     deletion_requested_at: datetime | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    # S11 auth fields
+    email: str | None = None
+    password_hash: str | None = None
+    is_anonymous: bool = True
+    display_name: str = "Adventurer"
+    role: str = "player"
+    last_login_at: datetime | None = None
 
     # Consent & age gate (S17 FR-17.22–17.26, FR-17.36–17.39)
     consent_version: str | None = None
@@ -25,10 +33,34 @@ class Player(BaseModel):
 
 
 class PlayerSession(BaseModel):
-    """Authenticated player session / token record."""
+    """Legacy opaque token session — deprecated, use JWT auth."""
 
     id: UUID = Field(default_factory=uuid4)
     player_id: UUID
     token: str
     expires_at: datetime
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class AuthSession(BaseModel):
+    """JWT session family for token rotation (S11 FR-11.20-22)."""
+
+    id: UUID = Field(default_factory=uuid4)
+    player_id: UUID
+    is_anonymous: bool = True
+    revoked_at: datetime | None = None
+    expires_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    last_used_at: datetime | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class RefreshToken(BaseModel):
+    """Refresh token record tied to an auth session family."""
+
+    id: UUID = Field(default_factory=uuid4)
+    session_id: UUID
+    player_id: UUID
+    token_jti: str
+    used: bool = False
+    expires_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/tests/unit/api/test_auth_routes.py
+++ b/tests/unit/api/test_auth_routes.py
@@ -1,0 +1,428 @@
+"""Tests for auth routes (S11 Anonymous Auth & Session Lifecycle)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tta.api.app import create_app
+from tta.api.deps import get_current_player, get_pg, get_redis
+from tta.config import Settings
+from tta.models.player import Player
+
+_NOW = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+_PID = uuid4()
+_SFID = uuid4()
+_SECRET = "test-secret-key-minimum-32-bytes-long!!"
+
+_ANON_PLAYER = Player(
+    id=_PID,
+    handle=f"anon-{_PID.hex[:8]}",
+    created_at=_NOW,
+    is_anonymous=True,
+    display_name="Adventurer",
+    role="player",
+)
+
+_REG_PLAYER = Player(
+    id=_PID,
+    handle="registered-user",
+    created_at=_NOW,
+    is_anonymous=False,
+    display_name="Zara",
+    role="player",
+    email="zara@example.com",
+)
+
+
+def _settings() -> Settings:
+    return Settings(
+        database_url="postgresql://test@localhost/test",
+        neo4j_password="test",
+        jwt_secret=_SECRET,
+    )
+
+
+def _make_result(
+    rows: list[dict[str, Any]] | None = None,
+    *,
+    scalar: Any = None,
+) -> MagicMock:
+    result = MagicMock()
+    if rows is not None:
+        objs = [SimpleNamespace(**r) for r in rows]
+        result.one_or_none.return_value = objs[0] if objs else None
+        result.one.return_value = objs[0] if objs else None
+        result.all.return_value = objs
+    else:
+        result.one_or_none.return_value = None
+        result.one.return_value = None
+        result.all.return_value = []
+    if scalar is not None:
+        result.scalar_one.return_value = scalar
+    return result
+
+
+@pytest.fixture()
+def pg() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture()
+def redis() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture()
+def app(pg: AsyncMock, redis: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    settings = _settings()
+    monkeypatch.setattr("tta.api.routes.auth.get_settings", lambda: settings)
+    monkeypatch.setattr("tta.auth.jwt.get_settings", lambda: settings)
+    a = create_app(settings=settings)
+
+    async def _pg():
+        yield pg
+
+    a.dependency_overrides[get_pg] = _pg
+    a.dependency_overrides[get_redis] = lambda: redis
+    return a
+
+
+@pytest.fixture()
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+# ── POST /auth/anonymous ───────────────────────────────────────
+
+
+class TestCreateAnonymous:
+    def test_creates_anon_player_and_returns_tokens(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        pg.execute = AsyncMock(return_value=_make_result())
+        pg.commit = AsyncMock()
+
+        resp = client.post("/api/v1/auth/anonymous")
+        assert resp.status_code == 201
+
+        data = resp.json()["data"]
+        assert data["is_anonymous"] is True
+        assert data["token_type"] == "Bearer"
+        assert "access_token" in data
+        assert "refresh_token" in data
+        assert "player_id" in data
+        assert data["expires_in"] > 0
+
+    def test_sets_auth_cookie(self, client: TestClient, pg: AsyncMock) -> None:
+        pg.execute = AsyncMock(return_value=_make_result())
+        pg.commit = AsyncMock()
+
+        resp = client.post("/api/v1/auth/anonymous")
+        assert "tta_session" in resp.cookies
+
+    def test_commits_to_database(self, client: TestClient, pg: AsyncMock) -> None:
+        pg.execute = AsyncMock(return_value=_make_result())
+        pg.commit = AsyncMock()
+
+        client.post("/api/v1/auth/anonymous")
+        pg.commit.assert_awaited_once()
+
+    def test_inserts_player_and_session(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        pg.execute = AsyncMock(return_value=_make_result())
+        pg.commit = AsyncMock()
+
+        client.post("/api/v1/auth/anonymous")
+        # 3 inserts: player, auth_session, refresh_token
+        assert pg.execute.await_count == 3
+
+
+# ── POST /auth/refresh ─────────────────────────────────────────
+
+
+class TestRefreshTokens:
+    def _make_valid_refresh(self) -> str:
+        """Create a real refresh token for testing."""
+        from tta.auth.jwt import create_refresh_token
+
+        token, _ = create_refresh_token(
+            _PID, session_family_id=_SFID, is_anonymous=True
+        )
+        return token
+
+    def test_rotates_tokens_successfully(
+        self, client: TestClient, pg: AsyncMock, redis: AsyncMock
+    ) -> None:
+        token = self._make_valid_refresh()
+
+        # is_token_denied → False (uses redis.exists, not redis.get)
+        redis.exists = AsyncMock(return_value=0)
+
+        # Sequence: token lookup, session lookup, player lookup, mark used,
+        #           insert new refresh, update session, commit
+        token_record = _make_result([{"id": uuid4(), "used": False}])
+        session_record = _make_result([{"is_anonymous": True, "revoked_at": None}])
+        player_record = _make_result([{"role": "player", "is_anonymous": True}])
+        insert_result = _make_result()
+
+        pg.execute = AsyncMock(
+            side_effect=[
+                token_record,
+                session_record,
+                player_record,
+                insert_result,  # mark used
+                insert_result,  # insert new refresh
+                insert_result,  # update session
+            ]
+        )
+        pg.commit = AsyncMock()
+
+        resp = client.post("/api/v1/auth/refresh", json={"refresh_token": token})
+        assert resp.status_code == 200
+
+        data = resp.json()["data"]
+        assert "access_token" in data
+        assert "refresh_token" in data
+        assert data["is_anonymous"] is True
+
+    def test_rejects_invalid_token(self, client: TestClient) -> None:
+        resp = client.post("/api/v1/auth/refresh", json={"refresh_token": "garbage"})
+        assert resp.status_code == 401
+
+    def test_detects_token_reuse(
+        self, client: TestClient, pg: AsyncMock, redis: AsyncMock
+    ) -> None:
+        """FR-11.22: reused refresh token invalidates entire session."""
+        token = self._make_valid_refresh()
+        redis.exists = AsyncMock(return_value=0)
+
+        # Token found but already used
+        token_record = _make_result([{"id": uuid4(), "used": True}])
+        revoke_result = _make_result()
+
+        pg.execute = AsyncMock(side_effect=[token_record, revoke_result])
+        pg.commit = AsyncMock()
+
+        resp = client.post("/api/v1/auth/refresh", json={"refresh_token": token})
+        assert resp.status_code == 401
+        assert "SESSION_REVOKED" in resp.text
+
+    def test_rejects_denied_token(
+        self, client: TestClient, pg: AsyncMock, redis: AsyncMock
+    ) -> None:
+        token = self._make_valid_refresh()
+        # Token is in deny-list
+        redis.exists = AsyncMock(return_value=1)
+
+        resp = client.post("/api/v1/auth/refresh", json={"refresh_token": token})
+        assert resp.status_code == 401
+
+    def test_rejects_revoked_session(
+        self, client: TestClient, pg: AsyncMock, redis: AsyncMock
+    ) -> None:
+        token = self._make_valid_refresh()
+        redis.exists = AsyncMock(return_value=0)
+
+        token_record = _make_result([{"id": uuid4(), "used": False}])
+        session_record = _make_result([{"is_anonymous": True, "revoked_at": _NOW}])
+
+        pg.execute = AsyncMock(side_effect=[token_record, session_record])
+
+        resp = client.post("/api/v1/auth/refresh", json={"refresh_token": token})
+        assert resp.status_code == 401
+        assert "SESSION_REVOKED" in resp.text
+
+
+# ── POST /auth/logout ──────────────────────────────────────────
+
+
+class TestLogout:
+    def _make_valid_access(self) -> str:
+        from tta.auth.jwt import create_access_token
+
+        return create_access_token(
+            _PID, role="player", is_anonymous=True, session_family_id=_SFID
+        )
+
+    def test_logout_succeeds_with_bearer(
+        self, client: TestClient, pg: AsyncMock, redis: AsyncMock
+    ) -> None:
+        token = self._make_valid_access()
+        redis.setex = AsyncMock()
+        pg.execute = AsyncMock(return_value=_make_result())
+        pg.commit = AsyncMock()
+
+        resp = client.post(
+            "/api/v1/auth/logout",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 204
+
+    def test_logout_denies_token_in_redis(
+        self, client: TestClient, pg: AsyncMock, redis: AsyncMock
+    ) -> None:
+        token = self._make_valid_access()
+        redis.setex = AsyncMock()
+        pg.execute = AsyncMock(return_value=_make_result())
+        pg.commit = AsyncMock()
+
+        client.post(
+            "/api/v1/auth/logout",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        redis.setex.assert_awaited_once()
+
+    def test_logout_deletes_cookie(
+        self, client: TestClient, pg: AsyncMock, redis: AsyncMock
+    ) -> None:
+        token = self._make_valid_access()
+        redis.setex = AsyncMock()
+        pg.execute = AsyncMock(return_value=_make_result())
+        pg.commit = AsyncMock()
+
+        resp = client.post(
+            "/api/v1/auth/logout",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        # Cookie should be expired (deleted)
+        cookie_header = resp.headers.get("set-cookie", "")
+        assert "tta_session" in cookie_header
+
+    def test_logout_no_token_returns_401(self, client: TestClient) -> None:
+        resp = client.post("/api/v1/auth/logout")
+        assert resp.status_code == 401
+
+    def test_logout_invalid_token_returns_401(self, client: TestClient) -> None:
+        resp = client.post(
+            "/api/v1/auth/logout",
+            headers={"Authorization": "Bearer garbage-token"},
+        )
+        assert resp.status_code == 401
+
+
+# ── POST /auth/upgrade ─────────────────────────────────────────
+
+
+class TestUpgradeAnonymous:
+    @pytest.fixture()
+    def anon_app(
+        self,
+        pg: AsyncMock,
+        redis: AsyncMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> FastAPI:
+        """App where authenticated player is anonymous."""
+        settings = _settings()
+        monkeypatch.setattr("tta.api.routes.auth.get_settings", lambda: settings)
+        monkeypatch.setattr("tta.auth.jwt.get_settings", lambda: settings)
+        a = create_app(settings=settings)
+
+        async def _pg():
+            yield pg
+
+        a.dependency_overrides[get_pg] = _pg
+        a.dependency_overrides[get_redis] = lambda: redis
+        a.dependency_overrides[get_current_player] = lambda: _ANON_PLAYER
+        return a
+
+    @pytest.fixture()
+    def anon_client(self, anon_app: FastAPI) -> TestClient:
+        return TestClient(anon_app)
+
+    def test_upgrades_anonymous_to_registered(
+        self, anon_client: TestClient, pg: AsyncMock
+    ) -> None:
+        # email uniqueness check → no conflict
+        pg.execute = AsyncMock(
+            side_effect=[
+                _make_result(),  # email check: no rows
+                _make_result(),  # update player
+                _make_result(),  # insert auth_session
+                _make_result(),  # insert refresh_token
+            ]
+        )
+        pg.commit = AsyncMock()
+
+        resp = anon_client.post(
+            "/api/v1/auth/upgrade",
+            json={
+                "email": "test@example.com",
+                "password": "Secure1pass",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["is_anonymous"] is False
+        assert data["player_id"] == str(_PID)
+
+    def test_rejects_duplicate_email(
+        self, anon_client: TestClient, pg: AsyncMock
+    ) -> None:
+        pg.execute = AsyncMock(return_value=_make_result([{"id": uuid4()}]))
+
+        resp = anon_client.post(
+            "/api/v1/auth/upgrade",
+            json={
+                "email": "taken@example.com",
+                "password": "Secure1pass",
+            },
+        )
+        assert resp.status_code == 409
+        assert "EMAIL_ALREADY_REGISTERED" in resp.text
+
+    def test_rejects_weak_password(self, anon_client: TestClient) -> None:
+        resp = anon_client.post(
+            "/api/v1/auth/upgrade",
+            json={"email": "a@b.com", "password": "short"},
+        )
+        # pydantic rejects min_length=8
+        assert resp.status_code == 422
+
+    def test_rejects_password_no_digit(
+        self, anon_client: TestClient, pg: AsyncMock
+    ) -> None:
+        # email check passes
+        pg.execute = AsyncMock(return_value=_make_result())
+
+        resp = anon_client.post(
+            "/api/v1/auth/upgrade",
+            json={"email": "a@b.com", "password": "NoDigitsHere"},
+        )
+        assert resp.status_code == 400
+        assert "PASSWORD_INVALID" in resp.text
+
+    def test_registered_player_cannot_upgrade(
+        self,
+        pg: AsyncMock,
+        redis: AsyncMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Already-registered player gets ALREADY_REGISTERED error."""
+        settings = _settings()
+        monkeypatch.setattr("tta.api.routes.auth.get_settings", lambda: settings)
+        monkeypatch.setattr("tta.auth.jwt.get_settings", lambda: settings)
+        a = create_app(settings=settings)
+
+        async def _pg_gen():
+            yield pg
+
+        a.dependency_overrides[get_pg] = _pg_gen
+        a.dependency_overrides[get_redis] = lambda: redis
+        a.dependency_overrides[get_current_player] = lambda: _REG_PLAYER
+
+        c = TestClient(a)
+        resp = c.post(
+            "/api/v1/auth/upgrade",
+            json={"email": "x@y.com", "password": "Secure1pass"},
+        )
+        assert resp.status_code == 400
+        assert "ALREADY_REGISTERED" in resp.text

--- a/tests/unit/api/test_auth_routes.py
+++ b/tests/unit/api/test_auth_routes.py
@@ -85,6 +85,7 @@ def app(pg: AsyncMock, redis: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> Fas
     settings = _settings()
     monkeypatch.setattr("tta.api.routes.auth.get_settings", lambda: settings)
     monkeypatch.setattr("tta.auth.jwt.get_settings", lambda: settings)
+    monkeypatch.setattr("tta.auth.passwords.get_settings", lambda: settings)
     a = create_app(settings=settings)
 
     async def _pg():
@@ -324,6 +325,7 @@ class TestUpgradeAnonymous:
         settings = _settings()
         monkeypatch.setattr("tta.api.routes.auth.get_settings", lambda: settings)
         monkeypatch.setattr("tta.auth.jwt.get_settings", lambda: settings)
+        monkeypatch.setattr("tta.auth.passwords.get_settings", lambda: settings)
         a = create_app(settings=settings)
 
         async def _pg():
@@ -410,6 +412,7 @@ class TestUpgradeAnonymous:
         settings = _settings()
         monkeypatch.setattr("tta.api.routes.auth.get_settings", lambda: settings)
         monkeypatch.setattr("tta.auth.jwt.get_settings", lambda: settings)
+        monkeypatch.setattr("tta.auth.passwords.get_settings", lambda: settings)
         a = create_app(settings=settings)
 
         async def _pg_gen():

--- a/tests/unit/api/test_commands.py
+++ b/tests/unit/api/test_commands.py
@@ -93,7 +93,7 @@ def app(pg: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
 
     a.dependency_overrides[get_pg] = _pg
     a.dependency_overrides[get_current_player] = lambda: _PLAYER
-    a.dependency_overrides[require_consent] = lambda: None
+    a.dependency_overrides[require_consent] = lambda: _PLAYER
     return a
 
 

--- a/tests/unit/api/test_gameplay_e2e.py
+++ b/tests/unit/api/test_gameplay_e2e.py
@@ -18,7 +18,12 @@ import pytest
 from fastapi.testclient import TestClient
 
 from tta.api.app import create_app
-from tta.api.deps import get_current_player, get_pg, require_consent
+from tta.api.deps import (
+    get_current_player,
+    get_pg,
+    require_anonymous_game_limit,
+    require_consent,
+)
 from tta.config import Settings
 from tta.models.player import Player
 
@@ -90,7 +95,8 @@ def client(pg: AsyncMock) -> TestClient:
     app = create_app(settings)
     app.dependency_overrides[get_pg] = lambda: pg
     app.dependency_overrides[get_current_player] = lambda: _PLAYER
-    app.dependency_overrides[require_consent] = lambda: None
+    app.dependency_overrides[require_consent] = lambda: _PLAYER
+    app.dependency_overrides[require_anonymous_game_limit] = lambda: _PLAYER
     return TestClient(app, raise_server_exceptions=False)
 
 

--- a/tests/unit/api/test_games.py
+++ b/tests/unit/api/test_games.py
@@ -13,7 +13,12 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from tta.api.app import create_app
-from tta.api.deps import get_current_player, get_pg, require_consent
+from tta.api.deps import (
+    get_current_player,
+    get_pg,
+    require_anonymous_game_limit,
+    require_consent,
+)
 from tta.config import Settings
 from tta.models.player import Player
 
@@ -100,7 +105,8 @@ def app(pg: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
 
     a.dependency_overrides[get_pg] = _pg
     a.dependency_overrides[get_current_player] = lambda: _PLAYER
-    a.dependency_overrides[require_consent] = lambda: None
+    a.dependency_overrides[require_consent] = lambda: _PLAYER
+    a.dependency_overrides[require_anonymous_game_limit] = lambda: _PLAYER
     return a
 
 

--- a/tests/unit/api/test_genesis_integration.py
+++ b/tests/unit/api/test_genesis_integration.py
@@ -309,7 +309,12 @@ def _app_for_genesis(monkeypatch: pytest.MonkeyPatch) -> Any:
     from fastapi.testclient import TestClient
 
     from tta.api.app import create_app
-    from tta.api.deps import get_current_player, get_pg, require_consent
+    from tta.api.deps import (
+        get_current_player,
+        get_pg,
+        require_anonymous_game_limit,
+        require_consent,
+    )
     from tta.models.player import Player
 
     settings = _settings()
@@ -337,7 +342,8 @@ def _app_for_genesis(monkeypatch: pytest.MonkeyPatch) -> Any:
     player = Player(id=_PLAYER_ID, handle="Tester", created_at=_NOW)
     app.dependency_overrides[get_pg] = _pg
     app.dependency_overrides[get_current_player] = lambda: player
-    app.dependency_overrides[require_consent] = lambda: None
+    app.dependency_overrides[require_consent] = lambda: player
+    app.dependency_overrides[require_anonymous_game_limit] = lambda: player
 
     return app, TestClient(app), pg_mock
 

--- a/tests/unit/api/test_players.py
+++ b/tests/unit/api/test_players.py
@@ -84,6 +84,8 @@ def pg() -> AsyncMock:
 def app(pg: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
     settings = _settings()
     monkeypatch.setattr("tta.api.routes.players.get_settings", lambda: settings)
+    monkeypatch.setattr("tta.auth.jwt.get_settings", lambda: settings)
+    monkeypatch.setattr("tta.auth.passwords.get_settings", lambda: settings)
     a = create_app(settings=settings)
 
     async def _pg():
@@ -99,6 +101,8 @@ def consented_app(pg: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
     """App where the authenticated player has valid consent."""
     settings = _settings()
     monkeypatch.setattr("tta.api.routes.players.get_settings", lambda: settings)
+    monkeypatch.setattr("tta.auth.jwt.get_settings", lambda: settings)
+    monkeypatch.setattr("tta.auth.passwords.get_settings", lambda: settings)
     a = create_app(settings=settings)
 
     async def _pg():

--- a/tests/unit/api/test_turn_atomicity.py
+++ b/tests/unit/api/test_turn_atomicity.py
@@ -88,7 +88,7 @@ def app(pg: AsyncMock) -> FastAPI:
     application = create_app(_settings())
     application.dependency_overrides[get_current_player] = lambda: _PLAYER
     application.dependency_overrides[get_pg] = lambda: pg
-    application.dependency_overrides[require_consent] = lambda: None
+    application.dependency_overrides[require_consent] = lambda: _PLAYER
     return application
 
 

--- a/tests/unit/auth/test_jwt.py
+++ b/tests/unit/auth/test_jwt.py
@@ -1,0 +1,256 @@
+"""Tests for JWT token creation, validation, and deny-list."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import jwt as pyjwt
+import pytest
+
+from tta.auth.jwt import (
+    TokenError,
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    deny_token,
+    is_token_denied,
+)
+from tta.config import Settings
+
+# ── Fixtures ─────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _override_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide deterministic settings for JWT tests."""
+    s = Settings(
+        database_url="postgresql://test@localhost/test",
+        neo4j_password="test",
+        jwt_secret="test-secret-key-minimum-32-bytes-long!!",
+        jwt_algorithm="HS256",
+        access_token_ttl=3600,
+        anon_access_token_ttl=86400,
+        refresh_token_ttl=2592000,
+        anon_refresh_token_ttl=604800,
+    )
+    monkeypatch.setattr("tta.auth.jwt.get_settings", lambda: s)
+
+
+_PID = uuid4()
+_SFID = uuid4()
+
+
+# ── create_access_token ─────────────────────────────────────────
+
+
+class TestCreateAccessToken:
+    def test_creates_valid_jwt(self) -> None:
+        token = create_access_token(_PID, role="player", is_anonymous=True)
+        claims = pyjwt.decode(
+            token,
+            "test-secret-key-minimum-32-bytes-long!!",
+            algorithms=["HS256"],
+        )
+        assert claims["sub"] == str(_PID)
+        assert claims["role"] == "player"
+        assert claims["anon"] is True
+        assert claims["typ"] == "access"
+        assert "jti" in claims
+        assert "iat" in claims
+        assert "exp" in claims
+
+    def test_anonymous_uses_longer_ttl(self) -> None:
+        token = create_access_token(_PID, is_anonymous=True)
+        claims = pyjwt.decode(
+            token,
+            "test-secret-key-minimum-32-bytes-long!!",
+            algorithms=["HS256"],
+        )
+        ttl = claims["exp"] - claims["iat"]
+        assert ttl == 86400  # anon_access_token_ttl
+
+    def test_registered_uses_shorter_ttl(self) -> None:
+        token = create_access_token(_PID, is_anonymous=False)
+        claims = pyjwt.decode(
+            token,
+            "test-secret-key-minimum-32-bytes-long!!",
+            algorithms=["HS256"],
+        )
+        ttl = claims["exp"] - claims["iat"]
+        assert ttl == 3600  # access_token_ttl
+
+    def test_session_family_id_included_when_set(self) -> None:
+        token = create_access_token(_PID, session_family_id=_SFID)
+        claims = pyjwt.decode(
+            token,
+            "test-secret-key-minimum-32-bytes-long!!",
+            algorithms=["HS256"],
+        )
+        assert claims["sfid"] == str(_SFID)
+
+    def test_session_family_id_absent_when_none(self) -> None:
+        token = create_access_token(_PID)
+        claims = pyjwt.decode(
+            token,
+            "test-secret-key-minimum-32-bytes-long!!",
+            algorithms=["HS256"],
+        )
+        assert "sfid" not in claims
+
+
+# ── create_refresh_token ────────────────────────────────────────
+
+
+class TestCreateRefreshToken:
+    def test_returns_token_and_jti(self) -> None:
+        token, jti = create_refresh_token(_PID, session_family_id=_SFID)
+        assert isinstance(token, str)
+        assert isinstance(jti, str)
+        assert len(jti) == 32  # token_hex(16)
+
+    def test_refresh_token_has_correct_type(self) -> None:
+        token, _ = create_refresh_token(_PID, session_family_id=_SFID)
+        claims = pyjwt.decode(
+            token,
+            "test-secret-key-minimum-32-bytes-long!!",
+            algorithms=["HS256"],
+        )
+        assert claims["typ"] == "refresh"
+
+    def test_anonymous_refresh_ttl(self) -> None:
+        token, _ = create_refresh_token(
+            _PID, session_family_id=_SFID, is_anonymous=True
+        )
+        claims = pyjwt.decode(
+            token,
+            "test-secret-key-minimum-32-bytes-long!!",
+            algorithms=["HS256"],
+        )
+        assert claims["exp"] - claims["iat"] == 604800
+
+    def test_registered_refresh_ttl(self) -> None:
+        token, _ = create_refresh_token(
+            _PID, session_family_id=_SFID, is_anonymous=False
+        )
+        claims = pyjwt.decode(
+            token,
+            "test-secret-key-minimum-32-bytes-long!!",
+            algorithms=["HS256"],
+        )
+        assert claims["exp"] - claims["iat"] == 2592000
+
+    def test_jti_matches_claims(self) -> None:
+        token, jti = create_refresh_token(_PID, session_family_id=_SFID)
+        claims = pyjwt.decode(
+            token,
+            "test-secret-key-minimum-32-bytes-long!!",
+            algorithms=["HS256"],
+        )
+        assert claims["jti"] == jti
+
+    def test_contains_session_family_id(self) -> None:
+        token, _ = create_refresh_token(_PID, session_family_id=_SFID)
+        claims = pyjwt.decode(
+            token,
+            "test-secret-key-minimum-32-bytes-long!!",
+            algorithms=["HS256"],
+        )
+        assert claims["sfid"] == str(_SFID)
+
+
+# ── decode_token ────────────────────────────────────────────────
+
+
+class TestDecodeToken:
+    def test_decodes_valid_access_token(self) -> None:
+        token = create_access_token(_PID)
+        claims = decode_token(token, expected_type="access")
+        assert claims["sub"] == str(_PID)
+
+    def test_decodes_valid_refresh_token(self) -> None:
+        token, _ = create_refresh_token(_PID, session_family_id=_SFID)
+        claims = decode_token(token, expected_type="refresh")
+        assert claims["sub"] == str(_PID)
+
+    def test_rejects_expired_token(self) -> None:
+        secret = "test-secret-key-minimum-32-bytes-long!!"
+        now = datetime.now(UTC) - timedelta(hours=2)
+        claims = {
+            "sub": str(_PID),
+            "typ": "access",
+            "iat": now,
+            "exp": now + timedelta(seconds=1),
+            "jti": "test-jti",
+        }
+        token = pyjwt.encode(claims, secret, algorithm="HS256")
+        with pytest.raises(TokenError, match="expired"):
+            decode_token(token)
+
+    def test_rejects_wrong_token_type(self) -> None:
+        token = create_access_token(_PID)
+        with pytest.raises(TokenError, match="Expected token type 'refresh'"):
+            decode_token(token, expected_type="refresh")
+
+    def test_rejects_tampered_token(self) -> None:
+        token = create_access_token(_PID)
+        tampered = token[:-5] + "XXXXX"
+        with pytest.raises(TokenError, match="Invalid token"):
+            decode_token(tampered)
+
+    def test_rejects_token_missing_required_claims(self) -> None:
+        secret = "test-secret-key-minimum-32-bytes-long!!"
+        token = pyjwt.encode({"sub": str(_PID)}, secret, algorithm="HS256")
+        with pytest.raises(TokenError, match="Invalid token"):
+            decode_token(token)
+
+    def test_confusion_attack_blocked(self) -> None:
+        """Refresh token cannot be used where access token is expected."""
+        refresh, _ = create_refresh_token(_PID, session_family_id=_SFID)
+        with pytest.raises(TokenError, match="Expected token type 'access'"):
+            decode_token(refresh, expected_type="access")
+
+
+# ── deny_token / is_token_denied ────────────────────────────────
+
+
+class TestDenyList:
+    @pytest.mark.anyio
+    async def test_deny_and_check(self) -> None:
+        redis = AsyncMock()
+        redis.exists = AsyncMock(return_value=1)
+        jti = "test-jti-001"
+        exp = datetime.now(UTC) + timedelta(hours=1)
+
+        await deny_token(redis, jti, exp)
+        redis.setex.assert_called_once()
+
+        assert await is_token_denied(redis, jti) is True
+
+    @pytest.mark.anyio
+    async def test_not_denied_returns_false(self) -> None:
+        redis = AsyncMock()
+        redis.exists = AsyncMock(return_value=0)
+
+        assert await is_token_denied(redis, "unknown-jti") is False
+
+    @pytest.mark.anyio
+    async def test_already_expired_skips_deny(self) -> None:
+        redis = AsyncMock()
+        exp = datetime.now(UTC) - timedelta(hours=1)
+
+        await deny_token(redis, "old-jti", exp)
+        redis.setex.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_no_redis_non_prod_logs_warning(self) -> None:
+        """Without Redis in dev, deny_token warns but doesn't crash."""
+        exp = datetime.now(UTC) + timedelta(hours=1)
+        await deny_token(None, "some-jti", exp)
+        # No exception = pass
+
+    @pytest.mark.anyio
+    async def test_no_redis_non_prod_not_denied(self) -> None:
+        """Without Redis in dev, is_token_denied returns False."""
+        assert await is_token_denied(None, "some-jti") is False

--- a/tests/unit/auth/test_passwords.py
+++ b/tests/unit/auth/test_passwords.py
@@ -1,0 +1,49 @@
+"""Tests for bcrypt password hashing and verification."""
+
+from __future__ import annotations
+
+import pytest
+
+from tta.auth.passwords import hash_password, verify_password
+from tta.config import Settings
+
+
+@pytest.fixture(autouse=True)
+def _override_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Use low bcrypt cost for fast tests."""
+    s = Settings(
+        database_url="postgresql://test@localhost/test",
+        neo4j_password="test",
+        bcrypt_cost=4,  # minimum for speed
+    )
+    monkeypatch.setattr("tta.auth.passwords.get_settings", lambda: s)
+
+
+class TestHashPassword:
+    def test_returns_bcrypt_hash(self) -> None:
+        h = hash_password("hunter2")
+        assert h.startswith("$2b$")
+
+    def test_different_passwords_different_hashes(self) -> None:
+        h1 = hash_password("password1")
+        h2 = hash_password("password2")
+        assert h1 != h2
+
+    def test_same_password_different_salts(self) -> None:
+        h1 = hash_password("same")
+        h2 = hash_password("same")
+        assert h1 != h2  # unique salt each time
+
+
+class TestVerifyPassword:
+    def test_correct_password_verifies(self) -> None:
+        h = hash_password("correct-horse")
+        assert verify_password("correct-horse", h) is True
+
+    def test_wrong_password_fails(self) -> None:
+        h = hash_password("correct-horse")
+        assert verify_password("wrong-horse", h) is False
+
+    def test_empty_password_fails(self) -> None:
+        h = hash_password("notempty")
+        assert verify_password("", h) is False

--- a/tests/unit/lifecycle/test_cleanup.py
+++ b/tests/unit/lifecycle/test_cleanup.py
@@ -18,13 +18,17 @@ def _make_pg(
     abandon_rowcount: int = 0,
     expire_rowcount: int = 0,
     idle_rowcount: int = 0,
+    anon_rowcount: int = 0,
 ) -> AsyncMock:
     """Build a mock PG session that returns the given rowcounts."""
     pg = AsyncMock()
     abandon_result = SimpleNamespace(rowcount=abandon_rowcount)
     expire_result = SimpleNamespace(rowcount=expire_rowcount)
     idle_result = SimpleNamespace(rowcount=idle_rowcount)
-    pg.execute = AsyncMock(side_effect=[abandon_result, expire_result, idle_result])
+    anon_result = SimpleNamespace(rowcount=anon_rowcount)
+    pg.execute = AsyncMock(
+        side_effect=[abandon_result, expire_result, idle_result, anon_result]
+    )
     pg.commit = AsyncMock()
     return pg
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -94,6 +94,7 @@ class TestEnumValidation:
                 database_url="postgresql://x@localhost/tta",
                 neo4j_password="s",
                 environment=env,
+                jwt_secret="test-secret-that-is-not-the-default-value",
             )
             assert s.environment == env
 
@@ -122,6 +123,7 @@ class TestEnvPrefix:
         monkeypatch.setenv("TTA_NEO4J_PASSWORD", "pw")
         monkeypatch.setenv("TTA_LOG_LEVEL", "DEBUG")
         monkeypatch.setenv("TTA_ENVIRONMENT", "production")
+        monkeypatch.setenv("TTA_JWT_SECRET", "test-secret-not-default")
         s = Settings()
         assert s.log_level == LogLevel.DEBUG
         assert s.environment == Environment.PRODUCTION

--- a/uv.lock
+++ b/uv.lock
@@ -218,6 +218,72 @@ wheels = [
 ]
 
 [[package]]
+name = "bcrypt"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806, upload-time = "2025-09-25T19:49:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/44/dc/01eb79f12b177017a726cbf78330eb0eb442fae0e7b3dfd84ea2849552f3/bcrypt-5.0.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:200af71bc25f22006f4069060c88ed36f8aa4ff7f53e67ff04d2ab3f1e79a5b2", size = 268626, upload-time = "2025-09-25T19:49:06.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/cf/e82388ad5959c40d6afd94fb4743cc077129d45b952d46bdc3180310e2df/bcrypt-5.0.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:baade0a5657654c2984468efb7d6c110db87ea63ef5a4b54732e7e337253e44f", size = 271853, upload-time = "2025-09-25T19:49:08.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/86/7134b9dae7cf0efa85671651341f6afa695857fae172615e960fb6a466fa/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c58b56cdfb03202b3bcc9fd8daee8e8e9b6d7e3163aa97c631dfcfcc24d36c86", size = 269793, upload-time = "2025-09-25T19:49:09.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/6296688ac1b9e503d034e7d0614d56e80c5d1a08402ff856a4549cb59207/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4bfd2a34de661f34d0bda43c3e4e79df586e4716ef401fe31ea39d69d581ef23", size = 289930, upload-time = "2025-09-25T19:49:11.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/18/884a44aa47f2a3b88dd09bc05a1e40b57878ecd111d17e5bba6f09f8bb77/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ed2e1365e31fc73f1825fa830f1c8f8917ca1b3ca6185773b349c20fd606cec2", size = 272194, upload-time = "2025-09-25T19:49:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/8f/371a3ab33c6982070b674f1788e05b656cfbf5685894acbfef0c65483a59/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:83e787d7a84dbbfba6f250dd7a5efd689e935f03dd83b0f919d39349e1f23f83", size = 269381, upload-time = "2025-09-25T19:49:14.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/34/7e4e6abb7a8778db6422e88b1f06eb07c47682313997ee8a8f9352e5a6f1/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:137c5156524328a24b9fac1cb5db0ba618bc97d11970b39184c1d87dc4bf1746", size = 271750, upload-time = "2025-09-25T19:49:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f416be2499bd72123c70d98d36c6cd61a4e33d9b89562c22481c81bb30/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:38cac74101777a6a7d3b3e3cfefa57089b5ada650dce2baf0cbdd9d65db22a9e", size = 303757, upload-time = "2025-09-25T19:49:17.244Z" },
+    { url = "https://files.pythonhosted.org/packages/13/62/062c24c7bcf9d2826a1a843d0d605c65a755bc98002923d01fd61270705a/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:d8d65b564ec849643d9f7ea05c6d9f0cd7ca23bdd4ac0c2dbef1104ab504543d", size = 306740, upload-time = "2025-09-25T19:49:18.693Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c8/1fdbfc8c0f20875b6b4020f3c7dc447b8de60aa0be5faaf009d24242aec9/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:741449132f64b3524e95cd30e5cd3343006ce146088f074f31ab26b94e6c75ba", size = 334197, upload-time = "2025-09-25T19:49:20.523Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c1/8b84545382d75bef226fbc6588af0f7b7d095f7cd6a670b42a86243183cd/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:212139484ab3207b1f0c00633d3be92fef3c5f0af17cad155679d03ff2ee1e41", size = 352974, upload-time = "2025-09-25T19:49:22.254Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a6/ffb49d4254ed085e62e3e5dd05982b4393e32fe1e49bb1130186617c29cd/bcrypt-5.0.0-cp313-cp313t-win32.whl", hash = "sha256:9d52ed507c2488eddd6a95bccee4e808d3234fa78dd370e24bac65a21212b861", size = 148498, upload-time = "2025-09-25T19:49:24.134Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a9/259559edc85258b6d5fc5471a62a3299a6aa37a6611a169756bf4689323c/bcrypt-5.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f6984a24db30548fd39a44360532898c33528b74aedf81c26cf29c51ee47057e", size = 145853, upload-time = "2025-09-25T19:49:25.702Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/df/9714173403c7e8b245acf8e4be8876aac64a209d1b392af457c79e60492e/bcrypt-5.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9fffdb387abe6aa775af36ef16f55e318dcda4194ddbf82007a6f21da29de8f5", size = 139626, upload-time = "2025-09-25T19:49:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/14/c18006f91816606a4abe294ccc5d1e6f0e42304df5a33710e9e8e95416e1/bcrypt-5.0.0-cp314-cp314t-macosx_10_12_universal2.whl", hash = "sha256:4870a52610537037adb382444fefd3706d96d663ac44cbb2f37e3919dca3d7ef", size = 481862, upload-time = "2025-09-25T19:49:28.365Z" },
+    { url = "https://files.pythonhosted.org/packages/67/49/dd074d831f00e589537e07a0725cf0e220d1f0d5d8e85ad5bbff251c45aa/bcrypt-5.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48f753100931605686f74e27a7b49238122aa761a9aefe9373265b8b7aa43ea4", size = 268544, upload-time = "2025-09-25T19:49:30.39Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/91/50ccba088b8c474545b034a1424d05195d9fcbaaf802ab8bfe2be5a4e0d7/bcrypt-5.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f70aadb7a809305226daedf75d90379c397b094755a710d7014b8b117df1ebbf", size = 271787, upload-time = "2025-09-25T19:49:32.144Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e7/d7dba133e02abcda3b52087a7eea8c0d4f64d3e593b4fffc10c31b7061f3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:744d3c6b164caa658adcb72cb8cc9ad9b4b75c7db507ab4bc2480474a51989da", size = 269753, upload-time = "2025-09-25T19:49:33.885Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fc/5b145673c4b8d01018307b5c2c1fc87a6f5a436f0ad56607aee389de8ee3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a28bc05039bdf3289d757f49d616ab3efe8cf40d8e8001ccdd621cd4f98f4fc9", size = 289587, upload-time = "2025-09-25T19:49:35.144Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d7/1ff22703ec6d4f90e62f1a5654b8867ef96bafb8e8102c2288333e1a6ca6/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7f277a4b3390ab4bebe597800a90da0edae882c6196d3038a73adf446c4f969f", size = 272178, upload-time = "2025-09-25T19:49:36.793Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/88/815b6d558a1e4d40ece04a2f84865b0fef233513bd85fd0e40c294272d62/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:79cfa161eda8d2ddf29acad370356b47f02387153b11d46042e93a0a95127493", size = 269295, upload-time = "2025-09-25T19:49:38.164Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/e0db387c79ab4931fc89827d37608c31cc57b6edc08ccd2386139028dc0d/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a5393eae5722bcef046a990b84dff02b954904c36a194f6cfc817d7dca6c6f0b", size = 271700, upload-time = "2025-09-25T19:49:39.917Z" },
+    { url = "https://files.pythonhosted.org/packages/06/83/1570edddd150f572dbe9fc00f6203a89fc7d4226821f67328a85c330f239/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f4c94dec1b5ab5d522750cb059bb9409ea8872d4494fd152b53cca99f1ddd8c", size = 334034, upload-time = "2025-09-25T19:49:41.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f2/ea64e51a65e56ae7a8a4ec236c2bfbdd4b23008abd50ac33fbb2d1d15424/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0cae4cb350934dfd74c020525eeae0a5f79257e8a201c0c176f4b84fdbf2a4b4", size = 352766, upload-time = "2025-09-25T19:49:43.08Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d4/1a388d21ee66876f27d1a1f41287897d0c0f1712ef97d395d708ba93004c/bcrypt-5.0.0-cp314-cp314t-win32.whl", hash = "sha256:b17366316c654e1ad0306a6858e189fc835eca39f7eb2cafd6aaca8ce0c40a2e", size = 152449, upload-time = "2025-09-25T19:49:44.971Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/61/3291c2243ae0229e5bca5d19f4032cecad5dfb05a2557169d3a69dc0ba91/bcrypt-5.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:92864f54fb48b4c718fc92a32825d0e42265a627f956bc0361fe869f1adc3e7d", size = 149310, upload-time = "2025-09-25T19:49:46.162Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/89/4b01c52ae0c1a681d4021e5dd3e45b111a8fb47254a274fa9a378d8d834b/bcrypt-5.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dd19cf5184a90c873009244586396a6a884d591a5323f0e8a5922560718d4993", size = 143761, upload-time = "2025-09-25T19:49:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/6237f151fbfe295fe3e074ecc6d44228faa1e842a81f6d34a02937ee1736/bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b", size = 494553, upload-time = "2025-09-25T19:49:49.006Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009, upload-time = "2025-09-25T19:49:50.581Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029, upload-time = "2025-09-25T19:49:52.533Z" },
+    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907, upload-time = "2025-09-25T19:49:54.709Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7e/d4e47d2df1641a36d1212e5c0514f5291e1a956a7749f1e595c07a972038/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd", size = 296500, upload-time = "2025-09-25T19:49:56.013Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412, upload-time = "2025-09-25T19:49:57.356Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486, upload-time = "2025-09-25T19:49:59.116Z" },
+    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940, upload-time = "2025-09-25T19:50:00.869Z" },
+    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776, upload-time = "2025-09-25T19:50:02.393Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922, upload-time = "2025-09-25T19:50:04.232Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367, upload-time = "2025-09-25T19:50:05.559Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187, upload-time = "2025-09-25T19:50:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/461f352fdca663524b4643d8b09e8435b4990f17fbf4fea6bc2a90aa0cc7/bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538", size = 153752, upload-time = "2025-09-25T19:50:08.515Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/4190e60921927b7056820291f56fc57d00d04757c8b316b2d3c0d1d6da2c/bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9", size = 150881, upload-time = "2025-09-25T19:50:09.742Z" },
+    { url = "https://files.pythonhosted.org/packages/54/12/cd77221719d0b39ac0b55dbd39358db1cd1246e0282e104366ebbfb8266a/bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980", size = 144931, upload-time = "2025-09-25T19:50:11.016Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a", size = 495313, upload-time = "2025-09-25T19:50:12.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290, upload-time = "2025-09-25T19:50:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253, upload-time = "2025-09-25T19:50:15.089Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084, upload-time = "2025-09-25T19:50:16.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/fa6e16145e145e87f1fa351bbd54b429354fd72145cd3d4e0c5157cf4c70/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac", size = 297185, upload-time = "2025-09-25T19:50:18.525Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656, upload-time = "2025-09-25T19:50:19.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662, upload-time = "2025-09-25T19:50:21.567Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240, upload-time = "2025-09-25T19:50:23.305Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152, upload-time = "2025-09-25T19:50:24.597Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284, upload-time = "2025-09-25T19:50:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643, upload-time = "2025-09-25T19:50:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698, upload-time = "2025-09-25T19:50:31.347Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
+    { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -1580,6 +1646,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[[package]]
 name = "pyright"
 version = "1.1.408"
 source = { registry = "https://pypi.org/simple" }
@@ -2218,6 +2293,7 @@ source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
+    { name = "bcrypt" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "jinja2" },
@@ -2229,6 +2305,7 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "prometheus-client" },
     { name = "pydantic-settings" },
+    { name = "pyjwt" },
     { name = "redis" },
     { name = "sqlmodel" },
     { name = "structlog" },
@@ -2254,6 +2331,7 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
     { name = "asyncpg", specifier = ">=0.30" },
+    { name = "bcrypt", specifier = ">=4.2" },
     { name = "fastapi", specifier = ">=0.135" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "jinja2", specifier = ">=3.1" },
@@ -2265,6 +2343,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", specifier = ">=1.40.0" },
     { name = "prometheus-client", specifier = ">=0.24.1" },
     { name = "pydantic-settings", specifier = ">=2.0" },
+    { name = "pyjwt", specifier = ">=2.9" },
     { name = "redis", specifier = ">=5.0" },
     { name = "sqlmodel", specifier = ">=0.0.38" },
     { name = "structlog", specifier = ">=24.0" },


### PR DESCRIPTION
## Summary

Implements S11 Player Identity & Sessions — JWT-based anonymous-first authentication with token rotation, deny-lists, and session lifecycle management.

### What changed

**Phase 1-3: JWT Infrastructure**
- Added PyJWT + bcrypt dependencies
- JWT settings in `config.py` (access/refresh TTLs per spec FR-11.29)
- Migration 009: auth columns on `players`, new `auth_sessions` + `refresh_tokens` tables
- `src/tta/auth/` package: JWT encode/decode/deny-list, bcrypt hash/verify

**Phase 4: Auth Endpoints** (`src/tta/api/routes/auth.py`)
- `POST /auth/anonymous` — create anonymous player + JWT pair
- `POST /auth/refresh` — rotate refresh tokens with theft detection
- `POST /auth/logout` — deny-list tokens via Redis
- `POST /auth/upgrade` — convert anonymous → registered (email + password)

**Phase 5: Auth Migration**
- Rewrote `get_current_player` in deps.py: JWT decode + Redis deny-list
- Migrated `POST /players` to issue JWT instead of opaque tokens
- Redis fail-closed in production, graceful degradation in dev/test

**Phase 6: Anonymous Limits & Cleanup**
- `require_anonymous_game_limit` dependency: max 1 active game for anon players (FR-11.55)
- Cleanup Rule 4: soft-delete anonymous players after 30d inactivity (FR-11.12)

**Phase 7: Tests**
- 48 new auth tests: JWT (21), passwords (6), auth routes (19)
- Fixed test regressions from dependency chain changes

### Spec compliance
- Targets 14 ACs from S11 (AC-11.01 through AC-11.14)
- AC-11.09 deferred (login lockout requires `/auth/login`, out of v1 scope per S11 §14)
- Spec deviations documented in `plans/api-and-sessions.md` §0

### Quality gate
- 1775 tests pass (8 pre-existing failures unchanged)
- 0 ruff errors, 0 pyright errors, format clean

### Spec deviations (documented in plans/api-and-sessions.md §0)
1. UUID kept instead of spec ULID — existing migrations use UUID everywhere
2. Token TTLs follow spec (1h/24h access, 30d/7d refresh) — 15min recommendation noted as v2 amendment
3. Plan said "no JWT" — spec wins per SDD methodology