### PR TITLE
feat(admin): S26 Admin & Operator Tooling — compliance tests and implementation fixes (Wave 31)

### DIFF
--- a/src/tta/api/routes/admin.py
+++ b/src/tta/api/routes/admin.py
@@ -238,10 +238,23 @@ async def suspend_player(
         updated = result.first()
 
     if updated is None:
+        # Disambiguate: 404 if player does not exist, 409 if already suspended
+        async with request.app.state.pg() as session:
+            check = await session.execute(
+                sa.text("SELECT status FROM players WHERE id = :pid"),
+                {"pid": player_id},
+            )
+            existing = check.first()
+        if existing is None:
+            raise AppError(
+                ErrorCategory.NOT_FOUND,
+                "PLAYER_NOT_FOUND",
+                f"Player {player_id} not found.",
+            )
         raise AppError(
             ErrorCategory.CONFLICT,
-            "PLAYER_NOT_FOUND_OR_ALREADY_SUSPENDED",
-            f"Player {player_id} not found or already suspended.",
+            "PLAYER_ALREADY_SUSPENDED",
+            f"Player {player_id} is already suspended.",
         )
 
     await _audit(
@@ -417,35 +430,38 @@ async def terminate_game(
     """Force-terminate a game (FR-26.12)."""
     import sqlalchemy as sa
 
-    # Step 1: Check if game exists and get its current status
+    # Atomic UPDATE: only matches active/paused games (EC-26.2)
     async with request.app.state.pg() as session:
-        row = await session.execute(
-            sa.text("SELECT status FROM game_sessions WHERE id = :gid"),
+        result = await session.execute(
+            sa.text(
+                "UPDATE game_sessions SET status = 'ended' "
+                "WHERE id = :gid AND status IN ('active', 'paused') "
+                "RETURNING id"
+            ),
             {"gid": game_id},
         )
-        game = row.first()
+        await session.commit()
+        updated = result.first()
 
-    if game is None:
-        raise AppError(
-            ErrorCategory.NOT_FOUND,
-            "GAME_NOT_FOUND",
-            f"Game {game_id} not found.",
-        )
-
-    if game.status not in ("active", "paused"):
+    if updated is None:
+        # Disambiguate: 404 if game does not exist, 409 if already terminated
+        async with request.app.state.pg() as session:
+            check = await session.execute(
+                sa.text("SELECT status FROM game_sessions WHERE id = :gid"),
+                {"gid": game_id},
+            )
+            existing = check.first()
+        if existing is None:
+            raise AppError(
+                ErrorCategory.NOT_FOUND,
+                "GAME_NOT_FOUND",
+                f"Game {game_id} not found.",
+            )
         raise AppError(
             ErrorCategory.CONFLICT,
             "GAME_ALREADY_TERMINATED",
             "Game is already completed.",
         )
-
-    # Step 2: Terminate
-    async with request.app.state.pg() as session:
-        await session.execute(
-            sa.text("UPDATE game_sessions SET status = 'ended' WHERE id = :gid"),
-            {"gid": game_id},
-        )
-        await session.commit()
 
     SESSIONS_ACTIVE.dec()
 

--- a/src/tta/api/routes/admin.py
+++ b/src/tta/api/routes/admin.py
@@ -239,7 +239,7 @@ async def suspend_player(
 
     if updated is None:
         raise AppError(
-            ErrorCategory.NOT_FOUND,
+            ErrorCategory.CONFLICT,
             "PLAYER_NOT_FOUND_OR_ALREADY_SUSPENDED",
             f"Player {player_id} not found or already suspended.",
         )

--- a/src/tta/api/routes/admin.py
+++ b/src/tta/api/routes/admin.py
@@ -417,24 +417,35 @@ async def terminate_game(
     """Force-terminate a game (FR-26.12)."""
     import sqlalchemy as sa
 
+    # Step 1: Check if game exists and get its current status
     async with request.app.state.pg() as session:
-        result = await session.execute(
-            sa.text(
-                "UPDATE game_sessions SET status = 'ended' "
-                "WHERE id = :gid AND status IN ('active', 'paused') "
-                "RETURNING id"
-            ),
+        row = await session.execute(
+            sa.text("SELECT status FROM game_sessions WHERE id = :gid"),
+            {"gid": game_id},
+        )
+        game = row.first()
+
+    if game is None:
+        raise AppError(
+            ErrorCategory.NOT_FOUND,
+            "GAME_NOT_FOUND",
+            f"Game {game_id} not found.",
+        )
+
+    if game.status not in ("active", "paused"):
+        raise AppError(
+            ErrorCategory.CONFLICT,
+            "GAME_ALREADY_TERMINATED",
+            "Game is already completed.",
+        )
+
+    # Step 2: Terminate
+    async with request.app.state.pg() as session:
+        await session.execute(
+            sa.text("UPDATE game_sessions SET status = 'ended' WHERE id = :gid"),
             {"gid": game_id},
         )
         await session.commit()
-        updated = result.first()
-
-    if updated is None:
-        raise AppError(
-            ErrorCategory.NOT_FOUND,
-            "GAME_NOT_FOUND_OR_NOT_ACTIVE",
-            f"Game {game_id} not found or not in active/paused state.",
-        )
 
     SESSIONS_ACTIVE.dec()
 

--- a/tests/unit/api/test_admin.py
+++ b/tests/unit/api/test_admin.py
@@ -279,6 +279,8 @@ class TestPlayerSearch:
         assert "players" in body
         assert len(body["players"]) == 1
         assert body["players"][0]["handle"] == "CoolDragon42"
+        assert body["players"][0]["player_id"] is not None
+        assert body["players"][0]["status"] == "active"
 
     def test_empty_search_returns_all_players(self, settings: Settings) -> None:
         client = _build_client(settings)
@@ -384,7 +386,7 @@ class TestSuspendUnsuspend:
             json={"reason": "Repeated TOS violations"},
             headers=_auth_headers(),
         )
-        assert resp.status_code in (400, 404, 409)
+        assert resp.status_code == 409
         body = resp.json()
         assert "PLAYER_NOT_FOUND_OR_ALREADY_SUSPENDED" in str(body)
 

--- a/tests/unit/api/test_admin.py
+++ b/tests/unit/api/test_admin.py
@@ -9,13 +9,15 @@ Spec references:
   - AC-26.6: Flag review updates verdict and optionally suspends player
   - AC-26.7: Audit log is append-only, immutable, queryable by time/action/admin
   - AC-26.8: Health endpoint reports all subsystem statuses
+  - AC-26.4 (game): GET /admin/games/{game_id} returns full game state
+  - AC-26.5 (game): POST /admin/games/{game_id}/terminate force-ends a game
 """
 # ruff: noqa: E501
 
 from __future__ import annotations
 
 import uuid
-from datetime import UTC
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -256,7 +258,6 @@ class TestPlayerSearch:
         handle: str = "CoolDragon42",
         status: str = "active",
     ) -> MagicMock:
-        from datetime import datetime
 
         row = MagicMock()
         row.id = uuid.uuid4()
@@ -408,7 +409,6 @@ class TestGetPlayerSuccess:
     """GET /admin/players/{id} — success path (complement to 404 test)."""
 
     def test_get_player_returns_full_profile(self, settings: Settings) -> None:
-        from datetime import datetime
 
         client = _build_client(settings)
         player_id = uuid.uuid4()
@@ -454,3 +454,191 @@ class TestGetPlayerSuccess:
         assert body["games"]["total"] == 5
         assert body["games"]["active"] == 2
         assert "rate_limit" in body
+
+
+# ── AC-26.4 (game): Game inspection ─────────────────────────────
+
+
+class TestGameInspection:
+    """GET /admin/games/{game_id} returns full game state (AC-26.4)."""
+
+    def _make_game_row(self, game_id: uuid.UUID, player_id: uuid.UUID) -> MagicMock:
+        row = MagicMock()
+        row.id = game_id
+        row.player_id = player_id
+        row.status = "active"
+        row.world_seed = "dark-castle"
+        row.title = "The Dark Castle"
+        row.summary = "A tale of adventure."
+        row.turn_count = 5
+        row.needs_recovery = False
+        row.last_played_at = None
+        row.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+        row.updated_at = None
+        return row
+
+    def _build_game_client(self, settings: Settings, game_row: MagicMock) -> TestClient:
+        client = _build_client(settings)
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.first.return_value = game_row
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        client.app.state.pg = MagicMock(return_value=mock_session)  # type: ignore[union-attr]
+        return client
+
+    def test_get_game_returns_full_state(self, settings: Settings) -> None:
+        game_id = uuid.uuid4()
+        player_id = uuid.uuid4()
+        row = self._make_game_row(game_id, player_id)
+        client = self._build_game_client(settings, row)
+
+        resp = client.get(f"/admin/games/{game_id}", headers=_auth_headers())
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["game_id"] == str(game_id)
+        assert body["player_id"] == str(player_id)
+        assert body["status"] == "active"
+        assert "moderation_flags" in body
+
+    def test_get_game_includes_moderation_flags(self, settings: Settings) -> None:
+        game_id = uuid.uuid4()
+        player_id = uuid.uuid4()
+        row = self._make_game_row(game_id, player_id)
+        client = self._build_game_client(settings, row)
+
+        recorder = MagicMock()
+        recorder.query = AsyncMock(
+            return_value=[{"moderation_id": "abc", "category": "violence"}]
+        )
+        client.app.state.moderation_recorder = recorder  # type: ignore[union-attr]
+
+        resp = client.get(f"/admin/games/{game_id}", headers=_auth_headers())
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["moderation_flags"]) > 0
+
+    def test_get_game_not_found_returns_404(self, settings: Settings) -> None:
+        client = _build_client(settings)
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.first.return_value = None
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        client.app.state.pg = MagicMock(return_value=mock_session)  # type: ignore[union-attr]
+
+        resp = client.get(f"/admin/games/{uuid.uuid4()}", headers=_auth_headers())
+
+        assert resp.status_code == 404
+
+    def test_get_game_turns_returns_paginated_list(self, settings: Settings) -> None:
+        client = _build_client(settings)
+
+        def _make_turn_row(n: int) -> MagicMock:
+            r = MagicMock()
+            r.id = uuid.uuid4()
+            r.session_id = uuid.uuid4()
+            r.turn_number = n
+            r.player_input = f"input {n}"
+            r.status = "completed"
+            r.narrative_output = f"narrative {n}"
+            r.model_used = "gpt-4"
+            r.latency_ms = 250
+            r.token_count = 100
+            r.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+            r.completed_at = None
+            return r
+
+        turn_rows = [_make_turn_row(1), _make_turn_row(2)]
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.all.return_value = turn_rows
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        client.app.state.pg = MagicMock(return_value=mock_session)  # type: ignore[union-attr]
+
+        resp = client.get(
+            f"/admin/games/{uuid.uuid4()}/turns",
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["turns"]) == 2
+        for turn in body["turns"]:
+            assert "turn_id" in turn
+            assert "turn_number" in turn
+            assert "player_input" in turn
+
+
+# ── AC-26.5 (game): Game termination ────────────────────────────
+
+
+class TestGameTermination:
+    """POST /admin/games/{game_id}/terminate force-ends a game (AC-26.5)."""
+
+    def test_terminate_game_success(self, settings: Settings) -> None:
+        client = _build_client(settings)
+        game_id = uuid.uuid4()
+        updated_row = MagicMock()
+        updated_row.id = game_id
+        client.app.state.pg = _mock_pg_with_rows([updated_row])  # type: ignore[union-attr]
+
+        resp = client.post(
+            f"/admin/games/{game_id}/terminate",
+            json={"reason": "Admin force-terminated for policy violation"},
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ended"
+        audit_repo = client.app.state.audit_repo  # type: ignore[union-attr]
+        audit_repo.create_and_append.assert_awaited_once()
+
+    def test_terminate_game_not_active_returns_error(self, settings: Settings) -> None:
+        """EC-26: UPDATE returns no rows → 404 GAME_NOT_FOUND_OR_NOT_ACTIVE."""
+        client = _build_client(settings)
+        client.app.state.pg = _mock_pg_with_rows([])  # type: ignore[union-attr]
+
+        resp = client.post(
+            f"/admin/games/{uuid.uuid4()}/terminate",
+            json={"reason": "Trying to end a completed game"},
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 404
+        body = resp.json()
+        assert "GAME_NOT_FOUND_OR_NOT_ACTIVE" in str(body)
+
+    def test_terminate_requires_reason_min_length(self, settings: Settings) -> None:
+        """EC-26.4: TerminateRequest.reason min_length=10 → 422."""
+        client = _build_client(settings)
+
+        resp = client.post(
+            f"/admin/games/{uuid.uuid4()}/terminate",
+            json={"reason": "short"},
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 422
+
+    def test_terminate_already_completed_returns_error(
+        self, settings: Settings
+    ) -> None:
+        """Completed/ended games share the same NOT_ACTIVE code path as not-found."""
+        client = _build_client(settings)
+        client.app.state.pg = _mock_pg_with_rows([])  # type: ignore[union-attr]
+
+        resp = client.post(
+            f"/admin/games/{uuid.uuid4()}/terminate",
+            json={"reason": "Attempting to terminate already ended game"},
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 404

--- a/tests/unit/api/test_admin.py
+++ b/tests/unit/api/test_admin.py
@@ -715,8 +715,15 @@ class TestModerationFlagReview:
         assert body["action"] == "dismiss"
         assert body["new_verdict"] == "pass"
 
+        # AC-26.6: flag verdict updated to "pass" (the reviewed/dismissed state)
+        recorder = client.app.state.moderation_recorder  # type: ignore[union-attr]
+        recorder.update_verdict.assert_awaited_once_with(flag_id, "pass")
+
+        # AC-26.6: audit entry created with action "moderation_review_dismiss"
         audit_repo = client.app.state.audit_repo  # type: ignore[union-attr]
         audit_repo.create_and_append.assert_awaited_once()
+        call_kwargs = audit_repo.create_and_append.call_args
+        assert call_kwargs.kwargs["action"] == "moderation_review_dismiss"
 
     def test_review_warn_maps_to_flag_verdict(self, settings: Settings) -> None:
         client = self._build_recorder_client(settings, update_verdict_return=True)

--- a/tests/unit/api/test_admin.py
+++ b/tests/unit/api/test_admin.py
@@ -8,7 +8,7 @@ Spec references:
   - AC-26.5: Moderation queue returns paginated flags with filtering
   - AC-26.6: Flag review updates verdict and optionally suspends player
   - AC-26.7: Audit log is append-only, immutable, queryable by time/action/admin
-  - AC-26.8: Health endpoint reports all subsystem statuses
+  - AC-26.8: Audit log completeness — all write ops produce entries with required fields
   - AC-26.4 (game): GET /admin/games/{game_id} returns full game state
   - AC-26.5 (game): POST /admin/games/{game_id}/terminate force-ends a game
 """
@@ -984,3 +984,151 @@ class TestRateLimitReset:
             headers=_auth_headers(),
         )
         assert resp2.status_code == 422
+
+
+# ── AC-26.8: Audit log completeness ────────────────────────────
+
+
+def _make_audit_entry(
+    *,
+    action: str,
+    target_type: str,
+    target_id: str,
+    reason: str = "test reason",
+    admin_id: str = "admin-test",
+) -> MagicMock:
+    """Build a mock audit log entry with required fields."""
+    from types import SimpleNamespace
+
+    entry = SimpleNamespace(
+        id=uuid.uuid4(),
+        admin_id=admin_id,
+        action=action,
+        target_type=target_type,
+        target_id=target_id,
+        reason=reason,
+        source_ip="127.0.0.1",
+        timestamp=datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC),
+    )
+    return entry  # type: ignore[return-value]
+
+
+class TestAuditLogCompleteness:
+    """AC-26.8: Audit log records all admin writes with required fields (FR-26.24)."""
+
+    def test_audit_log_entries_include_required_fields(
+        self, settings: Settings
+    ) -> None:
+        """GET /admin/audit-log entries include admin_id, action, target, reason, timestamp."""
+        client = _build_client(settings)
+
+        suspend_entry = _make_audit_entry(
+            action="suspend_player", target_type="player", target_id=str(uuid.uuid4())
+        )
+        terminate_entry = _make_audit_entry(
+            action="terminate_game", target_type="game", target_id=str(uuid.uuid4())
+        )
+        review_entry = _make_audit_entry(
+            action="moderation_review_dismiss",
+            target_type="moderation_flag",
+            target_id="flag-xyz",
+        )
+
+        audit_repo = client.app.state.audit_repo  # type: ignore[union-attr]
+        audit_repo.query = AsyncMock(
+            return_value=[suspend_entry, terminate_entry, review_entry]
+        )
+        audit_repo.encode_cursor = MagicMock(return_value="cursor-token")
+
+        resp = client.get("/admin/audit-log", headers=_auth_headers())
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "entries" in body
+        entries = body["entries"]
+        assert len(entries) == 3
+
+        # All entries must have the required fields (FR-26.24)
+        for entry in entries:
+            assert "admin_id" in entry
+            assert "action" in entry
+            assert "target_type" in entry
+            assert "target_id" in entry
+            assert "reason" in entry
+            assert "timestamp" in entry
+
+        # Verify the three expected actions are present
+        actions = {e["action"] for e in entries}
+        assert "suspend_player" in actions
+        assert "terminate_game" in actions
+        assert "moderation_review_dismiss" in actions
+
+    def test_audit_log_filter_by_action(self, settings: Settings) -> None:
+        """GET /admin/audit-log?action=suspend_player returns only matching entries."""
+        client = _build_client(settings)
+
+        suspend_entry = _make_audit_entry(
+            action="suspend_player", target_type="player", target_id=str(uuid.uuid4())
+        )
+        audit_repo = client.app.state.audit_repo  # type: ignore[union-attr]
+        audit_repo.query = AsyncMock(return_value=[suspend_entry])
+        audit_repo.encode_cursor = MagicMock(return_value="cursor-token")
+
+        resp = client.get(
+            "/admin/audit-log?action=suspend_player",
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 200
+        entries = resp.json()["entries"]
+        assert len(entries) == 1
+        assert entries[0]["action"] == "suspend_player"
+
+        # Verify repo was queried with the action filter
+        call_kwargs = audit_repo.query.call_args
+        assert call_kwargs.kwargs.get("action") == "suspend_player"
+
+    def test_audit_log_filter_by_admin_id(self, settings: Settings) -> None:
+        """GET /admin/audit-log?admin_id=X returns entries filtered by admin."""
+        client = _build_client(settings)
+
+        entry = _make_audit_entry(
+            action="terminate_game",
+            target_type="game",
+            target_id=str(uuid.uuid4()),
+            admin_id="specific-admin",
+        )
+        audit_repo = client.app.state.audit_repo  # type: ignore[union-attr]
+        audit_repo.query = AsyncMock(return_value=[entry])
+        audit_repo.encode_cursor = MagicMock(return_value=None)
+
+        resp = client.get(
+            "/admin/audit-log?admin_id=specific-admin",
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 200
+        entries = resp.json()["entries"]
+        assert len(entries) == 1
+        assert entries[0]["admin_id"] == "specific-admin"
+
+        call_kwargs = audit_repo.query.call_args
+        assert call_kwargs.kwargs.get("admin_id") == "specific-admin"
+
+    def test_audit_log_empty_when_no_entries(self, settings: Settings) -> None:
+        """GET /admin/audit-log returns empty list and null cursor when no entries."""
+        client = _build_client(settings)
+        # Default _build_client stubs audit_repo.query to return []
+
+        resp = client.get("/admin/audit-log", headers=_auth_headers())
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["entries"] == []
+        assert body["next_cursor"] is None
+
+    def test_audit_log_requires_authentication(self, settings: Settings) -> None:
+        """GET /admin/audit-log without auth returns 401."""
+        client = _build_client(settings)
+        resp = client.get("/admin/audit-log")
+        assert resp.status_code == 401

--- a/tests/unit/api/test_admin.py
+++ b/tests/unit/api/test_admin.py
@@ -678,3 +678,302 @@ class TestGameTermination:
         assert resp.status_code == 404
         body = resp.json()
         assert "GAME_NOT_FOUND" in str(body)
+
+
+# ── AC-26.6: Moderation flag review ─────────────────────────────
+
+
+class TestModerationFlagReview:
+    """POST /admin/moderation/flags/{flag_id}/review (AC-26.6)."""
+
+    def _build_recorder_client(
+        self,
+        settings: Settings,
+        *,
+        update_verdict_return: object = True,
+    ) -> TestClient:
+        client = _build_client(settings)
+        recorder = MagicMock()
+        recorder.update_verdict = AsyncMock(return_value=update_verdict_return)
+        recorder.query = AsyncMock(return_value=[])
+        client.app.state.moderation_recorder = recorder  # type: ignore[union-attr]
+        return client
+
+    def test_review_dismiss_returns_200_and_audit(self, settings: Settings) -> None:
+        client = self._build_recorder_client(settings, update_verdict_return=True)
+        flag_id = "flag-abc-123"
+
+        resp = client.post(
+            f"/admin/moderation/flags/{flag_id}/review",
+            json={"action": "dismiss", "notes": "False positive notes here"},
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["flag_id"] == flag_id
+        assert body["action"] == "dismiss"
+        assert body["new_verdict"] == "pass"
+
+        audit_repo = client.app.state.audit_repo  # type: ignore[union-attr]
+        audit_repo.create_and_append.assert_awaited_once()
+
+    def test_review_warn_maps_to_flag_verdict(self, settings: Settings) -> None:
+        client = self._build_recorder_client(settings, update_verdict_return=True)
+        flag_id = "flag-def-456"
+
+        resp = client.post(
+            f"/admin/moderation/flags/{flag_id}/review",
+            json={
+                "action": "warn",
+                "notes": "Player was warned for inappropriate content",
+            },
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["new_verdict"] == "flag"
+        assert body["action"] == "warn"
+
+    def test_review_flag_not_found_returns_404(self, settings: Settings) -> None:
+        client = self._build_recorder_client(settings, update_verdict_return=False)
+
+        resp = client.post(
+            "/admin/moderation/flags/nonexistent-flag/review",
+            json={"action": "dismiss", "notes": "This flag does not exist here"},
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 404
+        body = resp.json()
+        assert "FLAG_NOT_FOUND" in str(body)
+
+    def test_review_no_recorder_returns_503(self, settings: Settings) -> None:
+        client = _build_client(settings)
+        # moderation_recorder is None by default in _build_client
+
+        resp = client.post(
+            "/admin/moderation/flags/some-flag/review",
+            json={"action": "dismiss", "notes": "Notes that are long enough to pass"},
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 503
+        body = resp.json()
+        assert "MODERATION_NOT_CONFIGURED" in str(body)
+
+    def test_review_invalid_action_returns_422(self, settings: Settings) -> None:
+        client = self._build_recorder_client(settings)
+
+        resp = client.post(
+            "/admin/moderation/flags/some-flag/review",
+            json={"action": "approve", "notes": "This action is not allowed here"},
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 422
+
+    def test_review_short_notes_returns_422(self, settings: Settings) -> None:
+        client = self._build_recorder_client(settings)
+
+        resp = client.post(
+            "/admin/moderation/flags/some-flag/review",
+            json={"action": "dismiss", "notes": "short"},
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 422
+
+
+# ── AC-26.7: Rate-limit inspection (read paths) ──────────────────
+
+
+class TestRateLimitInspection:
+    """GET /admin/rate-limits/player/{id} and /ip/{ip} (AC-26.7 read paths)."""
+
+    def test_get_player_rate_limits_no_detector(self, settings: Settings) -> None:
+        client = _build_client(settings)
+        # abuse_detector is None by default
+
+        resp = client.get(
+            f"/admin/rate-limits/player/{uuid.uuid4()}",
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["cooldown"] is None
+
+    def test_get_player_rate_limits_with_detector(self, settings: Settings) -> None:
+        client = _build_client(settings)
+
+        # Active cooldown returned for player-id lookups (route handler).
+        cd_active = MagicMock()
+        cd_active.active = True
+        cd_active.remaining_seconds = 45
+        cd_active.pattern = "rapid_turn"
+        cd_active.violation_count = 3
+
+        # Inactive cooldown returned for IP-based lookups (middleware).
+        cd_inactive = MagicMock()
+        cd_inactive.active = False
+        cd_inactive.remaining_seconds = 0
+        cd_inactive.pattern = None
+        cd_inactive.violation_count = 0
+
+        async def _check_cooldown(key: str) -> MagicMock:
+            # Middleware calls with "ip:<addr>"; route calls with player UUID string.
+            return cd_inactive if key.startswith("ip:") else cd_active
+
+        detector = MagicMock()
+        detector.check_cooldown = _check_cooldown
+        client.app.state.abuse_detector = detector  # type: ignore[union-attr]
+
+        resp = client.get(
+            f"/admin/rate-limits/player/{uuid.uuid4()}",
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["cooldown"] is not None
+        assert body["cooldown"]["active"] is True
+        assert body["cooldown"]["remaining_seconds"] == 45
+        assert body["cooldown"]["pattern"] == "rapid_turn"
+        assert body["cooldown"]["violation_count"] == 3
+
+    def test_get_ip_rate_limits_no_detector(self, settings: Settings) -> None:
+        client = _build_client(settings)
+        # abuse_detector is None by default
+
+        resp = client.get(
+            "/admin/rate-limits/ip/192.168.1.1",
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["cooldown"] is None
+        assert body["ip"] == "192.168.1.1"
+
+    def test_get_player_rate_limits_no_activity_ec26_7(
+        self, settings: Settings
+    ) -> None:
+        """EC-26.7: zero-activity player returns 200 with zeros, not 404."""
+        client = _build_client(settings)
+        cd = MagicMock()
+        cd.active = False
+        cd.remaining_seconds = 0
+        cd.pattern = None
+        cd.violation_count = 0
+        detector = MagicMock()
+        detector.check_cooldown = AsyncMock(return_value=cd)
+        client.app.state.abuse_detector = detector  # type: ignore[union-attr]
+
+        player_id = uuid.uuid4()
+        resp = client.get(
+            f"/admin/rate-limits/player/{player_id}",
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["cooldown"]["active"] is False
+        assert body["cooldown"]["violation_count"] == 0
+        assert body["player_id"] == str(player_id)
+
+
+# ── AC-26.7: Rate-limit management (write paths) ─────────────────
+
+
+class TestRateLimitReset:
+    """POST /admin/rate-limits/player/{id}/reset and /ip/{ip}/unblock (AC-26.7 write)."""
+
+    def test_reset_player_rate_limits_clears_and_audits(
+        self, settings: Settings
+    ) -> None:
+        client = _build_client(settings)
+        detector = MagicMock()
+        detector.clear_cooldown = AsyncMock()
+        client.app.state.abuse_detector = detector  # type: ignore[union-attr]
+
+        player_id = uuid.uuid4()
+        resp = client.post(
+            f"/admin/rate-limits/player/{player_id}/reset",
+            json={"reason": "Manual admin reset for player"},
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "rate_limits_cleared"
+        assert body["player_id"] == str(player_id)
+
+        detector.clear_cooldown.assert_awaited_once_with(str(player_id))
+
+        audit_repo = client.app.state.audit_repo  # type: ignore[union-attr]
+        call_kwargs = audit_repo.create_and_append.call_args
+        assert call_kwargs.kwargs["action"] == "reset_player_rate_limits"
+
+    def test_reset_player_no_detector_still_audits(self, settings: Settings) -> None:
+        client = _build_client(settings)
+        # abuse_detector is None by default
+
+        player_id = uuid.uuid4()
+        resp = client.post(
+            f"/admin/rate-limits/player/{player_id}/reset",
+            json={"reason": "Resetting player with no detector configured"},
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "rate_limits_cleared"
+        assert body["player_id"] == str(player_id)
+
+        audit_repo = client.app.state.audit_repo  # type: ignore[union-attr]
+        audit_repo.create_and_append.assert_awaited_once()
+
+    def test_unblock_ip_clears_all_groups_and_audits(self, settings: Settings) -> None:
+        client = _build_client(settings)
+        client.app.state.rate_limiter.clear_key = AsyncMock()  # type: ignore[union-attr]
+
+        resp = client.post(
+            "/admin/rate-limits/ip/10.0.0.1/unblock",
+            json={"reason": "Unblocking IP for admin review"},
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "unblocked"
+        assert body["ip"] == "10.0.0.1"
+
+        rl = client.app.state.rate_limiter  # type: ignore[union-attr]
+        assert (
+            rl.clear_key.await_count == 5
+        )  # one per group: turns, game_mgmt, auth, sse, health
+
+        audit_repo = client.app.state.audit_repo  # type: ignore[union-attr]
+        call_kwargs = audit_repo.create_and_append.call_args
+        assert call_kwargs.kwargs["action"] == "unblock_ip"
+
+    def test_reset_requires_reason(self, settings: Settings) -> None:
+        client = _build_client(settings)
+
+        # Empty string fails min_length=1
+        resp = client.post(
+            f"/admin/rate-limits/player/{uuid.uuid4()}/reset",
+            json={"reason": ""},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+        # Missing reason field also fails
+        resp2 = client.post(
+            f"/admin/rate-limits/player/{uuid.uuid4()}/reset",
+            json={},
+            headers=_auth_headers(),
+        )
+        assert resp2.status_code == 422

--- a/tests/unit/api/test_admin.py
+++ b/tests/unit/api/test_admin.py
@@ -377,10 +377,25 @@ class TestSuspendUnsuspend:
         assert body["player_id"] == str(player_id)
 
     def test_suspend_already_suspended_returns_error(self, settings: Settings) -> None:
-        """EC-26.1: UPDATE returns no rows → error with PLAYER_NOT_FOUND_OR_ALREADY_SUSPENDED."""
+        """EC-26.1: UPDATE returns no rows, player exists → 409 PLAYER_ALREADY_SUSPENDED."""
         client = _build_client(settings)
-        # first() returns None → player not found or already suspended
-        client.app.state.pg = _mock_pg_with_rows([])  # type: ignore[union-attr]
+
+        # UPDATE RETURNING returns no rows (player already suspended)
+        no_rows = MagicMock()
+        no_rows.first.return_value = None
+
+        # Disambiguation SELECT returns the player (exists, but already suspended)
+        suspended_row = MagicMock()
+        suspended_row.status = "suspended"
+        exists_result = MagicMock()
+        exists_result.first.return_value = suspended_row
+
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(side_effect=[no_rows, exists_result])
+        mock_session.commit = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        client.app.state.pg = MagicMock(return_value=mock_session)  # type: ignore[union-attr]
 
         resp = client.post(
             f"/admin/players/{uuid.uuid4()}/suspend",
@@ -389,7 +404,7 @@ class TestSuspendUnsuspend:
         )
         assert resp.status_code == 409
         body = resp.json()
-        assert "PLAYER_NOT_FOUND_OR_ALREADY_SUSPENDED" in str(body)
+        assert "PLAYER_ALREADY_SUSPENDED" in str(body)
 
     def test_suspend_short_reason_returns_422(self, settings: Settings) -> None:
         """EC-26.4: SuspendRequest.reason min_length=10 → 422 validation error."""
@@ -586,18 +601,14 @@ class TestGameTermination:
         client = _build_client(settings)
         game_id = uuid.uuid4()
 
-        # Step 1: SELECT returns a row with status="active"
-        select_result = MagicMock()
-        active_row = MagicMock()
-        active_row.status = "active"
-        select_result.first.return_value = active_row
-
-        # Step 2: UPDATE returns nothing
+        # Atomic UPDATE RETURNING returns the game id (game was active → now ended)
+        updated_row = MagicMock()
+        updated_row.id = game_id
         update_result = MagicMock()
-        update_result.first.return_value = None
+        update_result.first.return_value = updated_row
 
         mock_session = AsyncMock()
-        mock_session.execute = AsyncMock(side_effect=[select_result, update_result])
+        mock_session.execute = AsyncMock(return_value=update_result)
         mock_session.commit = AsyncMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=False)
@@ -619,14 +630,18 @@ class TestGameTermination:
         """EC-26.2: Game exists but is non-active → 409 GAME_ALREADY_TERMINATED."""
         client = _build_client(settings)
 
-        # SELECT returns a row with status="ended" (game found, but non-terminable)
-        select_result = MagicMock()
+        # UPDATE RETURNING returns no rows (game not in active/paused state)
+        no_rows = MagicMock()
+        no_rows.first.return_value = None
+
+        # Disambiguation SELECT returns an ended game row
         ended_row = MagicMock()
         ended_row.status = "ended"
-        select_result.first.return_value = ended_row
+        exists_result = MagicMock()
+        exists_result.first.return_value = ended_row
 
         mock_session = AsyncMock()
-        mock_session.execute = AsyncMock(return_value=select_result)
+        mock_session.execute = AsyncMock(side_effect=[no_rows, exists_result])
         mock_session.commit = AsyncMock()
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=False)
@@ -658,7 +673,7 @@ class TestGameTermination:
         """EC-26.2: Game does not exist → 404 GAME_NOT_FOUND."""
         client = _build_client(settings)
 
-        # SELECT returns None (game not found)
+        # UPDATE RETURNING returns no rows; disambiguation SELECT also returns None → 404
         select_result = MagicMock()
         select_result.first.return_value = None
 
@@ -1056,6 +1071,7 @@ class TestAuditLogCompleteness:
             assert "target_id" in entry
             assert "reason" in entry
             assert "timestamp" in entry
+            assert "source_ip" in entry  # FR-26.24 required field
 
         # Verify the three expected actions are present
         actions = {e["action"] for e in entries}

--- a/tests/unit/api/test_admin.py
+++ b/tests/unit/api/test_admin.py
@@ -585,9 +585,23 @@ class TestGameTermination:
     def test_terminate_game_success(self, settings: Settings) -> None:
         client = _build_client(settings)
         game_id = uuid.uuid4()
-        updated_row = MagicMock()
-        updated_row.id = game_id
-        client.app.state.pg = _mock_pg_with_rows([updated_row])  # type: ignore[union-attr]
+
+        # Step 1: SELECT returns a row with status="active"
+        select_result = MagicMock()
+        active_row = MagicMock()
+        active_row.status = "active"
+        select_result.first.return_value = active_row
+
+        # Step 2: UPDATE returns nothing
+        update_result = MagicMock()
+        update_result.first.return_value = None
+
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(side_effect=[select_result, update_result])
+        mock_session.commit = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        client.app.state.pg = MagicMock(return_value=mock_session)  # type: ignore[union-attr]
 
         resp = client.post(
             f"/admin/games/{game_id}/terminate",
@@ -602,9 +616,21 @@ class TestGameTermination:
         audit_repo.create_and_append.assert_awaited_once()
 
     def test_terminate_game_not_active_returns_error(self, settings: Settings) -> None:
-        """EC-26: UPDATE returns no rows → 404 GAME_NOT_FOUND_OR_NOT_ACTIVE."""
+        """EC-26.2: Game exists but is non-active → 409 GAME_ALREADY_TERMINATED."""
         client = _build_client(settings)
-        client.app.state.pg = _mock_pg_with_rows([])  # type: ignore[union-attr]
+
+        # SELECT returns a row with status="ended" (game found, but non-terminable)
+        select_result = MagicMock()
+        ended_row = MagicMock()
+        ended_row.status = "ended"
+        select_result.first.return_value = ended_row
+
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=select_result)
+        mock_session.commit = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        client.app.state.pg = MagicMock(return_value=mock_session)  # type: ignore[union-attr]
 
         resp = client.post(
             f"/admin/games/{uuid.uuid4()}/terminate",
@@ -612,9 +638,9 @@ class TestGameTermination:
             headers=_auth_headers(),
         )
 
-        assert resp.status_code == 404
+        assert resp.status_code == 409
         body = resp.json()
-        assert "GAME_NOT_FOUND_OR_NOT_ACTIVE" in str(body)
+        assert "GAME_ALREADY_TERMINATED" in str(body)
 
     def test_terminate_requires_reason_min_length(self, settings: Settings) -> None:
         """EC-26.4: TerminateRequest.reason min_length=10 → 422."""
@@ -628,17 +654,27 @@ class TestGameTermination:
 
         assert resp.status_code == 422
 
-    def test_terminate_already_completed_returns_error(
-        self, settings: Settings
-    ) -> None:
-        """Completed/ended games share the same NOT_ACTIVE code path as not-found."""
+    def test_terminate_game_not_found_returns_404(self, settings: Settings) -> None:
+        """EC-26.2: Game does not exist → 404 GAME_NOT_FOUND."""
         client = _build_client(settings)
-        client.app.state.pg = _mock_pg_with_rows([])  # type: ignore[union-attr]
+
+        # SELECT returns None (game not found)
+        select_result = MagicMock()
+        select_result.first.return_value = None
+
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=select_result)
+        mock_session.commit = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        client.app.state.pg = MagicMock(return_value=mock_session)  # type: ignore[union-attr]
 
         resp = client.post(
             f"/admin/games/{uuid.uuid4()}/terminate",
-            json={"reason": "Attempting to terminate already ended game"},
+            json={"reason": "Attempting to terminate a non-existent game"},
             headers=_auth_headers(),
         )
 
         assert resp.status_code == 404
+        body = resp.json()
+        assert "GAME_NOT_FOUND" in str(body)

--- a/tests/unit/api/test_admin.py
+++ b/tests/unit/api/test_admin.py
@@ -10,10 +10,12 @@ Spec references:
   - AC-26.7: Audit log is append-only, immutable, queryable by time/action/admin
   - AC-26.8: Health endpoint reports all subsystem statuses
 """
+# ruff: noqa: E501
 
 from __future__ import annotations
 
 import uuid
+from datetime import UTC
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -225,3 +227,228 @@ class TestAdminMetrics:
         resp = client.get("/admin/metrics", headers=_auth_headers())
         assert resp.status_code == 200
         assert "text/plain" in resp.headers.get("content-type", "")
+
+
+# ── Shared pg-mock helper ────────────────────────────────────────
+
+
+def _mock_pg_with_rows(rows: list) -> MagicMock:
+    """Build a pg context-manager mock that returns *rows* on execute()."""
+    mock_result = MagicMock()
+    mock_result.first.return_value = rows[0] if rows else None
+    mock_result.all.return_value = rows
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.commit = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=mock_session)
+
+
+# ── AC-26.2: Player search ───────────────────────────────────────
+
+
+class TestPlayerSearch:
+    """GET /admin/players?search=... (AC-26.2)."""
+
+    def _make_player_row(
+        self,
+        handle: str = "CoolDragon42",
+        status: str = "active",
+    ) -> MagicMock:
+        from datetime import datetime
+
+        row = MagicMock()
+        row.id = uuid.uuid4()
+        row.handle = handle
+        row.status = status
+        row.created_at = datetime(2025, 1, 1, tzinfo=UTC)
+        return row
+
+    def test_search_by_handle_prefix_returns_matches(self, settings: Settings) -> None:
+        client = _build_client(settings)
+        row = self._make_player_row(handle="CoolDragon42")
+        client.app.state.pg = _mock_pg_with_rows([row])  # type: ignore[union-attr]
+
+        resp = client.get(
+            "/admin/players?search=CoolDragon",
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "players" in body
+        assert len(body["players"]) == 1
+        assert body["players"][0]["handle"] == "CoolDragon42"
+
+    def test_empty_search_returns_all_players(self, settings: Settings) -> None:
+        client = _build_client(settings)
+        rows = [
+            self._make_player_row(handle="Alice"),
+            self._make_player_row(handle="Bob"),
+        ]
+        client.app.state.pg = _mock_pg_with_rows(rows)  # type: ignore[union-attr]
+
+        resp = client.get("/admin/players", headers=_auth_headers())
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["players"]) == 2
+
+    def test_no_matching_search_returns_empty_not_404(self, settings: Settings) -> None:
+        client = _build_client(settings)
+        client.app.state.pg = _mock_pg_with_rows([])  # type: ignore[union-attr]
+
+        resp = client.get(
+            "/admin/players?search=NoSuchHandle",
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["players"] == []
+
+    def test_next_cursor_set_when_results_exist(self, settings: Settings) -> None:
+        client = _build_client(settings)
+        row = self._make_player_row()
+        client.app.state.pg = _mock_pg_with_rows([row])  # type: ignore[union-attr]
+
+        resp = client.get("/admin/players", headers=_auth_headers())
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["next_cursor"] is not None
+        assert body["next_cursor"] == str(row.id)
+
+    def test_next_cursor_null_when_empty(self, settings: Settings) -> None:
+        client = _build_client(settings)
+        client.app.state.pg = _mock_pg_with_rows([])  # type: ignore[union-attr]
+
+        resp = client.get("/admin/players", headers=_auth_headers())
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["next_cursor"] is None
+
+
+# ── AC-26.3: Suspend / unsuspend ────────────────────────────────
+
+
+class TestSuspendUnsuspend:
+    """POST /admin/players/{id}/suspend and /unsuspend (AC-26.3)."""
+
+    def test_suspend_success_returns_200_and_audit(self, settings: Settings) -> None:
+        client = _build_client(settings)
+        player_id = uuid.uuid4()
+        updated_row = MagicMock()
+        updated_row.id = player_id
+        client.app.state.pg = _mock_pg_with_rows(  # type: ignore[union-attr]
+            [updated_row]
+        )
+
+        resp = client.post(
+            f"/admin/players/{player_id}/suspend",
+            json={"reason": "Repeated TOS violations over multiple sessions"},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "suspended"
+        assert body["player_id"] == str(player_id)
+
+        # Audit entry must have been created
+        audit_repo = client.app.state.audit_repo  # type: ignore[union-attr]
+        audit_repo.create_and_append.assert_awaited_once()
+
+    def test_unsuspend_success_returns_200(self, settings: Settings) -> None:
+        client = _build_client(settings)
+        player_id = uuid.uuid4()
+        updated_row = MagicMock()
+        updated_row.id = player_id
+        client.app.state.pg = _mock_pg_with_rows(  # type: ignore[union-attr]
+            [updated_row]
+        )
+
+        resp = client.post(
+            f"/admin/players/{player_id}/unsuspend",
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "active"
+        assert body["player_id"] == str(player_id)
+
+    def test_suspend_already_suspended_returns_error(self, settings: Settings) -> None:
+        """EC-26.1: UPDATE returns no rows → error with PLAYER_NOT_FOUND_OR_ALREADY_SUSPENDED."""
+        client = _build_client(settings)
+        # first() returns None → player not found or already suspended
+        client.app.state.pg = _mock_pg_with_rows([])  # type: ignore[union-attr]
+
+        resp = client.post(
+            f"/admin/players/{uuid.uuid4()}/suspend",
+            json={"reason": "Repeated TOS violations"},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code in (400, 404, 409)
+        body = resp.json()
+        assert "PLAYER_NOT_FOUND_OR_ALREADY_SUSPENDED" in str(body)
+
+    def test_suspend_short_reason_returns_422(self, settings: Settings) -> None:
+        """EC-26.4: SuspendRequest.reason min_length=10 → 422 validation error."""
+        client = _build_client(settings)
+        resp = client.post(
+            f"/admin/players/{uuid.uuid4()}/suspend",
+            json={"reason": "short"},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+
+# ── AC-26.3 / get_player success path ───────────────────────────
+
+
+class TestGetPlayerSuccess:
+    """GET /admin/players/{id} — success path (complement to 404 test)."""
+
+    def test_get_player_returns_full_profile(self, settings: Settings) -> None:
+        from datetime import datetime
+
+        client = _build_client(settings)
+        player_id = uuid.uuid4()
+
+        player_row = MagicMock()
+        player_row.id = player_id
+        player_row.handle = "HeroPlayer99"
+        player_row.status = "active"
+        player_row.suspended_reason = None
+        player_row.created_at = datetime(2025, 3, 15, tzinfo=UTC)
+
+        counts_row = MagicMock()
+        counts_row.total = 5
+        counts_row.active = 2
+
+        # pg is called twice: once for player, once for game counts.
+        # We need each call to return its own result.
+        player_result = MagicMock()
+        player_result.first.return_value = player_row
+
+        counts_result = MagicMock()
+        counts_result.first.return_value = counts_row
+
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(side_effect=[player_result, counts_result])
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        client.app.state.pg = MagicMock(  # type: ignore[union-attr]
+            return_value=mock_session
+        )
+
+        resp = client.get(
+            f"/admin/players/{player_id}",
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["player_id"] == str(player_id)
+        assert body["handle"] == "HeroPlayer99"
+        assert body["status"] == "active"
+        assert "created_at" in body
+        assert "games" in body
+        assert body["games"]["total"] == 5
+        assert body["games"]["active"] == 2
+        assert "rate_limit" in body


### PR DESCRIPTION
## Summary

- **37 new tests** (49 total) covering all 8 S26 ACs: player management, game inspection/termination, moderation flag review, rate-limit reset, and audit log completeness
- **2 implementation fixes** in `admin.py`: atomic `UPDATE...RETURNING` for `terminate_game` (eliminates TOCTOU race), and proper 404/409 disambiguation for `suspend_player`
- **`specs/index.json`** updated with per-AC compliance tracking for S26 (8/8 done, 100%)

## Test Plan

- [ ] `uv run python -m pytest tests/unit/api/test_admin.py` — 49 tests pass
- [ ] `uv run python -m pytest tests/unit/` — 1817 tests pass, 0 failures
- [ ] `make validate-all` — spec/plan validators pass cleanly
- [ ] All 8 AC Gherkin scenarios covered: AC-26.1 through AC-26.8

🤖 Generated with [Claude Code](https://claude.ai/claude-code)