### PR TITLE
[Spec] Reconcile S10 with S23/S27 for API error/lifecycle/health contracts

### DIFF
--- a/plans/api-and-sessions.md
+++ b/plans/api-and-sessions.md
@@ -522,9 +522,10 @@ class UpdateGameRequest(BaseModel):
 
 **Response (204 No Content):**
 
-- Requires `confirm=true` in request body.
+- Requires `confirm=true` as a query parameter.
 - Soft delete transitions status to `abandoned` and records `deleted_at` (S27 FR-27.16).
 - Requests without confirmation return 400 `CONFIRM_REQUIRED` (S27 FR-27.18).
+- A `204` response never includes a response body.
 
 ### 2.13 — Health Endpoints
 
@@ -558,7 +559,7 @@ If any required check fails → 503 with the failing check identified (S23 FR-23
 | `POST` | `/api/v1/games/{id}/save` | Yes | 10/hr | 200 | Save game |
 | `POST` | `/api/v1/games/{id}/resume` | Yes | 10/hr | 200 / 422 | Resume game |
 | `PATCH` | `/api/v1/games/{id}` | Yes | 10/hr | 200 / 422 | Pause game |
-| `DELETE` | `/api/v1/games/{id}` | Yes | 10/hr | 204 / 400 / 404 / 409 | Soft-delete game |
+| `DELETE` | `/api/v1/games/{id}?confirm=true` | Yes | 10/hr | 204 / 400 / 404 / 409 | Soft-delete game |
 | `GET` | `/api/v1/health` | No | None | 200 / 503 | Health |
 | `GET` | `/api/v1/health/ready` | No | None | 200 / 503 | Readiness |
 
@@ -1516,7 +1517,10 @@ async def validation_error_handler(
     )
 
 async def unhandled_error_handler(request: Request, exc: Exception) -> JSONResponse:
-    structlog.get_logger().exception("unhandled_error", request_id=request.state.request_id)
+    structlog.get_logger().exception(
+        "unhandled_error",
+        correlation_id=request.state.request_id,
+    )
     return JSONResponse(
         status_code=500,
         content={

--- a/plans/api-and-sessions.md
+++ b/plans/api-and-sessions.md
@@ -35,6 +35,19 @@ or plan update can tighten these values.
 S11 references ULID-style identifiers. The codebase uses UUID4 throughout. Keeping
 UUID4 for consistency; ULID migration deferred to a future spec if needed.
 
+### 0.4 — S10/S23/S27 Contract Reconciliation (Issue #128)
+
+**Decision**: Canonical API contracts are reconciled as follows:
+
+- `POST /games/{id}/turns` whitespace-only input uses `400 input_invalid` (S23 taxonomy).
+- `DELETE /games/{id}` is a soft-delete to `abandoned` with confirmation semantics (S27).
+- Health/readiness public routes are `/api/v1/health` and `/api/v1/health/ready`.
+- Error envelope trace field is `correlation_id` (sourced from request correlation context).
+
+**Migration note**: Implementations or clients using legacy `request_id` naming in error
+payloads should migrate to `correlation_id`; internal request state naming may remain
+`request_id` as an implementation detail.
+
 ## 1. FastAPI Application Structure
 
 ### 1.1 — Application Factory
@@ -454,7 +467,8 @@ class TurnAccepted(BaseModel):
 8. Return 202 immediately (within 500ms — FR-10.05).
 
 - Rate limit: 10 per minute per session (FR-10.61).
-- Empty/whitespace input → 422 (FR-10.08). Over 2000 chars → 422 (FR-10.09).
+- Empty/whitespace input → 400 `input_invalid` (FR-10.08 / S23 FR-23.01).
+  Over 2000 chars → 422 (FR-10.09).
 
 ### 2.8 — Game SSE Stream (`GET /api/v1/games/{game_id}/stream`)
 
@@ -501,41 +515,33 @@ class UpdateGameRequest(BaseModel):
 
 - `active` → `paused` is the only valid explicit transition via this endpoint.
 - `paused` → `active` goes through `POST .../resume`.
-- `active` → `ended` goes through `DELETE .../`.
+- `active` → `abandoned` goes through `DELETE .../`.
 - Invalid transitions return 422 `INVALID_STATE_TRANSITION` (FR-11.39).
 
-### 2.12 — End Game (`DELETE /api/v1/games/{game_id}`)
+### 2.12 — Delete Game (`DELETE /api/v1/games/{game_id}`)
 
-**Response (200 OK):**
+**Response (204 No Content):**
 
-```python
-class GameEndedResponse(BaseModel):
-    data: GameEndedData
-
-class GameEndedData(BaseModel):
-    game_id: str
-    status: str         # "ended"
-    turn_count: int
-    ended_at: datetime
-```
-
-Soft delete: transitions status to `ended`, clears Redis cache. Game data is retained
-(FR-10.19). An ended game rejects new turns (FR-10.20).
+- Requires `confirm=true` in request body.
+- Soft delete transitions status to `abandoned` and records `deleted_at` (S27 FR-27.16).
+- Requests without confirmation return 400 `CONFIRM_REQUIRED` (S27 FR-27.18).
 
 ### 2.13 — Health Endpoints
 
-**`GET /api/v1/health`** — Liveness. Returns `200 {"status": "ok"}`. No auth, no
-dependency checks (FR-10.23/24).
+**`GET /api/v1/health`** — Health contract from S23 FR-23.23/24. Returns tri-state
+status (`healthy`/`degraded`/`unhealthy`) with per-service checks and version metadata.
+No auth.
 
-**`GET /api/v1/health/ready`** — Readiness. Pings Postgres, Redis, Neo4j. Returns 200 or 503.
+**`GET /api/v1/health/ready`** — Readiness contract from S23 FR-23.25. Returns 200 only
+when required services are available; otherwise 503.
 
 ```python
 class ReadyResponse(BaseModel):
-    status: str                         # "ready" or "degraded"
-    checks: dict[str, str]              # {"database": "ok", "cache": "ok", "graph": "ok"}
+    status: str                    # "ready" or "not_ready"
+    checks: dict[str, str]         # {"postgres": "ok", "redis": "ok", "neo4j": "ok"}
 ```
 
-If any check fails → 503 with the failing check identified (FR-10.26).
+If any required check fails → 503 with the failing check identified (S23 FR-23.25).
 
 ### 2.14 — Endpoint Summary Table
 
@@ -552,8 +558,8 @@ If any check fails → 503 with the failing check identified (FR-10.26).
 | `POST` | `/api/v1/games/{id}/save` | Yes | 10/hr | 200 | Save game |
 | `POST` | `/api/v1/games/{id}/resume` | Yes | 10/hr | 200 / 422 | Resume game |
 | `PATCH` | `/api/v1/games/{id}` | Yes | 10/hr | 200 / 422 | Pause game |
-| `DELETE` | `/api/v1/games/{id}` | Yes | 10/hr | 200 / 404 | End game |
-| `GET` | `/api/v1/health` | No | None | 200 | Liveness |
+| `DELETE` | `/api/v1/games/{id}` | Yes | 10/hr | 204 / 400 / 404 / 409 | Soft-delete game |
+| `GET` | `/api/v1/health` | No | None | 200 / 503 | Health |
 | `GET` | `/api/v1/health/ready` | No | None | 200 / 503 | Readiness |
 
 ---
@@ -1461,7 +1467,7 @@ Every error response uses a consistent envelope:
     "code": "TURN_IN_PROGRESS",
     "message": "A turn is already being processed for this game.",
     "details": {},
-    "request_id": "a1b2c3d4-..."
+    "correlation_id": "a1b2c3d4-..."
   }
 }
 ```
@@ -1489,7 +1495,7 @@ async def app_error_handler(request: Request, exc: AppError) -> JSONResponse:
                 "code": exc.code,
                 "message": exc.message,
                 "details": exc.details,
-                "request_id": request.state.request_id,
+                "correlation_id": request.state.request_id,
             }
         },
     )
@@ -1504,7 +1510,7 @@ async def validation_error_handler(
                 "code": "VALIDATION_ERROR",
                 "message": "Request validation failed.",
                 "details": {"errors": exc.errors()},
-                "request_id": request.state.request_id,
+                "correlation_id": request.state.request_id,
             }
         },
     )
@@ -1518,7 +1524,7 @@ async def unhandled_error_handler(request: Request, exc: Exception) -> JSONRespo
                 "code": "INTERNAL_ERROR",
                 "message": "An unexpected error occurred.",
                 "details": {},
-                "request_id": request.state.request_id,
+                "correlation_id": request.state.request_id,
             }
         },
     )

--- a/plans/resilience-and-safety.md
+++ b/plans/resilience-and-safety.md
@@ -15,7 +15,7 @@ This plan implements S23, S24, and S25 subject to system.md overrides:
 
 | Conflict | Resolution |
 |----------|------------|
-| S23 defines health check endpoint at `/health` | **Aligned with existing implementation.** Health checks are already at `/api/v1/health` per ops.md. S23's readiness endpoint maps to `/api/v1/health/ready`. |
+| S23 health paths previously referenced `/health`/`/ready` | **Canonicalized.** Public health endpoints are `/api/v1/health` and `/api/v1/health/ready` across S10, S23, plans, and implementation. |
 | S24 requires stream interruption within 2 tokens | **v1 uses buffer-then-stream** (system.md §2.4). Content moderation inspects the complete buffer before streaming begins, so stream interruption means cancelling the buffer-to-SSE delivery — not interrupting the LLM stream. |
 | S25 defines Redis-backed rate limiting | **Aligned.** Redis is already a required service. Rate limit counters use the same Redis instance with a `ratelimit:` key prefix. |
 

--- a/specs/01-gameplay-loop.md
+++ b/specs/01-gameplay-loop.md
@@ -112,10 +112,9 @@ see the first token within 2 seconds under normal conditions.
 **FR-1.3** — The system MUST NOT accept new player input while a response is still
 streaming. The input prompt appears only after streaming completes.
 
-**FR-1.4** — If the player submits empty or whitespace-only input, the system responds
-with an in-world prompt: a gentle narrative nudge, not an error message.
-Example: *"You stand still for a moment, the sounds of the marketplace washing over
-you. What draws your attention?"*
+**FR-1.4** — If the player submits empty or whitespace-only input, the API boundary
+returns `400 input_invalid` (per S10/S23). Client UX MAY render a gentle narrative nudge
+copy as presentation behavior.
 
 ### FR-2: Turn Types
 

--- a/specs/08-turn-processing-pipeline.md
+++ b/specs/08-turn-processing-pipeline.md
@@ -110,7 +110,8 @@ Transform raw player text into structured understanding of player intent. This i
 
 **FR-08.06**: The system SHALL validate input length. Inputs exceeding the maximum length (configurable, default: 2000 characters) SHALL be truncated with a player-facing note.
 
-**FR-08.07**: Empty or whitespace-only input SHALL be handled gracefully — the system responds with a gentle narrative prompt (e.g. "You pause, considering your options…") without treating it as an error.
+**FR-08.07**: Empty or whitespace-only input SHALL be rejected at the API boundary with
+`400 input_invalid` (per S10/S23). The turn pipeline stage is not invoked for this case.
 
 ### 4.5 — LLM usage in this stage
 
@@ -497,10 +498,11 @@ Scenario: Gibberish input produces a graceful response
   Then the intent is classified as "other" with confidence below 0.5
   And the system produces an in-character narrative response, not an error
 
-Scenario: Empty input produces a narrative prompt
+Scenario: Empty input is rejected at API boundary
   Given a player is in an active session
   When the player submits an empty string or whitespace
-  Then the system responds with a gentle narrative prompt (e.g. "You pause, considering your options…")
+  Then the API returns 400 with error category "input_invalid"
+  And the turn does not enter the pipeline stages
 
 Scenario: Meta-command is detected and routed separately
   Given a player is in an active session

--- a/specs/10-api-and-streaming.md
+++ b/specs/10-api-and-streaming.md
@@ -138,7 +138,8 @@ pipeline and streams narrative back.
   accepted.
 - FR-10.07: If a turn is already in progress for this game, the server MUST return
   `409 Conflict` with a message indicating the active turn.
-- FR-10.08: Empty or whitespace-only input MUST be rejected with `422 Unprocessable Entity`.
+- FR-10.08: Empty or whitespace-only input MUST be rejected with `400 Bad Request`
+  and error category `input_invalid` (per S23 FR-23.01).
 - FR-10.09: Input exceeding 2000 characters MUST be rejected with `422`.
 
 ### 5.2 Session / Game Management
@@ -203,8 +204,8 @@ End and archive a game.
 
 **Behavior:**
 - FR-10.19: This is a soft delete. Game data is retained for the player's history but the
-  game transitions to "ended" status.
-- FR-10.20: An ended game MUST NOT accept new turns.
+  game transitions to "abandoned" status (per S27 FR-27.16).
+- FR-10.20: An abandoned game MUST NOT accept new turns.
 
 ### 5.3 Player Profile
 
@@ -229,25 +230,22 @@ Update profile or preferences.
 
 ### 5.4 Health & Operations
 
-#### `GET /health`
+#### `GET /api/v1/health`
 
-Liveness probe. Returns `200 OK` if the process is running.
-
-**Response:** `{"status": "ok"}`
+Health probe. Canonical response semantics are defined in S23 FR-23.23/24.
 
 **Behavior:**
-- FR-10.23: This endpoint MUST NOT check downstream dependencies.
+- FR-10.23: This endpoint contract (status model, checks, and dependency semantics) is
+  defined by S23 FR-23.23/FR-23.24.
 - FR-10.24: This endpoint MUST NOT require authentication.
 
-#### `GET /ready`
+#### `GET /api/v1/health/ready`
 
-Readiness probe. Returns `200 OK` if the service can accept traffic.
-
-**Response:** `{"status": "ready", "checks": {"database": "ok", "cache": "ok", "graph": "ok"}}`
+Readiness probe. Canonical response semantics are defined in S23 FR-23.25.
 
 **Behavior:**
-- FR-10.25: This endpoint MUST verify connectivity to all required backends (SQL, Redis,
-  Neo4j).
+- FR-10.25: This endpoint contract (readiness gating and required services) is defined
+  by S23 FR-23.25.
 - FR-10.26: If any backend is unreachable, return `503 Service Unavailable` with the
   failing check identified.
 - FR-10.27: This endpoint MUST NOT require authentication.
@@ -386,7 +384,7 @@ followed by a single `narrative_end` event.
     "code": "TURN_IN_PROGRESS",
     "message": "A turn is already being processed for this game.",
     "details": { ... },     // optional, context-specific
-    "request_id": "..."     // trace identifier
+    "correlation_id": "..." // trace identifier
   }
 }
 ```
@@ -394,7 +392,8 @@ followed by a single `narrative_end` event.
 - FR-10.51: All error responses MUST use the `error` wrapper.
 - FR-10.52: The `code` field MUST be a stable, machine-readable string (UPPER_SNAKE_CASE).
 - FR-10.53: The `message` field MUST be a human-readable explanation safe to display.
-- FR-10.54: Every error response MUST include a `request_id` for tracing.
+- FR-10.54: Every error response MUST include a `correlation_id` for tracing (matching
+  the request correlation ID semantics in S23 FR-23.03).
 
 ### 8.2 HTTP Status Code Usage
 
@@ -403,7 +402,7 @@ followed by a single `narrative_end` event.
 | `200` | Successful retrieval or update |
 | `201` | Resource created |
 | `202` | Turn accepted, processing asynchronously |
-| `400` | Malformed request (bad JSON, missing fields) |
+| `400` | Malformed request or `input_invalid` category errors |
 | `401` | Missing or invalid authentication |
 | `403` | Authenticated but not authorized for this resource |
 | `404` | Resource not found (or not owned by this player) |
@@ -425,7 +424,8 @@ followed by a single `narrative_end` event.
 Authentication is defined in S11. This section specifies how auth tokens flow through
 the API.
 
-- FR-10.57: All endpoints except `/health`, `/ready`, and `/api/v1/auth/*` MUST require
+- FR-10.57: All endpoints except `/api/v1/health`, `/api/v1/health/ready`, and
+  `/api/v1/auth/*` MUST require
   a valid `Authorization: Bearer <token>` header.
 - FR-10.58: SSE connections MUST validate the token at connection time. If the token
   expires during an active SSE connection, the connection MAY remain open until the next
@@ -577,7 +577,10 @@ the API.
 
 - **AC-10.09**: No API response ever contains stack traces, file paths, or internal
   implementation details.
-- **AC-10.10**: Every error response includes a `request_id` that can be found in server logs.
+- **AC-10.10**: Every error response includes a `correlation_id` that can be found in
+  server logs.
+- **AC-10.13**: Submitting a turn with empty or whitespace-only input returns `400` with
+  error category `input_invalid`.
 
 ### Security
 
@@ -611,3 +614,17 @@ the API.
   within the stream? Needs playtesting data.
 - OQ-10.04: Should admin endpoints live under `/api/v1/admin/` or use the same paths
   with role-based visibility? Leaning toward separate prefix for clarity.
+
+---
+
+## 17. Migration Notes (Issue #128)
+
+- **Input validation status alignment**: `FR-10.08` now requires `400 input_invalid`
+  (instead of `422`) to align with S23's canonical error taxonomy.
+- **Lifecycle alignment**: `DELETE /api/v1/games/{game_id}` now normatively maps to
+  `abandoned` (soft-delete) per S27, rather than `ended`.
+- **Health/readiness path + ownership alignment**: S10 now defines canonical public paths
+  (`/api/v1/health`, `/api/v1/health/ready`) and delegates behavior semantics to S23.
+- **Error envelope identifier alignment**: `correlation_id` is canonical in the error
+  envelope. Implementations MAY continue to source it from `request.state.request_id`
+  internally, but response field naming is `correlation_id`.

--- a/specs/14-deployment.md
+++ b/specs/14-deployment.md
@@ -83,7 +83,7 @@ This spec describes behavior: what a developer or operator does, and what the sy
 
 | Container | Health Check |
 |-----------|-------------|
-| `tta-api` | `GET /health` returns 200 |
+| `tta-api` | `GET /api/v1/health` returns 200 or 503 per S23 health semantics |
 | `tta-worker` | Process is alive and task queue is reachable |
 | `tta-neo4j` | Cypher query `RETURN 1` succeeds |
 | `tta-redis` | `PING` returns `PONG` |
@@ -324,8 +324,8 @@ This spec describes behavior: what a developer or operator does, and what the sy
 
 | Endpoint | Purpose | Response |
 |----------|---------|----------|
-| `GET /health` | Shallow liveness check | `200 {"status": "ok"}` |
-| `GET /health/ready` | Deep readiness check (all dependencies) | `200` or `503` with details |
+| `GET /api/v1/health` | Health check (tri-state) | `200` or `503` with status/checks/version (per S23 FR-23.23/24) |
+| `GET /api/v1/health/ready` | Deep readiness check (all dependencies) | `200` or `503` with details |
 
 **FR-14.34**: The readiness check SHALL verify:
 - PostgreSQL is reachable and schema is current.
@@ -351,9 +351,9 @@ This spec describes behavior: what a developer or operator does, and what the sy
 
 ### 9.2 Acceptance Criteria
 
-- [ ] `GET /health` returns 200 even when Neo4j is temporarily slow.
-- [ ] `GET /health/ready` returns 503 when PostgreSQL is down.
-- [ ] `GET /health/ready` returns `degraded` when Redis is down but PostgreSQL and Neo4j are up.
+- [ ] `GET /api/v1/health` returns 200 with status `degraded` when Neo4j is temporarily slow.
+- [ ] `GET /api/v1/health/ready` returns 503 when PostgreSQL is down.
+- [ ] `GET /api/v1/health/ready` returns 503 with status `not_ready` when Redis is down but PostgreSQL and Neo4j are up.
 - [ ] Health check response includes latency for each dependency.
 
 ---
@@ -391,7 +391,7 @@ Scenario: Fresh stack starts from clone
   And the developer runs "cp .env.example .env"
   When the developer runs "docker compose up -d"
   Then all 5 containers reach "healthy" status within 120 seconds
-  And "GET /health" returns 200 with status "ok"
+  And "GET /api/v1/health" returns 200 with status "healthy"
 
 Scenario: Stack restart preserves data
   Given the full stack is running with player data in PostgreSQL and Neo4j
@@ -409,8 +409,8 @@ Scenario: Missing required env var fails fast
 Scenario: Health readiness degrades when Redis is down
   Given the full stack is running and healthy
   When Redis becomes unreachable
-  Then "GET /health" still returns 200
-  And "GET /health/ready" returns 503 with status "degraded"
+  Then "GET /api/v1/health" still returns 200 with status "degraded"
+  And "GET /api/v1/health/ready" returns 503 with status "not_ready"
   And the response body shows redis status as "fail"
   And postgres and neo4j statuses remain "ok"
 ```

--- a/specs/14-deployment.md
+++ b/specs/14-deployment.md
@@ -333,21 +333,23 @@ This spec describes behavior: what a developer or operator does, and what the sy
 - Redis is reachable.
 - At least one LLM provider is configured (key present, not necessarily reachable).
 
-**FR-14.35**: The readiness check SHALL return a JSON body listing each dependency and its status:
+**FR-14.35**: The readiness check SHALL return a JSON body listing each dependency and
+its status:
 
 ```json
 {
-  "status": "degraded",
+  "status": "not_ready",
   "checks": {
-    "postgres": {"status": "ok", "latency_ms": 2},
-    "neo4j": {"status": "ok", "latency_ms": 15},
-    "redis": {"status": "fail", "error": "connection refused"},
-    "llm_config": {"status": "ok"}
+    "postgres": "ok",
+    "neo4j": "ok",
+    "redis": "unavailable",
+    "llm": "ok"
   }
 }
 ```
 
-**FR-14.36**: The overall status SHALL be `ok` if all checks pass, `degraded` if non-critical checks fail, and `fail` if any critical check fails. PostgreSQL and Neo4j are critical. Redis is critical for gameplay but not for health. LLM config is informational.
+**FR-14.36**: The readiness status SHALL be `ready` when all required checks are
+available. Otherwise it SHALL be `not_ready` and the endpoint SHALL return HTTP 503.
 
 ### 9.2 Acceptance Criteria
 

--- a/specs/23-error-handling-and-resilience.md
+++ b/specs/23-error-handling-and-resilience.md
@@ -242,7 +242,7 @@ reconnect.
 
 ### 3.7 — Health and Readiness
 
-**FR-23.23**: The system SHALL expose a `/health` endpoint that returns:
+**FR-23.23**: The system SHALL expose a `/api/v1/health` endpoint that returns:
 - `status`: "healthy", "degraded", or "unhealthy"
 - `checks`: object with per-service health (postgres, redis, neo4j, llm)
 - `version`: application version string
@@ -251,9 +251,9 @@ reconnect.
 Neo4j) is unavailable but the core game loop can still function (with reduced features).
 "Unhealthy" SHALL be returned only when PostgreSQL is unreachable.
 
-**FR-23.25**: The system SHALL expose a `/ready` endpoint that returns 200 only when all
-required services are connected and the application is ready to accept player requests.
-Orchestrators SHALL use this for traffic routing.
+**FR-23.25**: The system SHALL expose a `/api/v1/health/ready` endpoint that returns
+200 only when all required services are connected and the application is ready to accept
+player requests. Orchestrators SHALL use this for traffic routing.
 
 ---
 
@@ -320,7 +320,8 @@ player-visible error to the operator-visible details.
   7. PostgreSQL recovers. Half-open probe succeeds. Circuit closes.
   8. Player retries — turn processes normally.
 - **Happy path**: Database recovers quickly, circuit closes, player resumes.
-- **Alternative path**: Extended outage. `/health` reports "unhealthy." Operator is alerted.
+- **Alternative path**: Extended outage. `/api/v1/health` reports "unhealthy."
+  Operator is alerted.
 
 ### Journey 3: Player submits malformed input
 
@@ -350,7 +351,7 @@ player-visible error to the operator-visible details.
 |---|----------|-------------------|
 | EC-23.1 | Error occurs during error handling (logging fails) | System uses fallback stderr logging. Player still sees standard error response. |
 | EC-23.2 | Client disconnects before error response is sent | Error is logged. Turn state is updated. No player notification possible — client reconnect will show current state. |
-| EC-23.3 | Multiple services fail simultaneously | Circuit breakers open independently. `/health` reports each service's status. Player sees most relevant error (database > LLM > Redis). |
+| EC-23.3 | Multiple services fail simultaneously | Circuit breakers open independently. `/api/v1/health` reports each service's status. Player sees most relevant error (database > LLM > Redis). |
 | EC-23.4 | Error response body exceeds reasonable size | Error responses are capped at the standard envelope (FR-23.02). No unbounded data in error responses. |
 | EC-23.5 | Retry succeeds but response is too slow | Player-facing timeout (60s per NFR-23.2) applies to the entire operation including retries. After 60s, return `service_unavailable`. |
 | EC-23.6 | Circuit breaker flaps (service repeatedly fails and recovers) | Exponential cooldown: each consecutive open→close→open cycle doubles the cooldown period, up to a maximum of 5 minutes. |
@@ -431,7 +432,7 @@ Feature: Error Handling & Resilience
   Scenario: AC-23.9 — Health endpoint reports degraded
     Given Redis is unreachable
     And PostgreSQL is healthy
-    When GET /health is called
+    When GET /api/v1/health is called
     Then the response contains status "degraded"
     And the "checks.redis" field indicates unhealthy
     And the "checks.postgres" field indicates healthy
@@ -452,7 +453,7 @@ Feature: Error Handling & Resilience
 
   Scenario: AC-23.12 — Health endpoint reports unhealthy
     Given PostgreSQL is unreachable
-    When GET /health is called
+    When GET /api/v1/health is called
     Then the response status is 503
     And the response contains status "unhealthy"
 ```
@@ -479,7 +480,7 @@ Feature: Error Handling & Resilience
 |------|-------------|----------|
 | S07 (LLM Integration) | Extends | S07 defines LLM-specific fallback tiers. S23 wraps LLM failures in the standard error taxonomy and adds circuit-breaking. S23 does not override S07 tier behavior — it standardizes the error surface after all tiers are exhausted. |
 | S08 (Turn Pipeline) | Extends | S08 defines pipeline stages. S23 defines what happens when any stage fails: turn atomicity (FR-23.16–23.18), error propagation, and player notification. |
-| S10 (API & Streaming) | Extends | S10 defines HTTP error shapes. S23 consolidates them into a single taxonomy (FR-23.01) and adds SSE error events (FR-23.20). S10's error codes MUST map to S23's categories. |
+| S10 (API & Streaming) | Extends | S10 defines HTTP routing/auth integration. S23 is canonical for error taxonomy/envelope and health semantics. S10's error/status contracts and health paths MUST map to S23 FR-23.01-03 and FR-23.23-25. |
 | S12 (Persistence) | Requires | S23 requires transactional semantics for turn atomicity. S12 must support atomic writes and rollback for turn state. |
 | S15 (Observability) | Cooperates | S23 defines error log structure (FR-23.06–23.08). S15 defines the logging infrastructure and dashboards. Error metrics from S23 are exposed via S15's metric pipeline. |
 | S17 (Data Privacy) | Constrains | S23's error logging must NOT include PII (FR-23.08). Error context references IDs, not data values. |
@@ -507,6 +508,18 @@ Feature: Error Handling & Resilience
 - **Error rate-based auto-scaling** — Scaling is handled in S28. — Handled in S28.
 - **User-facing error telemetry** — Client-side error tracking (Sentry for frontend) is not in v1 scope. — Deferred.
 - **LLM fallback tier design** — Tier structure and model selection are S07's responsibility. S23 handles what happens after all tiers are exhausted. — Handled in S07.
+
+---
+
+## 11. Migration Notes (Issue #128)
+
+- Public health/readiness paths are canonicalized as `/api/v1/health` and
+  `/api/v1/health/ready`.
+- `correlation_id` remains the canonical envelope field for traceability.
+  `request_id` naming is non-normative legacy terminology and should not appear in
+  response schemas.
+- Input validation category `input_invalid` remains canonical at HTTP 400 (including
+  whitespace-only turn input).
 
 ---
 

--- a/specs/24-content-moderation-v1.md
+++ b/specs/24-content-moderation-v1.md
@@ -193,7 +193,7 @@ text) in a separate, access-controlled store. General logs SHALL reference the
 down or moderation model fails to load), the system SHALL:
 1. Continue processing turns WITHOUT moderation (fail-open for v1)
 2. Log every unmoderated turn at WARN level
-3. Expose the moderation service status in `/health` (per S23 FR-23.23)
+3. Expose the moderation service status in `/api/v1/health` (per S23 FR-23.23)
 4. Alert the operator immediately
 
 **FR-24.16**: The decision to fail-open vs. fail-closed SHALL be configurable
@@ -292,7 +292,7 @@ audit trail. No moderation decision SHALL be unlogged.
 - **Trigger**: Moderation model fails to load at startup.
 - **Steps**:
   1. Application starts with `TTA_MODERATION_FAIL_MODE=open`.
-  2. Moderation health check fails. `/health` reports moderation as degraded.
+  2. Moderation health check fails. `/api/v1/health` reports moderation as degraded.
   3. Operator alert fires.
   4. Players continue playing. All turns logged as unmoderated (WARN level).
   5. Operator restarts the moderation service. Next moderation check succeeds.

--- a/specs/25-rate-limiting-and-anti-abuse.md
+++ b/specs/25-rate-limiting-and-anti-abuse.md
@@ -235,7 +235,7 @@ tier) and `tta_abuse_detected_total` (counter, labels: pattern_type).
   1. Rate limit middleware detects Redis unavailability.
   2. Falls back to in-memory rate limiting (per-instance, not globally consistent).
   3. Logs warning: "Rate limiting degraded: using in-memory fallback."
-  4. `/health` reports Redis as degraded (per S23).
+  4. `/api/v1/health` reports Redis as degraded (per S23).
   5. When Redis recovers, rate limiting returns to normal.
 - **Outcome**: Rate limiting continues with reduced accuracy. System stays available.
 

--- a/specs/28-performance-and-scaling.md
+++ b/specs/28-performance-and-scaling.md
@@ -80,7 +80,7 @@ load (defined as ≤ 80% of capacity):
 | Turn processing (total) | 10 seconds | Understand: ≤500ms, Enrich: ≤1s, Generate (LLM): ≤7s, Persist: ≤1s, Overhead: ≤500ms |
 | First SSE token | 2 seconds | From turn submission to first narrative_token event |
 | `DELETE /games/{id}` | 500ms | Soft delete: ≤200ms, cleanup: ≤300ms |
-| Health check (`/health`) | 100ms | Subsystem checks: ≤80ms, aggregation: ≤20ms |
+| Health check (`/api/v1/health`) | 100ms | Subsystem checks: ≤80ms, aggregation: ≤20ms |
 
 **FR-28.02**: When a turn's LLM generation exceeds 7 seconds (p95 target), the system
 SHALL NOT add additional latency beyond the specified non-LLM budgets. The LLM is the

--- a/specs/index.json
+++ b/specs/index.json
@@ -858,7 +858,7 @@
         {
           "id": "AC-10.10",
           "ac_status": "done",
-          "description": "Every error response includes a correlation_id (request_id) traceable in server logs"
+          "description": "Every error response includes a correlation_id traceable in server logs"
         },
         {
           "id": "AC-10.11",


### PR DESCRIPTION
Summary:\n- reconcile S10 error contract with S23 canonical taxonomy and envelope: 400 input_invalid and correlation_id\n- reconcile S10 delete lifecycle with S27: DELETE games soft-deletes to abandoned\n- canonicalize health and readiness public paths as /api/v1/health and /api/v1/health/ready\n- propagate these contracts to dependent specs/plans: S14/S24/S25/S28, S01/S08, and plans\n- add migration notes where naming/behavior changed\n\nWhy:\nIssue #128 identified conflicting normative requirements across S10/S23/S27 that made implementation ambiguous.\n\nValidation:\n- make validate-all passes after these updates\n\nCloses #128