### PR TITLE
Wave 33: reconciliation cleanup

### DIFF
--- a/specs/23-error-handling-and-resilience.md
+++ b/specs/23-error-handling-and-resilience.md
@@ -94,6 +94,7 @@ defined behavior for the player, the operator, and the system.
 | Category | HTTP Status | Player sees | System behavior | Example |
 |---|---|---|---|---|
 | `input_invalid` | 400 | Specific validation message | Log at WARN, no retry | Missing turn text, invalid game ID format |
+| `schema_invalid` | 422 | Specific validation message | Log at WARN, no retry | Pydantic schema/type violations on request body |
 | `auth_required` | 401 | Prompt to register or log in | Log at INFO | Expired session, missing token |
 | `forbidden` | 403 | "You don't have access to this" | Log at WARN | Player accessing another's game |
 | `not_found` | 404 | "Game not found" / "Page not found" | Log at INFO | Deleted game, bad URL |
@@ -519,7 +520,8 @@ Feature: Error Handling & Resilience
   `request_id` naming is non-normative legacy terminology and should not appear in
   response schemas.
 - Input validation category `input_invalid` remains canonical at HTTP 400 (including
-  whitespace-only turn input).
+  whitespace-only turn input). Schema/type violations from Pydantic use `schema_invalid`
+  at HTTP 422.
 
 ---
 

--- a/src/tta/api/errors.py
+++ b/src/tta/api/errors.py
@@ -123,7 +123,7 @@ async def validation_error_handler(
     logger.warning(
         "validation_error",
         error_code="VALIDATION_ERROR",
-        error_category="input_invalid",
+        error_category="schema_invalid",
         status_code=422,
         **_request_context(request),
     )

--- a/src/tta/api/errors.py
+++ b/src/tta/api/errors.py
@@ -123,7 +123,7 @@ async def validation_error_handler(
     logger.warning(
         "validation_error",
         error_code="VALIDATION_ERROR",
-        error_category="schema_invalid",
+        error_category=ErrorCategory.SCHEMA_INVALID.value,
         status_code=422,
         **_request_context(request),
     )

--- a/src/tta/api/health.py
+++ b/src/tta/api/health.py
@@ -66,6 +66,26 @@ async def _check_moderation(request: Request) -> str:
     return "ok"
 
 
+async def _check_llm_breaker(request: Request) -> str:
+    """Check LLM circuit breaker state (FR-23.24).
+
+    OPEN or HALF_OPEN means the LLM is experiencing failures; surface as
+    a distinct state so _derive_status can report "degraded".
+    """
+    try:
+        breaker = request.app.state.pipeline_deps.llm_circuit_breaker
+    except AttributeError:
+        return "not_configured"
+    from tta.resilience.circuit_breaker import CircuitState
+
+    state = breaker.state
+    if state == CircuitState.OPEN:
+        return "open"
+    if state == CircuitState.HALF_OPEN:
+        return "half_open"
+    return "ok"
+
+
 async def _run_checks(
     request: Request,
 ) -> dict[str, str]:
@@ -76,6 +96,7 @@ async def _run_checks(
         ("neo4j", _check_neo4j),
         ("redis", _check_redis),
         ("moderation", _check_moderation),
+        ("llm_breaker", _check_llm_breaker),
     ]:
         try:
             checks[name] = await check_fn(request)
@@ -89,18 +110,17 @@ def _derive_status(checks: dict[str, str]) -> str:
     """Derive aggregate status from per-service checks (FR-23.24).
 
     - "unhealthy" if any critical service (Postgres) is unavailable
-    - "degraded" if any non-critical service is unavailable
+    - "degraded" if any non-critical service is unavailable or the
+      LLM circuit breaker is OPEN / HALF_OPEN
     - "healthy" otherwise
-
-    TODO: incorporate circuit-breaker states — a tripped LLM breaker
-    should surface as "degraded" even if the LLM health-check hasn't
-    failed yet.
     """
     for svc, status in checks.items():
         if status == "unavailable" and svc in CRITICAL_SERVICES:
             return "unhealthy"
-    for _svc, status in checks.items():
+    for svc, status in checks.items():
         if status == "unavailable":
+            return "degraded"
+        if svc == "llm_breaker" and status in ("open", "half_open"):
             return "degraded"
     return "healthy"
 

--- a/src/tta/api/health.py
+++ b/src/tta/api/health.py
@@ -76,6 +76,8 @@ async def _check_llm_breaker(request: Request) -> str:
         breaker = request.app.state.pipeline_deps.llm_circuit_breaker
     except AttributeError:
         return "not_configured"
+    if breaker is None:
+        return "not_configured"
     from tta.resilience.circuit_breaker import CircuitState
 
     state = breaker.state

--- a/src/tta/api/sse.py
+++ b/src/tta/api/sse.py
@@ -8,13 +8,13 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from redis.asyncio import Redis
 
+from tta.persistence.redis_session import _SSE_BUFFER_KEY as _BUFFER_KEY
+from tta.persistence.redis_session import _SSE_COUNTER_KEY as _COUNTER_KEY
+
 # Maximum number of events to retain per game in the replay buffer.
 SSE_BUFFER_MAX_EVENTS = 100
 # TTL (seconds) for the replay buffer sorted set.  FR-10.41: ≥5 min.
 SSE_BUFFER_TTL_SECONDS = 300
-# Redis key templates for SSE replay state.
-_COUNTER_KEY = "tta:sse_counter:{game_id}"
-_BUFFER_KEY = "tta:sse_buffer:{game_id}"
 
 
 class SSECounter:
@@ -130,16 +130,3 @@ def format_sse(
     data_lines = "\n".join(f"data: {line}" for line in lines)
     id_line = f"id: {event_id}\n" if event_id is not None else ""
     return f"{id_line}event: {event}\n{data_lines}\n\n"
-
-
-async def evict_game_keys(redis: Redis, game_id: str) -> None:
-    """Delete all Redis keys associated with a game session.
-
-    Removes the session cache key and SSE replay state (buffer + counter).
-    Callers are responsible for handling exceptions (e.g. make best-effort).
-    """
-    await redis.delete(
-        f"tta:session:{game_id}",
-        _BUFFER_KEY.format(game_id=game_id),
-        _COUNTER_KEY.format(game_id=game_id),
-    )

--- a/src/tta/errors.py
+++ b/src/tta/errors.py
@@ -12,9 +12,10 @@ __all__ = ["ErrorCategory", "CATEGORY_STATUS"]
 
 
 class ErrorCategory(StrEnum):
-    """Nine error categories per S23 §3.1 error taxonomy."""
+    """Ten error categories per S23 §3.1 error taxonomy."""
 
     INPUT_INVALID = "input_invalid"
+    SCHEMA_INVALID = "schema_invalid"
     AUTH_REQUIRED = "auth_required"
     FORBIDDEN = "forbidden"
     NOT_FOUND = "not_found"
@@ -27,6 +28,7 @@ class ErrorCategory(StrEnum):
 
 CATEGORY_STATUS: dict[ErrorCategory, int] = {
     ErrorCategory.INPUT_INVALID: 400,
+    ErrorCategory.SCHEMA_INVALID: 422,
     ErrorCategory.AUTH_REQUIRED: 401,
     ErrorCategory.FORBIDDEN: 403,
     ErrorCategory.NOT_FOUND: 404,

--- a/src/tta/persistence/redis_session.py
+++ b/src/tta/persistence/redis_session.py
@@ -32,7 +32,7 @@ log = structlog.get_logger()
 _KEY_PREFIX = "tta:session:"
 _DEFAULT_TTL = 3600
 
-# SSE key templates — must stay in sync with src/tta/api/sse.py
+# SSE key templates (canonical source; imported by src/tta/api/sse.py)
 _SSE_BUFFER_KEY = "tta:sse_buffer:{game_id}"
 _SSE_COUNTER_KEY = "tta:sse_counter:{game_id}"
 

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -20,12 +20,24 @@ from pytest_bdd import given, parsers, then
 
 from tta.api.app import create_app
 from tta.api.deps import get_current_player, get_pg, get_redis
-from tta.config import Settings
+from tta.config import (
+    CURRENT_CONSENT_VERSION,
+    REQUIRED_CONSENT_CATEGORIES,
+    Settings,
+)
 from tta.models.player import Player
 
 _NOW = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
 _PLAYER_ID = uuid4()
-_PLAYER = Player(id=_PLAYER_ID, handle="BddHero", created_at=_NOW)
+_PLAYER = Player(
+    id=_PLAYER_ID,
+    handle="BddHero",
+    created_at=_NOW,
+    consent_version=CURRENT_CONSENT_VERSION,
+    consent_categories=dict.fromkeys(REQUIRED_CONSENT_CATEGORIES, True),
+    consent_accepted_at=_NOW,
+    age_confirmed_at=_NOW,
+)
 _GAME_ID = uuid4()
 _TURN_ID = uuid4()
 
@@ -54,6 +66,7 @@ def _make_result(
         result.all.return_value = []
     if scalar is not None:
         result.scalar_one.return_value = scalar
+        result.scalar.return_value = scalar
     return result
 
 

--- a/tests/bdd/features/game_session.feature
+++ b/tests/bdd/features/game_session.feature
@@ -26,8 +26,7 @@ Feature: Game Session Management
   Scenario: End a game session
     Given the player has an active game
     When the player ends that game
-    Then the response status is 200
-    And the game status is "abandoned"
+    Then the response status is 204
 
   Scenario: Cannot create game without authentication
     Given no authentication is provided

--- a/tests/bdd/features/turn_pipeline.feature
+++ b/tests/bdd/features/turn_pipeline.feature
@@ -15,7 +15,6 @@ Feature: Turn Processing Pipeline
     Then the turn is accepted with status 202
     And the response includes a stream URL
 
-  Scenario: Empty input returns a nudge response
+  Scenario: Empty input is rejected
     When the player submits empty turn text
-    Then the response status is 200
-    And the response is a nudge
+    Then the response status is 400

--- a/tests/bdd/step_defs/test_game_session.py
+++ b/tests/bdd/step_defs/test_game_session.py
@@ -52,7 +52,8 @@ def test_no_auth():
 def create_game(ctx: dict, client: TestClient, pg: AsyncMock) -> dict:
     pg.execute = AsyncMock(
         side_effect=[
-            _make_result(scalar=0),  # count active games
+            _make_result(scalar=0),  # require_anonymous_game_limit (scalar)
+            _make_result(scalar=0),  # _count_active_games (scalar_one)
             _make_result(),  # INSERT
         ]
     )

--- a/tests/bdd/step_defs/test_player_identity.py
+++ b/tests/bdd/step_defs/test_player_identity.py
@@ -15,6 +15,13 @@ from tests.bdd.conftest import (
     _PLAYER_ID,
     _make_result,
 )
+from tta.config import CURRENT_CONSENT_VERSION, REQUIRED_CONSENT_CATEGORIES
+
+_CONSENT_BODY = {
+    "age_13_plus_confirmed": True,
+    "consent_version": CURRENT_CONSENT_VERSION,
+    "consent_categories": dict.fromkeys(REQUIRED_CONSENT_CATEGORIES, True),
+}
 
 FEATURE = "../features/player_identity.feature"
 
@@ -76,7 +83,7 @@ def register(ctx: dict, client: TestClient, pg: AsyncMock) -> dict:
     pg.commit = AsyncMock()
     ctx["response"] = client.post(
         "/api/v1/players",
-        json={"handle": ctx["handle"]},
+        json={"handle": ctx["handle"], **_CONSENT_BODY},
     )
     return ctx
 

--- a/tests/bdd/step_defs/test_turn_pipeline.py
+++ b/tests/bdd/step_defs/test_turn_pipeline.py
@@ -31,7 +31,7 @@ def test_narrative_generated():
 
 
 @scenario(FEATURE, "Empty input is rejected")
-def test_empty_input_returns_nudge():
+def test_empty_input_is_rejected():
     pass
 
 

--- a/tests/bdd/step_defs/test_turn_pipeline.py
+++ b/tests/bdd/step_defs/test_turn_pipeline.py
@@ -30,7 +30,7 @@ def test_narrative_generated():
     pass
 
 
-@scenario(FEATURE, "Empty input returns a nudge response")
+@scenario(FEATURE, "Empty input is rejected")
 def test_empty_input_returns_nudge():
     pass
 

--- a/tests/unit/api/test_errors.py
+++ b/tests/unit/api/test_errors.py
@@ -280,7 +280,7 @@ class TestStructuredErrorLogging:
         assert len(err_logs) == 1
         log = err_logs[0]
         assert log["error_code"] == "VALIDATION_ERROR"
-        assert log["error_category"] == "input_invalid"
+        assert log["error_category"] == "schema_invalid"
         assert log["status_code"] == 422
         assert log["request_method"] == "POST"
         assert log["request_path"] == "/validation"

--- a/tests/unit/api/test_games.py
+++ b/tests/unit/api/test_games.py
@@ -376,6 +376,61 @@ class TestListGames:
 
 
 # ------------------------------------------------------------------
+# _PUBLIC_STATE_MAP — internal→public status translation (S27 FR-27.15)
+# ------------------------------------------------------------------
+
+
+class TestPublicStateMap:
+    """Direct unit tests for _PUBLIC_STATE_MAP (no HTTP needed)."""
+
+    def test_ended_maps_to_completed(self) -> None:
+        """Internal 'ended' status must surface as 'completed' per S27 FR-27.15."""
+        from tta.api.routes.games import _PUBLIC_STATE_MAP
+
+        assert _PUBLIC_STATE_MAP["ended"] == "completed", (
+            "'ended' must map to 'completed' for S27 compliance"
+        )
+
+    def test_completed_maps_to_completed(self) -> None:
+        from tta.api.routes.games import _PUBLIC_STATE_MAP
+
+        assert _PUBLIC_STATE_MAP["completed"] == "completed"
+
+    def test_abandoned_maps_to_abandoned(self) -> None:
+        from tta.api.routes.games import _PUBLIC_STATE_MAP
+
+        assert _PUBLIC_STATE_MAP["abandoned"] == "abandoned"
+
+    def test_expired_maps_to_abandoned(self) -> None:
+        from tta.api.routes.games import _PUBLIC_STATE_MAP
+
+        assert _PUBLIC_STATE_MAP["expired"] == "abandoned"
+
+    def test_active_states_map_to_active(self) -> None:
+        from tta.api.routes.games import _PUBLIC_STATE_MAP
+
+        for internal in ("created", "active", "paused"):
+            assert _PUBLIC_STATE_MAP[internal] == "active", (
+                f"'{internal}' must map to 'active'"
+            )
+
+    def test_ended_visible_as_completed_via_list_api(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        """AC-27.10 / S27 FR-27.15: GET /games returns 'completed' for ended rows."""
+        row = _game_row(status="ended")
+        pg.execute = AsyncMock(return_value=_make_result([row]))
+
+        resp = client.get("/api/v1/games")
+
+        assert resp.status_code == 200
+        game = resp.json()["data"][0]
+        assert game["status"] == "completed", (
+            "API must return 'completed' when internal status is 'ended'"
+        )
+
+
+# ------------------------------------------------------------------
 # GET /api/v1/games/{id} — Game state
 # ------------------------------------------------------------------
 

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -216,7 +216,11 @@ class TestReadiness:
     def test_body_includes_all_checks(self, client: TestClient) -> None:
         data = client.get("/api/v1/health/ready").json()
         assert set(data["checks"]) == {
-            "postgres", "neo4j", "redis", "moderation", "llm_breaker"
+            "postgres",
+            "neo4j",
+            "redis",
+            "moderation",
+            "llm_breaker",
         }
 
     def test_returns_503_when_postgres_fails(

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -215,7 +215,9 @@ class TestReadiness:
 
     def test_body_includes_all_checks(self, client: TestClient) -> None:
         data = client.get("/api/v1/health/ready").json()
-        assert set(data["checks"]) == {"postgres", "neo4j", "redis", "moderation", "llm_breaker"}
+        assert set(data["checks"]) == {
+            "postgres", "neo4j", "redis", "moderation", "llm_breaker"
+        }
 
     def test_returns_503_when_postgres_fails(
         self,

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -215,7 +215,7 @@ class TestReadiness:
 
     def test_body_includes_all_checks(self, client: TestClient) -> None:
         data = client.get("/api/v1/health/ready").json()
-        assert set(data["checks"]) == {"postgres", "neo4j", "redis", "moderation"}
+        assert set(data["checks"]) == {"postgres", "neo4j", "redis", "moderation", "llm_breaker"}
 
     def test_returns_503_when_postgres_fails(
         self,

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -49,17 +49,20 @@ def _build_client(
     neo4j: str = "ok",
     redis: str = "ok",
     moderation: str = "disabled",
+    llm_breaker: str = "ok",
 ) -> TestClient:
     """Build a TestClient with per-service stubs.
 
     Pass "ok" for healthy, "unavailable" for a failing check,
     or "not_configured" / "disabled" for non-error states.
+    For llm_breaker, also accepts "open" and "half_open".
     """
     for svc, status in [
         ("postgres", postgres),
         ("neo4j", neo4j),
         ("redis", redis),
         ("moderation", moderation),
+        ("llm_breaker", llm_breaker),
     ]:
         if status == "unavailable":
             monkeypatch.setattr(f"tta.api.health._check_{svc}", _make_failing_stub())
@@ -299,3 +302,69 @@ class TestHealthModeration:
         data = resp.json()
         assert data["status"] == "degraded"
         assert data["checks"]["moderation"] == "unavailable"
+
+
+# ------------------------------------------------------------------
+# LLM circuit breaker health check (FR-23.24)
+# ------------------------------------------------------------------
+
+
+class TestHealthLLMBreaker:
+    """LLM circuit breaker check — OPEN/HALF_OPEN degrade health and block readiness."""
+
+    def test_breaker_open_degrades_health(
+        self,
+        _settings: Settings,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """OPEN circuit breaker → /health reports degraded."""
+        c = _build_client(monkeypatch, _settings, llm_breaker="open")
+        resp = c.get("/api/v1/health")
+        data = resp.json()
+        assert data["status"] == "degraded"
+        assert data["checks"]["llm_breaker"] == "open"
+
+    def test_breaker_half_open_degrades_health(
+        self,
+        _settings: Settings,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """HALF_OPEN circuit breaker → /health reports degraded."""
+        c = _build_client(monkeypatch, _settings, llm_breaker="half_open")
+        resp = c.get("/api/v1/health")
+        data = resp.json()
+        assert data["status"] == "degraded"
+        assert data["checks"]["llm_breaker"] == "half_open"
+
+    def test_breaker_open_blocks_readiness(
+        self,
+        _settings: Settings,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """OPEN circuit breaker → /health/ready returns 503."""
+        c = _build_client(monkeypatch, _settings, llm_breaker="open")
+        resp = c.get("/api/v1/health/ready")
+        assert resp.status_code == 503
+        assert resp.json()["status"] == "not_ready"
+
+    def test_breaker_half_open_blocks_readiness(
+        self,
+        _settings: Settings,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """HALF_OPEN circuit breaker → /health/ready returns 503."""
+        c = _build_client(monkeypatch, _settings, llm_breaker="half_open")
+        resp = c.get("/api/v1/health/ready")
+        assert resp.status_code == 503
+        assert resp.json()["status"] == "not_ready"
+
+    def test_breaker_not_configured_is_ready(
+        self,
+        _settings: Settings,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """not_configured breaker does not block readiness."""
+        c = _build_client(monkeypatch, _settings, llm_breaker="not_configured")
+        resp = c.get("/api/v1/health/ready")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ready"


### PR DESCRIPTION
## Summary

Closes #128

Five technical-debt items identified in the Wave 32 audit, now resolved.

---

### Changes

**1. BDD consent fixture** (commit `a165585`)
`tests/bdd/conftest.py` `_PLAYER` fixture was missing `consent_version`, `consent_categories`, `consent_accepted_at`, `age_confirmed_at`. The `require_consent` dependency rejects requests where `consent_version=None` with 403 CONSENT_REQUIRED, silently breaking all BDD scenarios.

**2. `sse.py` dead-code cleanup**
- Removed duplicate `_BUFFER_KEY`/`_COUNTER_KEY` local constants; now imports canonical names from `redis_session.py`
- Deleted orphaned `evict_game_keys()` (no callers since Wave 32 added `evict_game_state()` which also handles the session cache key)

**3. Health circuit-breaker wiring** (FR-23.24)
- Added `_check_llm_breaker()` helper reading `app.state.pipeline_deps.llm_circuit_breaker.state`
- Wired into `_run_checks()`; `OPEN`/`HALF_OPEN` breaker states → `"degraded"` status
- Readiness probe (`/ready`) now returns 503 when breaker is open
- Handles `AttributeError` gracefully (returns `"not_configured"` during tests)

**4. `schema_invalid` error category** (FR-23.01)
- Added `ErrorCategory.SCHEMA_INVALID = "schema_invalid"` to domain enum
- Added `SCHEMA_INVALID: 422` to HTTP status mapping
- `validation_error_handler` now logs `error_category="schema_invalid"` (was incorrectly `"input_invalid"` — 400 is input logic, 422 is schema validation)
- Added `schema_invalid → 422` row to S23 FR-23.01 table

**5. `ended → completed` mapping + stale comment**
- Added `TestPublicStateMap` (6 tests) to `test_games.py` covering the `_PUBLIC_STATE_MAP` in `routes/games.py`
- Updated stale comment in `redis_session.py:35` to reflect that `sse.py` now imports canonical keys from there

---

### Quality Gate
- `make quality`: ✅ 0 ruff errors, 0 pyright errors
- `make test` (unit): all passing