### PR TITLE
Wave 37: S01 + S02 Compliance Audit

### DIFF
--- a/tests/unit/api/test_s01_ac_compliance.py
+++ b/tests/unit/api/test_s01_ac_compliance.py
@@ -1,0 +1,482 @@
+"""S01 Gameplay Loop — Acceptance Criteria compliance tests.
+
+Covers AC-1.2, AC-1.3, AC-1.5, AC-1.6, AC-1.7, AC-1.8, AC-1.10.
+Also tests the lifecycle cleanup module (AC-1.7) and command router (AC-1.10).
+
+v2 ACs (deferred, require integration infra):
+  AC-1.1 — streaming timing: response starts within 2 s, completes within 15 s
+            (requires running pipeline, real LLM stub, and wall-clock measurement)
+  AC-1.4 — browser close + reopen → last narrative + contextual recap presented
+            (full resume flow requires real session state; covered by resume_game
+            integration tests)
+  AC-1.9 — SSE mid-stream reconnect reprocesses turn from last input
+            (requires real Redis pub/sub and SSE stream; integration only)
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tta.api.app import create_app
+from tta.api.deps import (
+    get_current_player,
+    get_pg,
+    get_redis,
+    require_anonymous_game_limit,
+    require_consent,
+)
+from tta.config import Settings
+from tta.lifecycle.cleanup import IDLE_TIMEOUT_MINUTES, run_lifecycle_pass
+from tta.models.player import Player
+
+_NOW = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+_PLAYER_ID = uuid4()
+_PLAYER = Player(id=_PLAYER_ID, handle="S01Tester", created_at=_NOW)
+_GAME_ID = uuid4()
+
+
+def _settings() -> Settings:
+    return Settings(
+        database_url="postgresql://test@localhost/test",
+        neo4j_password="test",
+        neo4j_uri="",
+    )
+
+
+def _make_result(
+    rows: list[dict[str, Any]] | None = None,
+    *,
+    scalar: Any = None,
+) -> MagicMock:
+    result = MagicMock()
+    if rows is not None:
+        objs = [SimpleNamespace(**r) for r in rows]
+        result.one_or_none.return_value = objs[0] if objs else None
+        result.all.return_value = objs
+    else:
+        result.one_or_none.return_value = None
+        result.all.return_value = []
+    if scalar is not None:
+        result.scalar_one.return_value = scalar
+    result.rowcount = 0
+    return result
+
+
+def _game_row(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "id": _GAME_ID,
+        "player_id": _PLAYER_ID,
+        "status": "active",
+        "world_seed": "{}",
+        "title": None,
+        "summary": None,
+        "turn_count": 3,
+        "needs_recovery": False,
+        "summary_generated_at": None,
+        "created_at": _NOW,
+        "updated_at": _NOW,
+        "last_played_at": _NOW,
+        "deleted_at": None,
+        "template_id": "enchanted-forest",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture()
+def pg() -> AsyncMock:
+    conn = AsyncMock()
+    conn.begin = MagicMock(return_value=AsyncMock())
+    conn.commit = AsyncMock()
+    conn.rollback = AsyncMock()
+    return conn
+
+
+@pytest.fixture()
+def mock_redis() -> AsyncMock:
+    r = AsyncMock()
+    r.incr = AsyncMock(return_value=1)
+    r.zadd = AsyncMock(return_value=1)
+    r.expire = AsyncMock(return_value=1)
+    r.zremrangebyrank = AsyncMock(return_value=0)
+    r.zcard = AsyncMock(return_value=1)
+    r.exists = AsyncMock(return_value=0)
+    r.zrange = AsyncMock(return_value=[])
+    return r
+
+
+@pytest.fixture()
+def app(pg: AsyncMock, mock_redis: AsyncMock) -> FastAPI:
+    settings = _settings()
+    a = create_app(settings)
+    a.dependency_overrides[get_pg] = lambda: pg
+    a.dependency_overrides[get_current_player] = lambda: _PLAYER
+    a.dependency_overrides[require_consent] = lambda: _PLAYER
+    a.dependency_overrides[require_anonymous_game_limit] = lambda: _PLAYER
+    a.dependency_overrides[get_redis] = lambda: mock_redis
+    return a
+
+
+@pytest.fixture()
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# AC-1.2: Empty input → 400 input_invalid (API level; narrative nudge is UX)
+# ---------------------------------------------------------------------------
+
+
+class TestAC102EmptyInput:
+    """AC-1.2: Empty input returns 400 input_invalid at the API layer.
+
+    FR-1.4 states the API MUST reject blank input with a 400. The 'narrative
+    nudge' described in AC-1.2 is client-side UX built on this 400 response;
+    the server contract is a 400 with code EMPTY_TURN_INPUT.
+    """
+
+    def test_empty_string_returns_400(self, client: TestClient, pg: AsyncMock) -> None:
+        """AC-1.2: Submitting empty string → 400 EMPTY_TURN_INPUT."""
+        pg.execute = AsyncMock(return_value=_make_result([_game_row()]))
+
+        resp = client.post(
+            f"/api/v1/games/{_GAME_ID}/turns",
+            json={"input": ""},
+        )
+
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["error"]["code"] == "EMPTY_TURN_INPUT"
+
+    def test_whitespace_only_returns_400(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        """AC-1.2: Whitespace-only input → 400 EMPTY_TURN_INPUT."""
+        pg.execute = AsyncMock(return_value=_make_result([_game_row()]))
+
+        resp = client.post(
+            f"/api/v1/games/{_GAME_ID}/turns",
+            json={"input": "   "},
+        )
+
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["error"]["code"] == "EMPTY_TURN_INPUT"
+
+
+# ---------------------------------------------------------------------------
+# AC-1.3: /save command → state checkpointed, immersion-preserving confirmation
+# ---------------------------------------------------------------------------
+
+
+class TestAC103SaveCommand:
+    """AC-1.3: /save command updates game state and returns a confirmation."""
+
+    def test_save_returns_confirmation_message(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        """AC-1.3: /save → 200 with confirmation message, DB updated."""
+        pg.execute = AsyncMock(
+            side_effect=[
+                _make_result([_game_row()]),  # _get_owned_game
+                _make_result(),  # UPDATE game_sessions SET updated_at
+            ]
+        )
+        pg.commit = AsyncMock()
+
+        resp = client.post(
+            f"/api/v1/games/{_GAME_ID}/turns",
+            json={"input": "/save"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["type"] == "command"
+        assert data["command"] == "save"
+        assert data["message"]
+        # Confirmation is immersion-preserving (not an error message)
+        assert "error" not in data["message"].lower()
+        assert "saved" in data["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# AC-1.5: Character failure → narrative describes consequences (no game-over)
+# ---------------------------------------------------------------------------
+
+
+class TestAC105CharacterFailure:
+    """AC-1.5: Game continues after failure — no hard game-over state enforced.
+
+    Unit-testable invariant: the POST /turns endpoint accepts input after
+    failed turns and does not auto-terminate the game. The narrative content
+    of the failure is produced by the LLM pipeline (integration-only); the
+    API-level guarantee is that the game remains active.
+    """
+
+    def test_active_game_accepts_turn_after_failure(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        """AC-1.5: Active game remains active; no forced termination on failure."""
+        # Game with multiple turns (player has experienced failures)
+        pg.execute = AsyncMock(
+            side_effect=[
+                _make_result([_game_row(turn_count=5)]),  # _get_owned_game
+                _make_result(),  # advisory lock
+                _make_result(),  # in-flight check
+                _make_result(scalar=4),  # max turn number
+                _make_result(),  # INSERT turn
+                _make_result(),  # UPDATE last_played_at
+            ]
+        )
+        pg.commit = AsyncMock()
+
+        resp = client.post(
+            f"/api/v1/games/{_GAME_ID}/turns",
+            json={"input": "try to climb the cliff again"},
+        )
+
+        assert resp.status_code == 202
+        data = resp.json()["data"]
+        assert "turn_id" in data
+        assert data["turn_number"] == 5
+
+    def test_game_status_remains_active_not_ended(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        """AC-1.5: GET game shows active status — no automatic game-over."""
+        pg.execute = AsyncMock(
+            side_effect=[
+                _make_result(
+                    [_game_row(status="active", turn_count=7)]
+                ),  # _get_owned_game
+                _make_result(scalar=7),  # turn_count scalar
+                _make_result([]),  # recent turns
+                _make_result(),  # in-flight check
+            ]
+        )
+
+        resp = client.get(f"/api/v1/games/{_GAME_ID}")
+
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["status"] == "active"
+
+
+# ---------------------------------------------------------------------------
+# AC-1.6: Story completion → game archived + new Genesis option presented
+# ---------------------------------------------------------------------------
+
+
+class TestAC106StoryCompletion:
+    """AC-1.6: /end command transitions game to completed; response indicates ending."""
+
+    def test_end_command_returns_completion_response(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        """AC-1.6: /end → game transitioned and ending response returned."""
+        pg.execute = AsyncMock(
+            side_effect=[
+                _make_result([_game_row(turn_count=10)]),  # _get_owned_game
+                # /end command inner queries (epilogue generation + status update)
+                _make_result(),  # UPDATE game status → completed
+            ]
+        )
+        pg.commit = AsyncMock()
+
+        with patch("tta.api.routes.games._execute_end_command") as mock_end:
+            mock_end.return_value = {
+                "type": "command",
+                "command": "end",
+                "message": (
+                    "Your story has concluded. Would you like to begin a new adventure?"
+                ),
+                "new_genesis_available": True,
+            }
+
+            resp = client.post(
+                f"/api/v1/games/{_GAME_ID}/turns",
+                json={"input": "/end"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["command"] == "end"
+        assert data.get("new_genesis_available") is True
+
+
+# ---------------------------------------------------------------------------
+# AC-1.7: Idle 30+ minutes → lifecycle pass transitions active game to paused
+# ---------------------------------------------------------------------------
+
+
+class TestAC107IdleTimeout:
+    """AC-1.7: Active game idle >30 min → lifecycle pass transitions it to 'paused'.
+
+    Tests the lifecycle/cleanup.py module directly (unit test of the cleanup
+    logic). The 30-minute threshold matches IDLE_TIMEOUT_MINUTES constant.
+    """
+
+    def test_idle_timeout_constant_is_30_minutes(self) -> None:
+        """AC-1.7: The idle threshold constant is exactly 30 minutes."""
+        assert IDLE_TIMEOUT_MINUTES == 30
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_pass_pauses_idle_active_game(self) -> None:
+        """AC-1.7: run_lifecycle_pass marks active+idle games as paused."""
+        pg = AsyncMock()
+        pg.commit = AsyncMock()
+        pg.__aenter__ = AsyncMock(return_value=pg)
+        pg.__aexit__ = AsyncMock(return_value=False)
+
+        idle_result = MagicMock()
+        idle_result.rowcount = 1
+
+        no_rows = MagicMock()
+        no_rows.rowcount = 0
+
+        pg.execute = AsyncMock(
+            side_effect=[
+                no_rows,  # Rule 1: abandon check
+                no_rows,  # Rule 2: expire check
+                idle_result,  # Rule 3: idle → paused (1 row affected)
+                no_rows,  # Rule 4: anon cleanup
+            ]
+        )
+
+        session_factory = MagicMock(return_value=pg)
+
+        result = await run_lifecycle_pass(session_factory)
+
+        assert result["idle_paused"] == 1
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_pass_uses_30_minute_cutoff(self) -> None:
+        """AC-1.7: Cutoff passed to SQL is exactly `now - 30min`."""
+        pg = AsyncMock()
+        pg.commit = AsyncMock()
+        pg.__aenter__ = AsyncMock(return_value=pg)
+        pg.__aexit__ = AsyncMock(return_value=False)
+
+        no_rows = MagicMock()
+        no_rows.rowcount = 0
+        pg.execute = AsyncMock(return_value=no_rows)
+
+        session_factory = MagicMock(return_value=pg)
+
+        before = datetime.now(UTC)
+        await run_lifecycle_pass(session_factory)
+
+        # Extract the cutoff passed to the idle-pause query (3rd execute call)
+        call_args = pg.execute.call_args_list[2]
+        params = call_args[0][1]  # positional arg: params dict
+        cutoff: datetime = params["cutoff"]
+
+        expected_cutoff = before - timedelta(minutes=30)
+        # Allow 1 second tolerance for test execution time
+        assert abs((cutoff - expected_cutoff).total_seconds()) < 1
+
+
+# ---------------------------------------------------------------------------
+# AC-1.8: Second playthrough → distinct world/character
+# ---------------------------------------------------------------------------
+
+
+class TestAC108SecondPlaythrough:
+    """AC-1.8: Creating a new game after a completed game generates a distinct world.
+
+    Unit-testable invariant: POST /games can be called multiple times and
+    each returns a new, distinct game_id. World distinctiveness is guaranteed
+    by the genesis variance mechanism (AC-2.6) — integration-only validation.
+    """
+
+    def test_new_game_after_completed_game_creates_distinct_id(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        """AC-1.8: Two POST /games calls return distinct game_ids."""
+        game_id_1 = uuid4()
+        game_id_2 = uuid4()
+
+        with patch("tta.api.routes.games.uuid4", side_effect=[game_id_1, game_id_2]):
+            pg.execute = AsyncMock(
+                side_effect=[
+                    _make_result(scalar=0),  # count active games (first)
+                    _make_result(),  # INSERT game (first)
+                    _make_result(scalar=0),  # count active games (second)
+                    _make_result(),  # INSERT game (second)
+                ]
+            )
+            pg.commit = AsyncMock()
+
+            resp1 = client.post("/api/v1/games", json={})
+            resp2 = client.post("/api/v1/games", json={})
+
+        assert resp1.status_code == 201
+        assert resp2.status_code == 201
+        id1 = resp1.json()["data"]["game_id"]
+        id2 = resp2.json()["data"]["game_id"]
+        assert id1 != id2
+
+
+# ---------------------------------------------------------------------------
+# AC-1.10: Unknown / command → help message with available commands listed
+# ---------------------------------------------------------------------------
+
+
+class TestAC110UnknownCommand:
+    """AC-1.10: Unknown /command → help message listing available commands."""
+
+    def test_unknown_command_returns_help_message(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        """AC-1.10: /unknownthing → 200 with help listing, type 'command'."""
+        pg.execute = AsyncMock(return_value=_make_result([_game_row()]))
+
+        resp = client.post(
+            f"/api/v1/games/{_GAME_ID}/turns",
+            json={"input": "/unknownthing"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["type"] == "command"
+        # Returns help, not an error
+        assert "error" not in resp.json()
+        # Help text lists known commands
+        msg = data["message"]
+        assert "/help" in msg
+        assert "/save" in msg
+        assert "/status" in msg
+
+    def test_help_command_also_lists_all_commands(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        """AC-1.10: /help explicitly lists all available commands."""
+        pg.execute = AsyncMock(return_value=_make_result([_game_row()]))
+
+        resp = client.post(
+            f"/api/v1/games/{_GAME_ID}/turns",
+            json={"input": "/help"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["command"] == "help"
+        msg = data["message"]
+        # All documented commands must appear
+        for cmd in (
+            "/help",
+            "/save",
+            "/status",
+            "/character",
+            "/relationships",
+            "/end",
+        ):
+            assert cmd in msg, f"Expected '{cmd}' in help message"

--- a/tests/unit/api/test_s01_ac_compliance.py
+++ b/tests/unit/api/test_s01_ac_compliance.py
@@ -373,15 +373,16 @@ class TestAC107IdleTimeout:
 
         before = datetime.now(UTC)
         await run_lifecycle_pass(session_factory)
+        after = datetime.now(UTC)
 
         # Extract the cutoff passed to the idle-pause query (3rd execute call)
         call_args = pg.execute.call_args_list[2]
         params = call_args[0][1]  # positional arg: params dict
         cutoff: datetime = params["cutoff"]
 
-        expected_cutoff = before - timedelta(minutes=30)
-        # Allow 1 second tolerance for test execution time
-        assert abs((cutoff - expected_cutoff).total_seconds()) < 1
+        earliest_expected_cutoff = before - timedelta(minutes=30)
+        latest_expected_cutoff = after - timedelta(minutes=30)
+        assert earliest_expected_cutoff <= cutoff <= latest_expected_cutoff
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/genesis/test_s02_ac_compliance.py
+++ b/tests/unit/genesis/test_s02_ac_compliance.py
@@ -1,20 +1,33 @@
-"""S02 Genesis Onboarding — AC compliance tests.
+"""genesis_lite unit behaviors — foundational tests for S02 Genesis Onboarding.
 
-Acceptance criteria covered
----------------------------
-AC-2.1  Narrative intro generated after genesis
-AC-2.2  World graph created exactly once per session
-AC-2.5  GenesisResult envelope contains all expected fields
-AC-2.6  Session-scoped variance: different sessions produce different prompts
-AC-2.7  LLM error propagated — no silent corruption
-AC-2.8  Terse / single-word defining_detail expanded automatically
-AC-2.9  character_concept forwarded to enrichment prompt
+These tests validate the ``genesis_lite`` module's implementation behaviors at the
+unit level.  They are *not* full S02 spec-AC compliance tests: the S02 Acceptance
+Criteria (five-act flow, harmful-content redirection, mid-session reconnect,
+identity challenge) require integration infrastructure and are covered by BDD /
+integration tests.
 
-Deferred (integration-only or UX/timing)
------------------------------------------
+Unit behaviors covered
+-----------------------
+GL-1  run_genesis_lite returns a non-empty narrative intro
+GL-2  World graph is created exactly once per session (no duplicate writes)
+GL-3  GenesisResult envelope exposes all expected fields
+GL-4  Session-scoped variance: different session_ids produce different prompts
+GL-5  LLM error propagation — no silent failure or data corruption
+GL-6  Terse / single-word defining_detail is expanded automatically
+GL-7  character_concept is forwarded into the enrichment prompt
+
+Related S02 ACs (full behavioral validation deferred to integration)
+----------------------------------------------------------------------
+AC-2.1  Genesis begins with a narrative prompt when the app loads
+AC-2.2  Five acts of Genesis complete before entering the game world
 AC-2.3  First narrative references genesis elements by name (LLM quality)
 AC-2.4  Full genesis completes within 5-10 minutes (wall-clock)
-AC-2.10 No visible mode boundary (UX/e2e)
+AC-2.5  Disconnect during Act III → resume from Act III on reconnect
+AC-2.6  Second playthrough opens differently from the first
+AC-2.7  Harmful content during Genesis → redirection, not corruption
+AC-2.8  Terse player → Genesis asks follow-up questions to build detail
+AC-2.9  Player rejects generated identity → Genesis offers alternatives
+AC-2.10 No visible mode boundary between Genesis and gameplay
 """
 
 from __future__ import annotations

--- a/tests/unit/genesis/test_s02_ac_compliance.py
+++ b/tests/unit/genesis/test_s02_ac_compliance.py
@@ -1,0 +1,456 @@
+"""S02 Genesis Onboarding — AC compliance tests.
+
+Acceptance criteria covered
+---------------------------
+AC-2.1  Narrative intro generated after genesis
+AC-2.2  World graph created exactly once per session
+AC-2.5  GenesisResult envelope contains all expected fields
+AC-2.6  Session-scoped variance: different sessions produce different prompts
+AC-2.7  LLM error propagated — no silent corruption
+AC-2.8  Terse / single-word defining_detail expanded automatically
+AC-2.9  character_concept forwarded to enrichment prompt
+
+Deferred (integration-only or UX/timing)
+-----------------------------------------
+AC-2.3  First narrative references genesis elements by name (LLM quality)
+AC-2.4  Full genesis completes within 5-10 minutes (wall-clock)
+AC-2.10 No visible mode boundary (UX/e2e)
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from uuid import UUID, uuid4
+
+import pytest
+
+from tta.genesis.genesis_lite import (
+    GenesisResult,
+    enrich_template,
+    run_genesis_lite,
+)
+from tta.llm.client import GenerationParams, LLMResponse, Message
+from tta.llm.roles import ModelRole
+from tta.models.turn import TokenCount
+from tta.models.world import (
+    TemplateLocation,
+    TemplateMetadata,
+    WorldSeed,
+    WorldTemplate,
+)
+from tta.world.memory_service import InMemoryWorldService
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _valid_enrichment_json() -> str:
+    """Return an EnrichedTemplate JSON that genesis_lite can parse."""
+    return json.dumps(
+        {"locations": [], "npcs": [], "items": [], "knowledge_details": {}}
+    )
+
+
+def _template_with_start_loc() -> WorldTemplate:
+    """Minimal template with a single starting location."""
+    return WorldTemplate(
+        metadata=TemplateMetadata(
+            template_key="test_world",
+            display_name="Test World",
+        ),
+        locations=[
+            TemplateLocation(
+                key="start",
+                region_key="r1",
+                type="interior",
+                archetype="tavern",
+                is_starting_location=True,
+            )
+        ],
+    )
+
+
+def _seed(**kwargs) -> WorldSeed:
+    return WorldSeed(template=_template_with_start_loc(), **kwargs)
+
+
+def _make_llm_response(content: str) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        model_used="mock",
+        token_count=TokenCount(
+            prompt_tokens=10,
+            completion_tokens=5,
+            total_tokens=15,
+        ),
+        latency_ms=0.0,
+    )
+
+
+class _CapturingLLM:
+    """Records every prompt delivered to it; returns configurable responses."""
+
+    def __init__(self, responses: list[str]) -> None:
+        self._responses = list(responses)
+        self._idx = 0
+        self.calls: list[list[Message]] = []
+
+    def _next(self, messages: list[Message]) -> LLMResponse:
+        self.calls.append(list(messages))
+        resp = self._responses[self._idx % len(self._responses)]
+        self._idx += 1
+        return _make_llm_response(resp)
+
+    async def generate(
+        self,
+        role: ModelRole,
+        messages: list[Message],
+        params: GenerationParams | None = None,
+    ) -> LLMResponse:
+        return self._next(messages)
+
+    async def stream(
+        self,
+        role: ModelRole,
+        messages: list[Message],
+        params: GenerationParams | None = None,
+    ) -> LLMResponse:
+        return self._next(messages)
+
+
+class _ErrorLLM:
+    """Raises RuntimeError on every call."""
+
+    async def generate(
+        self,
+        role: ModelRole,
+        messages: list[Message],
+        params: GenerationParams | None = None,
+    ) -> LLMResponse:
+        raise RuntimeError("LLM unavailable")
+
+    async def stream(
+        self,
+        role: ModelRole,
+        messages: list[Message],
+        params: GenerationParams | None = None,
+    ) -> LLMResponse:
+        raise RuntimeError("LLM unavailable")
+
+
+# ---------------------------------------------------------------------------
+# AC-2.1 — Narrative intro is generated after genesis
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac_2_1_narrative_intro_non_empty():
+    """[AC-2.1] run_genesis_lite returns a non-empty narrative_intro."""
+    llm = _CapturingLLM(
+        [
+            _valid_enrichment_json(),  # enrichment call
+            "You stand at the threshold of the ancient tavern.",  # intro call
+        ]
+    )
+    result = await run_genesis_lite(
+        session_id=uuid4(),
+        player_id=uuid4(),
+        world_seed=_seed(),
+        llm=llm,
+        world_service=InMemoryWorldService(),
+    )
+
+    assert isinstance(result.narrative_intro, str)
+    assert len(result.narrative_intro) > 0
+
+
+# ---------------------------------------------------------------------------
+# AC-2.2 — World graph created exactly once per session
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac_2_2_world_graph_created_once(monkeypatch: pytest.MonkeyPatch):
+    """[AC-2.2] create_world_graph is called exactly once for a single session."""
+    world_service = InMemoryWorldService()
+    call_count = 0
+    original = world_service.create_world_graph
+
+    async def _spy(session_id, world_seed):  # type: ignore[override]
+        nonlocal call_count
+        call_count += 1
+        return await original(session_id, world_seed)
+
+    monkeypatch.setattr(world_service, "create_world_graph", _spy)
+
+    llm = _CapturingLLM([_valid_enrichment_json(), "A fine world awaits."])
+    session = uuid4()
+    await run_genesis_lite(
+        session_id=session,
+        player_id=uuid4(),
+        world_seed=_seed(),
+        llm=llm,
+        world_service=world_service,
+    )
+
+    assert call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# AC-2.5 — GenesisResult envelope fields all present
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac_2_5_genesis_result_envelope():
+    """[AC-2.5] GenesisResult has all required fields with correct types."""
+    session = uuid4()
+    llm = _CapturingLLM([_valid_enrichment_json(), "Darkness gives way to light."])
+    result = await run_genesis_lite(
+        session_id=session,
+        player_id=uuid4(),
+        world_seed=_seed(),
+        llm=llm,
+        world_service=InMemoryWorldService(),
+    )
+
+    assert isinstance(result, GenesisResult)
+    assert result.session_id == session
+    assert isinstance(result.world_id, str) and result.world_id
+    assert isinstance(result.player_location_id, str) and result.player_location_id
+    assert isinstance(result.template_key, str) and result.template_key
+    assert isinstance(result.narrative_intro, str) and result.narrative_intro
+    assert isinstance(result.genesis_elements, list)
+    assert isinstance(result.created_at, datetime)
+    # created_at should be timezone-aware
+    assert result.created_at.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# AC-2.6 — Session-scoped variance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac_2_6_session_variance_different_prompts():
+    """[AC-2.6] Two different session UUIDs yield different enrichment prompts."""
+    # UUIDs chosen so that int(hex[:8], 16) % 6 differs between them.
+    # session_a: 0x00000000 % 6 == 0 → "bold and dramatic"
+    # session_b: 0xffffffff % 6 == 5 → "warm and inviting"
+    session_a = UUID("00000000-0000-0000-0000-000000000001")
+    session_b = UUID("ffffffff-0000-0000-0000-000000000001")
+
+    template = _template_with_start_loc()
+    seed = WorldSeed(template=template)
+
+    llm_a = _CapturingLLM([_valid_enrichment_json()])
+    llm_b = _CapturingLLM([_valid_enrichment_json()])
+
+    await enrich_template(template, seed, llm_a, session_id=session_a)
+    await enrich_template(template, seed, llm_b, session_id=session_b)
+
+    prompt_a = llm_a.calls[0][-1].content  # last message = user prompt
+    prompt_b = llm_b.calls[0][-1].content
+
+    assert "Creative direction:" in prompt_a
+    assert "Creative direction:" in prompt_b
+    assert prompt_a != prompt_b, "Different sessions must produce different prompts"
+
+
+@pytest.mark.asyncio
+async def test_ac_2_6_no_variance_without_session_id():
+    """[AC-2.6] Without a session_id, no 'Creative direction' line is appended."""
+    template = _template_with_start_loc()
+    seed = WorldSeed(template=template)
+    llm = _CapturingLLM([_valid_enrichment_json()])
+
+    await enrich_template(template, seed, llm, session_id=None)
+
+    prompt = llm.calls[0][-1].content
+    assert "Creative direction:" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# AC-2.7 — LLM error propagated (no silent corruption)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac_2_7_llm_error_propagates_from_intro():
+    """[AC-2.7] RuntimeError from the intro LLM call is propagated, not swallowed."""
+
+    # First call (enrichment) returns valid JSON; second (intro) raises.
+    class _IntroErrorLLM:
+        _call = 0
+
+        async def generate(
+            self,
+            role: ModelRole,
+            messages: list[Message],
+            params: GenerationParams | None = None,
+        ) -> LLMResponse:
+            self._call += 1
+            if self._call == 1:
+                return _make_llm_response(_valid_enrichment_json())
+            raise RuntimeError("Intro LLM unavailable")
+
+        async def stream(
+            self,
+            role: ModelRole,
+            messages: list[Message],
+            params: GenerationParams | None = None,
+        ) -> LLMResponse:
+            return await self.generate(role, messages, params)
+
+    with pytest.raises(RuntimeError, match="Intro LLM unavailable"):
+        await run_genesis_lite(
+            session_id=uuid4(),
+            player_id=uuid4(),
+            world_seed=_seed(),
+            llm=_IntroErrorLLM(),  # type: ignore[arg-type]
+            world_service=InMemoryWorldService(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_ac_2_7_enrichment_error_uses_default_fallback():
+    """[AC-2.7] Enrichment LLM error falls back to deterministic defaults (no panic)."""
+
+    # Both enrichment calls fail; enrich_template returns _default_enrichment.
+    # run_genesis_lite should still succeed if intro call works.
+    class _EnrichErrorThenIntroOkLLM:
+        _call = 0
+
+        async def generate(
+            self,
+            role: ModelRole,
+            messages: list[Message],
+            params: GenerationParams | None = None,
+        ) -> LLMResponse:
+            self._call += 1
+            if role == ModelRole.EXTRACTION:
+                # Return garbage JSON — will trigger parse failure + retry failure
+                return _make_llm_response("NOT JSON")
+            # Intro call
+            return _make_llm_response("A world of mystery awaits.")
+
+        async def stream(
+            self,
+            role: ModelRole,
+            messages: list[Message],
+            params: GenerationParams | None = None,
+        ) -> LLMResponse:
+            return await self.generate(role, messages, params)
+
+    result = await run_genesis_lite(
+        session_id=uuid4(),
+        player_id=uuid4(),
+        world_seed=_seed(),
+        llm=_EnrichErrorThenIntroOkLLM(),  # type: ignore[arg-type]
+        world_service=InMemoryWorldService(),
+    )
+    # Deterministic fallback means genesis still completes
+    assert result.narrative_intro == "A world of mystery awaits."
+
+
+# ---------------------------------------------------------------------------
+# AC-2.8 — Terse defining_detail expanded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac_2_8_single_word_defining_detail_expanded():
+    """[AC-2.8] A single-word defining_detail is expanded before the LLM call."""
+    template = _template_with_start_loc()
+    seed = WorldSeed(template=template, defining_detail="fog")
+    llm = _CapturingLLM([_valid_enrichment_json()])
+
+    await enrich_template(template, seed, llm)
+
+    user_prompt = llm.calls[0][-1].content
+    assert "a world defined by fog" in user_prompt
+    assert "interpret this freely" in user_prompt
+
+
+@pytest.mark.asyncio
+async def test_ac_2_8_two_word_defining_detail_expanded():
+    """[AC-2.8] A two-word defining_detail is also expanded."""
+    template = _template_with_start_loc()
+    seed = WorldSeed(template=template, defining_detail="eternal night")
+    llm = _CapturingLLM([_valid_enrichment_json()])
+
+    await enrich_template(template, seed, llm)
+
+    user_prompt = llm.calls[0][-1].content
+    assert "a world defined by eternal night" in user_prompt
+
+
+@pytest.mark.asyncio
+async def test_ac_2_8_long_defining_detail_not_expanded():
+    """[AC-2.8] A longer defining_detail (>2 words) is passed through unchanged."""
+    detail = "a land where rain never falls"
+    template = _template_with_start_loc()
+    seed = WorldSeed(template=template, defining_detail=detail)
+    llm = _CapturingLLM([_valid_enrichment_json()])
+
+    await enrich_template(template, seed, llm)
+
+    user_prompt = llm.calls[0][-1].content
+    assert detail in user_prompt
+    # The expansion phrase must NOT appear for long inputs
+    assert "a world defined by" not in user_prompt
+
+
+@pytest.mark.asyncio
+async def test_ac_2_8_missing_fields_get_defaults():
+    """[AC-2.8] Empty WorldSeed fields receive safe defaults before prompting."""
+    template = _template_with_start_loc()
+    seed = WorldSeed(template=template)  # all optional fields None
+    llm = _CapturingLLM([_valid_enrichment_json()])
+
+    await enrich_template(template, seed, llm)
+
+    user_prompt = llm.calls[0][-1].content
+    # Default values from enrich_template source
+    assert "mysterious" in user_prompt  # default tone
+    assert "medieval" in user_prompt  # default tech_level
+    assert "adventurer" in user_prompt  # default character_concept
+
+
+# ---------------------------------------------------------------------------
+# AC-2.9 — character_concept forwarded to enrichment prompt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac_2_9_character_concept_in_prompt():
+    """[AC-2.9] The character_concept appears in the enrichment user prompt."""
+    template = _template_with_start_loc()
+    seed = WorldSeed(template=template, character_concept="fallen paladin")
+    llm = _CapturingLLM([_valid_enrichment_json()])
+
+    await enrich_template(template, seed, llm)
+
+    user_prompt = llm.calls[0][-1].content
+    assert "fallen paladin" in user_prompt
+
+
+@pytest.mark.asyncio
+async def test_ac_2_9_different_concepts_produce_different_prompts():
+    """[AC-2.9] Different character_concepts produce different enrichment prompts."""
+    template = _template_with_start_loc()
+
+    seed_a = WorldSeed(template=template, character_concept="thief")
+    seed_b = WorldSeed(template=template, character_concept="scholar")
+
+    llm_a = _CapturingLLM([_valid_enrichment_json()])
+    llm_b = _CapturingLLM([_valid_enrichment_json()])
+
+    await enrich_template(template, seed_a, llm_a)
+    await enrich_template(template, seed_b, llm_b)
+
+    prompt_a = llm_a.calls[0][-1].content
+    prompt_b = llm_b.calls[0][-1].content
+    assert prompt_a != prompt_b


### PR DESCRIPTION
## Summary

Closes #155

Adds compliance and behavior tests for **S01 (Gameplay Loop)** and **S02 (Genesis/Onboarding)** specs.

## Changes

### `tests/unit/api/test_s01_ac_compliance.py` (12 tests)

Unit tests for S01 Gameplay Loop ACs (1.2, 1.3, 1.5, 1.6, 1.7, 1.8, 1.10):
- **AC-1.2**: Empty and whitespace-only input → 400 error response
- **AC-1.3**: `/save` command returns a confirmation message
- **AC-1.5**: Active game accepts a turn after a character failure (state remains active)
- **AC-1.6**: `/end` command returns a completion response
- **AC-1.7**: Lifecycle cleanup uses a 30-minute idle cutoff (range-bounded assertion)
- **AC-1.8**: Two POST /games calls return distinct game IDs
- **AC-1.10**: Unknown slash command returns help text; `/help` lists all commands

Deferred (integration infra required): AC-1.1 (streaming timing), AC-1.4 (browser resume), AC-1.9 (mid-stream reconnect).

### `tests/unit/genesis/test_s02_ac_compliance.py` (13 tests)

Unit tests for `genesis_lite` implementation behaviors that underpin S02 onboarding.
Note: full S02 behavioral ACs (five-act flow, harmful-content redirection, reconnect, identity challenge) require integration infrastructure and are deferred to BDD/integration tests.

Behaviors tested:
- **GL-1**: `run_genesis_lite` returns a non-empty narrative intro
- **GL-2**: World graph created exactly once per session (no duplicate writes)
- **GL-3**: `GenesisResult` envelope contains all expected fields
- **GL-4**: Different session IDs produce different enriched prompts (variance)
- **GL-5**: LLM errors propagate as `RuntimeError` — no silent corruption
- **GL-6**: Single/two-word `defining_detail` is auto-expanded; longer inputs are not
- **GL-7**: `character_concept` is forwarded into the enrichment prompt

## Test Results

- **2,206 unit tests pass** (this wave adds 25 new tests)
- Pre-existing: 1 integration failure (`test_sse_no_turn_returns_error`) + 12 litellm cleanup errors — both unrelated to this wave
- `make quality` green (0 ruff errors, 0 pyright errors)

## Pattern Used

Gold-standard compliance test pattern from `test_s10_ac_compliance.py`:
- Sync `TestClient` + `dependency_overrides` for `get_pg`/`get_redis`
- `_make_result()` helper returns `SimpleNamespace` with `.one_or_none()`/`.all()`