### PR TITLE
[S10] Groundwork for SSE replay/reconnect contract

### DIFF
--- a/src/tta/api/sse_replay.py
+++ b/src/tta/api/sse_replay.py
@@ -1,0 +1,112 @@
+"""SSE replay primitives for resumable EventSource streams (S10 FR-10.41..10.44)."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from time import monotonic
+from typing import Literal
+
+ReplayLookup = Literal["hit", "unavailable"]
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayEvent:
+    """Single SSE event in the replay buffer."""
+
+    event_id: int
+    payload: str
+    created_at: float
+
+
+def parse_last_event_id(header_value: str | None) -> int | None:
+    """Parse Last-Event-ID header as a positive integer or ``None``.
+
+    Event IDs used by this service are positive integer sequence values.
+    Unknown/invalid values are ignored to preserve stream compatibility.
+    """
+    if header_value is None:
+        return None
+    value = header_value.strip()
+    if not value:
+        return None
+    try:
+        parsed = int(value)
+    except ValueError:
+        return None
+    if parsed <= 0:
+        return None
+    return parsed
+
+
+class SSEReplayBuffer:
+    """In-memory replay store.
+
+    Retention policy implements FR-10.42:
+    keep at least ``min_events`` OR ``min_seconds`` worth of events, whichever
+    requires keeping more.
+    """
+
+    def __init__(
+        self,
+        *,
+        min_events: int = 100,
+        min_seconds: float = 300.0,
+    ) -> None:
+        if min_events <= 0:
+            msg = "min_events must be positive"
+            raise ValueError(msg)
+        if min_seconds <= 0:
+            msg = "min_seconds must be positive"
+            raise ValueError(msg)
+        self._min_events = min_events
+        self._min_seconds = min_seconds
+        self._events: deque[ReplayEvent] = deque()
+
+    @property
+    def size(self) -> int:
+        return len(self._events)
+
+    @property
+    def oldest_event_id(self) -> int | None:
+        if not self._events:
+            return None
+        return self._events[0].event_id
+
+    @property
+    def newest_event_id(self) -> int | None:
+        if not self._events:
+            return None
+        return self._events[-1].event_id
+
+    def append(self, event_id: int, payload: str) -> None:
+        now = monotonic()
+        self._events.append(
+            ReplayEvent(event_id=event_id, payload=payload, created_at=now)
+        )
+        self._prune(now=now)
+
+    def events_after(self, last_event_id: int) -> tuple[ReplayLookup, list[str]]:
+        """Return replay events after ``last_event_id``.
+
+        Returns:
+        - (``"hit"``, payloads) when replay can be served from buffer
+        - (``"unavailable"``, []) when requested id predates current buffer
+        """
+        if not self._events:
+            return "unavailable", []
+
+        oldest = self._events[0].event_id
+        if last_event_id < oldest:
+            return "unavailable", []
+
+        payloads = [e.payload for e in self._events if e.event_id > last_event_id]
+        return "hit", payloads
+
+    def _prune(self, *, now: float) -> None:
+        cutoff = now - self._min_seconds
+        while len(self._events) > self._min_events:
+            oldest = self._events[0]
+            if oldest.created_at >= cutoff:
+                break
+            self._events.popleft()

--- a/tests/unit/api/test_sse_replay.py
+++ b/tests/unit/api/test_sse_replay.py
@@ -1,0 +1,63 @@
+"""Unit tests for SSE replay groundwork utilities."""
+
+from __future__ import annotations
+
+from tta.api.sse_replay import SSEReplayBuffer, parse_last_event_id
+
+
+class TestParseLastEventId:
+    def test_none_returns_none(self) -> None:
+        assert parse_last_event_id(None) is None
+
+    def test_blank_returns_none(self) -> None:
+        assert parse_last_event_id("   ") is None
+
+    def test_invalid_returns_none(self) -> None:
+        assert parse_last_event_id("abc") is None
+
+    def test_non_positive_returns_none(self) -> None:
+        assert parse_last_event_id("0") is None
+        assert parse_last_event_id("-1") is None
+
+    def test_valid_positive_int(self) -> None:
+        assert parse_last_event_id("42") == 42
+        assert parse_last_event_id(" 7 ") == 7
+
+
+class TestSSEReplayBuffer:
+    def test_replays_events_after_id(self) -> None:
+        buf = SSEReplayBuffer(min_events=3, min_seconds=300.0)
+        buf.append(1, "e1")
+        buf.append(2, "e2")
+        buf.append(3, "e3")
+
+        status, payloads = buf.events_after(1)
+        assert status == "hit"
+        assert payloads == ["e2", "e3"]
+
+    def test_returns_unavailable_when_id_older_than_buffer(
+        self, monkeypatch
+    ) -> None:
+        ticks = iter([0.0, 10.0, 20.0])
+        monkeypatch.setattr("tta.api.sse_replay.monotonic", lambda: next(ticks))
+        buf = SSEReplayBuffer(min_events=2, min_seconds=0.0001)
+        buf.append(1, "e1")
+        buf.append(2, "e2")
+        buf.append(3, "e3")
+
+        status, payloads = buf.events_after(1)
+        assert status == "unavailable"
+        assert payloads == []
+
+    def test_keeps_at_least_min_events_even_if_old(self, monkeypatch) -> None:
+        ticks = iter([0.0, 10.0, 20.0, 30.0])
+        monkeypatch.setattr("tta.api.sse_replay.monotonic", lambda: next(ticks))
+        buf = SSEReplayBuffer(min_events=3, min_seconds=0.0001)
+        buf.append(1, "e1")
+        buf.append(2, "e2")
+        buf.append(3, "e3")
+        buf.append(4, "e4")
+
+        # min_events=3 ensures at least 3 entries are retained.
+        assert buf.size >= 3
+        assert buf.newest_event_id == 4


### PR DESCRIPTION
This is a groundwork-only PR for #129 while #131 review is in flight.\n\nIncluded:\n- new SSE replay primitives in src/tta/api/sse_replay.py\n  - Last-Event-ID parsing helper\n  - in-memory replay buffer with min-events + time-window retention policy\n  - replay lookup semantics for hit vs unavailable cases\n- unit coverage in tests/unit/api/test_sse_replay.py\n\nNot yet included:\n- stream endpoint wiring in routes/games.py\n- replay_unavailable + state_update fallback emission\n- replay metrics/log emission\n- integration tests for reconnect flows\n\nValidation run:\n- uv run ruff check src/tta/api/sse_replay.py tests/unit/api/test_sse_replay.py\n- uv run pytest tests/unit/api/test_sse_replay.py tests/unit/api/test_sse.py\n\nRelated: #129