### PR TITLE
fix: V1 sim runner + world templates for live end-to-end validation

### DIFF
--- a/scripts/sim_runner.py
+++ b/scripts/sim_runner.py
@@ -518,7 +518,10 @@ async def run(
     report = SimReport()
     t0 = time.monotonic()
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
+    # Use longer read timeout: genesis LLM calls can be slow on free-tier models
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(connect=10.0, read=120.0, write=30.0, pool=5.0)
+    ) as client:
         # Pre-flight health check
         if not json_output:
             print(_c("Pre-flight: checking API readiness…", DIM, color=color))

--- a/src/tta/llm/roles.py
+++ b/src/tta/llm/roles.py
@@ -31,7 +31,7 @@ DEFAULT_ROLE_CONFIGS: dict[ModelRole, ModelRoleConfig] = {
         fallback="anthropic/claude-haiku-4-20250514",
         temperature=0.85,
         max_tokens=1024,
-        timeout_seconds=30.0,
+        timeout_seconds=90.0,
     ),
     ModelRole.CLASSIFICATION: ModelRoleConfig(
         primary="anthropic/claude-haiku-4-20250514",

--- a/src/tta/observability/pool_metrics.py
+++ b/src/tta/observability/pool_metrics.py
@@ -59,8 +59,13 @@ async def _sample_once(app: FastAPI) -> None:
         if pool is not None:
             raw = getattr(pool, "in_use_connection_count", None)
             if raw is not None:
-                val = raw() if callable(raw) else raw  # type: ignore[operator]
-                NEO4J_POOL_ACTIVE.set(int(val))  # type: ignore[arg-type]
+                try:
+                    val = raw() if callable(raw) else raw  # type: ignore[operator]
+                    NEO4J_POOL_ACTIVE.set(int(val))  # type: ignore[arg-type]
+                except Exception:
+                    NEO4J_POOL_ACTIVE.set(
+                        0
+                    )  # method signature differs in this driver version
 
 
 async def _sampler_loop(app: FastAPI, interval: float) -> None:

--- a/src/tta/observability/pool_metrics.py
+++ b/src/tta/observability/pool_metrics.py
@@ -62,10 +62,12 @@ async def _sample_once(app: FastAPI) -> None:
                 try:
                     val = raw() if callable(raw) else raw  # type: ignore[operator]
                     NEO4J_POOL_ACTIVE.set(int(val))  # type: ignore[arg-type]
-                except Exception:
-                    NEO4J_POOL_ACTIVE.set(
-                        0
-                    )  # method signature differs in this driver version
+                except (TypeError, AttributeError) as exc:
+                    log.debug(
+                        "neo4j_pool_metric_unavailable",
+                        reason=str(exc),
+                    )
+                    NEO4J_POOL_ACTIVE.set(0)
 
 
 async def _sampler_loop(app: FastAPI, interval: float) -> None:

--- a/src/tta/pipeline/types.py
+++ b/src/tta/pipeline/types.py
@@ -83,7 +83,7 @@ class PipelineConfig(BaseModel):
         default_factory=lambda: [
             StageConfig(name=StageName.UNDERSTAND),
             StageConfig(name=StageName.CONTEXT),
-            StageConfig(name=StageName.GENERATE),
+            StageConfig(name=StageName.GENERATE, timeout_seconds=90.0),
             StageConfig(name=StageName.DELIVER),
         ]
     )

--- a/src/tta/world/template_registry.py
+++ b/src/tta/world/template_registry.py
@@ -196,4 +196,13 @@ class TemplateRegistry:
         if scale and scale in meta.compatible_scales:
             score += 1
 
+        # Tag-based matching: award +1 for each template tag that appears
+        # as a word in any preference value (handles "dark forest", "medieval castle")
+        for tag in meta.tags:
+            tag_lower = tag.lower()
+            for pref_val in preferences.values():
+                if tag_lower in pref_val.lower().split():
+                    score += 1
+                    break  # each tag scores at most once
+
         return score

--- a/src/tta/world/template_registry.py
+++ b/src/tta/world/template_registry.py
@@ -198,7 +198,7 @@ class TemplateRegistry:
 
         # Tag-based matching: award +1 for each template tag that appears
         # as a word in any preference value (handles "dark forest", "medieval castle")
-        for tag in meta.tags:
+        for tag in getattr(meta, "tags", []):
             tag_lower = tag.lower()
             for pref_val in preferences.values():
                 if tag_lower in pref_val.lower().split():

--- a/src/tta/world/templates/forest_clearing.json
+++ b/src/tta/world/templates/forest_clearing.json
@@ -1,0 +1,123 @@
+{
+  "metadata": {
+    "template_key": "forest_clearing",
+    "display_name": "The Ancient Forest",
+    "tags": ["fantasy", "forest", "dark", "nature", "outdoor", "woodland"],
+    "compatible_tones": ["dark", "hopeful", "whimsical"],
+    "compatible_tech_levels": ["primitive", "medieval"],
+    "compatible_magic": ["rare", "common", "pervasive"],
+    "compatible_scales": ["regional", "national"],
+    "location_count": 4,
+    "npc_count": 2
+  },
+  "regions": [
+    {"key": "reg_edge", "archetype": "forest edge where civilization ends"},
+    {"key": "reg_deep", "archetype": "ancient deep forest where few dare venture"}
+  ],
+  "locations": [
+    {
+      "key": "loc_trailhead",
+      "region_key": "reg_edge",
+      "type": "exterior",
+      "archetype": "overgrown trailhead where the road gives way to twisted roots",
+      "is_starting_location": true,
+      "light_level": "dim",
+      "tags": ["transitional", "eerie"]
+    },
+    {
+      "key": "loc_clearing",
+      "region_key": "reg_edge",
+      "type": "exterior",
+      "archetype": "sunlit clearing ringed by ancient oaks, an old campfire in the center",
+      "light_level": "bright",
+      "tags": ["social", "safe"]
+    },
+    {
+      "key": "loc_ruins",
+      "region_key": "reg_deep",
+      "type": "exterior",
+      "archetype": "moss-covered ruins of a forgotten shrine half-consumed by roots",
+      "light_level": "dim",
+      "tags": ["knowledge", "eerie"]
+    },
+    {
+      "key": "loc_glade",
+      "region_key": "reg_deep",
+      "type": "exterior",
+      "archetype": "silent glade where the air hums with old magic and no bird sings",
+      "light_level": "dark",
+      "tags": ["danger", "hidden"]
+    }
+  ],
+  "connections": [
+    {
+      "from_key": "loc_trailhead",
+      "to_key": "loc_clearing",
+      "direction": "north",
+      "bidirectional": true
+    },
+    {
+      "from_key": "loc_clearing",
+      "to_key": "loc_ruins",
+      "direction": "east",
+      "bidirectional": true
+    },
+    {
+      "from_key": "loc_ruins",
+      "to_key": "loc_glade",
+      "direction": "north",
+      "bidirectional": true,
+      "is_locked": false
+    }
+  ],
+  "npcs": [
+    {
+      "key": "npc_hermit",
+      "location_key": "loc_clearing",
+      "role": "quest_giver",
+      "archetype": "weather-beaten hermit who has lived in the forest for decades",
+      "disposition": "neutral"
+    },
+    {
+      "key": "npc_spirit",
+      "location_key": "loc_glade",
+      "role": "ambient",
+      "archetype": "luminous forest spirit bound to the ancient glade",
+      "disposition": "neutral"
+    }
+  ],
+  "items": [
+    {
+      "key": "item_carved_marker",
+      "location_key": "loc_trailhead",
+      "npc_key": null,
+      "type": "environmental",
+      "archetype": "carved wooden marker warning travelers to turn back",
+      "portable": false,
+      "hidden": false
+    },
+    {
+      "key": "item_shrine_token",
+      "location_key": "loc_ruins",
+      "npc_key": null,
+      "type": "quest",
+      "archetype": "small stone token etched with a symbol that glows faintly at dusk",
+      "portable": true,
+      "hidden": true
+    }
+  ],
+  "knowledge": [
+    {
+      "npc_key": "npc_hermit",
+      "about_key": "loc_glade",
+      "knowledge_type": "location",
+      "is_secret": true
+    },
+    {
+      "npc_key": "npc_spirit",
+      "about_key": "item_shrine_token",
+      "knowledge_type": "item",
+      "is_secret": false
+    }
+  ]
+}

--- a/src/tta/world/templates/forest_clearing.json
+++ b/src/tta/world/templates/forest_clearing.json
@@ -91,7 +91,7 @@
       "key": "item_carved_marker",
       "location_key": "loc_trailhead",
       "npc_key": null,
-      "type": "environmental",
+      "type": "ambient",
       "archetype": "carved wooden marker warning travelers to turn back",
       "portable": false,
       "hidden": false

--- a/src/tta/world/templates/mountain_castle.json
+++ b/src/tta/world/templates/mountain_castle.json
@@ -121,7 +121,7 @@
       "key": "item_battle_map",
       "location_key": "loc_tower",
       "npc_key": null,
-      "type": "environmental",
+      "type": "ambient",
       "archetype": "detailed battle map with troop positions marked in grease pencil",
       "portable": false,
       "hidden": false

--- a/src/tta/world/templates/mountain_castle.json
+++ b/src/tta/world/templates/mountain_castle.json
@@ -1,0 +1,144 @@
+{
+  "metadata": {
+    "template_key": "mountain_castle",
+    "display_name": "The Mountain Citadel",
+    "tags": ["fantasy", "castle", "medieval", "fortress", "epic", "political"],
+    "compatible_tones": ["dark", "austere", "hopeful"],
+    "compatible_tech_levels": ["medieval", "industrial"],
+    "compatible_magic": ["none", "rare", "common"],
+    "compatible_scales": ["regional", "national", "global"],
+    "location_count": 5,
+    "npc_count": 3
+  },
+  "regions": [
+    {"key": "reg_outer", "archetype": "outer bailey and castle approach"},
+    {"key": "reg_inner", "archetype": "inner keep with great hall and towers"}
+  ],
+  "locations": [
+    {
+      "key": "loc_gatehouse",
+      "region_key": "reg_outer",
+      "type": "exterior",
+      "archetype": "stone gatehouse spanning a dry moat, portcullis raised but guards watching",
+      "is_starting_location": true,
+      "light_level": "bright",
+      "tags": ["transitional", "danger"]
+    },
+    {
+      "key": "loc_courtyard",
+      "region_key": "reg_outer",
+      "type": "exterior",
+      "archetype": "cobbled courtyard where soldiers drill and merchants hawk wares",
+      "light_level": "bright",
+      "tags": ["social", "loud"]
+    },
+    {
+      "key": "loc_great_hall",
+      "region_key": "reg_inner",
+      "type": "interior",
+      "archetype": "great hall with a long feasting table beneath banners of old victories",
+      "light_level": "bright",
+      "tags": ["social", "knowledge"]
+    },
+    {
+      "key": "loc_armory",
+      "region_key": "reg_inner",
+      "type": "interior",
+      "archetype": "well-stocked armory smelling of oil and iron",
+      "light_level": "dim",
+      "tags": ["danger", "hidden"]
+    },
+    {
+      "key": "loc_tower",
+      "region_key": "reg_inner",
+      "type": "interior",
+      "archetype": "high tower overlooking the mountain pass, maps spread across a war table",
+      "light_level": "bright",
+      "tags": ["knowledge", "eerie"]
+    }
+  ],
+  "connections": [
+    {
+      "from_key": "loc_gatehouse",
+      "to_key": "loc_courtyard",
+      "direction": "north",
+      "bidirectional": true
+    },
+    {
+      "from_key": "loc_courtyard",
+      "to_key": "loc_great_hall",
+      "direction": "north",
+      "bidirectional": true
+    },
+    {
+      "from_key": "loc_great_hall",
+      "to_key": "loc_armory",
+      "direction": "east",
+      "bidirectional": true
+    },
+    {
+      "from_key": "loc_great_hall",
+      "to_key": "loc_tower",
+      "direction": "up",
+      "bidirectional": true,
+      "is_locked": true
+    }
+  ],
+  "npcs": [
+    {
+      "key": "npc_guard_captain",
+      "location_key": "loc_gatehouse",
+      "role": "quest_giver",
+      "archetype": "scarred guard captain who has defended the castle for twenty years",
+      "disposition": "neutral"
+    },
+    {
+      "key": "npc_steward",
+      "location_key": "loc_great_hall",
+      "role": "merchant",
+      "archetype": "hawk-faced steward who manages the castle's affairs with cold efficiency",
+      "disposition": "neutral"
+    },
+    {
+      "key": "npc_court_mage",
+      "location_key": "loc_tower",
+      "role": "ambient",
+      "archetype": "elderly court mage studying the movements of enemy forces in the pass below",
+      "disposition": "friendly"
+    }
+  ],
+  "items": [
+    {
+      "key": "item_signet_ring",
+      "location_key": null,
+      "npc_key": "npc_steward",
+      "type": "quest",
+      "archetype": "heavy signet ring bearing the lord's seal, grant of passage",
+      "portable": true,
+      "hidden": false
+    },
+    {
+      "key": "item_battle_map",
+      "location_key": "loc_tower",
+      "npc_key": null,
+      "type": "environmental",
+      "archetype": "detailed battle map with troop positions marked in grease pencil",
+      "portable": false,
+      "hidden": false
+    }
+  ],
+  "knowledge": [
+    {
+      "npc_key": "npc_guard_captain",
+      "about_key": "npc_court_mage",
+      "knowledge_type": "character",
+      "is_secret": true
+    },
+    {
+      "npc_key": "npc_court_mage",
+      "about_key": "loc_armory",
+      "knowledge_type": "location",
+      "is_secret": false
+    }
+  ]
+}

--- a/src/tta/world/templates/tavern_inn.json
+++ b/src/tta/world/templates/tavern_inn.json
@@ -1,0 +1,130 @@
+{
+  "metadata": {
+    "template_key": "tavern_inn",
+    "display_name": "The Wanderer's Rest",
+    "tags": ["fantasy", "tavern", "social", "inn", "warm", "cozy"],
+    "compatible_tones": ["hopeful", "whimsical", "dark"],
+    "compatible_tech_levels": ["primitive", "medieval"],
+    "compatible_magic": ["none", "rare", "common"],
+    "compatible_scales": ["intimate", "regional"],
+    "location_count": 4,
+    "npc_count": 3
+  },
+  "regions": [
+    {"key": "reg_common", "archetype": "busy tavern common area"},
+    {"key": "reg_back", "archetype": "private back rooms and cellar"}
+  ],
+  "locations": [
+    {
+      "key": "loc_entrance",
+      "region_key": "reg_common",
+      "type": "exterior",
+      "archetype": "tavern entrance with a creaking wooden sign swaying overhead",
+      "is_starting_location": true,
+      "light_level": "bright",
+      "tags": ["transitional", "social"]
+    },
+    {
+      "key": "loc_common_room",
+      "region_key": "reg_common",
+      "type": "interior",
+      "archetype": "warm common room packed with travelers and the smell of roasting meat",
+      "light_level": "bright",
+      "tags": ["social", "loud"]
+    },
+    {
+      "key": "loc_bar",
+      "region_key": "reg_common",
+      "type": "interior",
+      "archetype": "long bar of scarred oak where the innkeeper pours drinks",
+      "light_level": "bright",
+      "tags": ["social", "knowledge"]
+    },
+    {
+      "key": "loc_back_room",
+      "region_key": "reg_back",
+      "type": "interior",
+      "archetype": "private back room used for hushed deals and secret meetings",
+      "light_level": "dim",
+      "tags": ["hidden", "danger"]
+    }
+  ],
+  "connections": [
+    {
+      "from_key": "loc_entrance",
+      "to_key": "loc_common_room",
+      "direction": "north",
+      "bidirectional": true
+    },
+    {
+      "from_key": "loc_common_room",
+      "to_key": "loc_bar",
+      "direction": "east",
+      "bidirectional": true
+    },
+    {
+      "from_key": "loc_bar",
+      "to_key": "loc_back_room",
+      "direction": "north",
+      "bidirectional": true,
+      "is_locked": false
+    }
+  ],
+  "npcs": [
+    {
+      "key": "npc_innkeeper",
+      "location_key": "loc_bar",
+      "role": "quest_giver",
+      "archetype": "stout innkeeper who knows every rumor in the region",
+      "disposition": "friendly"
+    },
+    {
+      "key": "npc_bard",
+      "location_key": "loc_common_room",
+      "role": "ambient",
+      "archetype": "traveling bard strumming a battered lute",
+      "disposition": "friendly"
+    },
+    {
+      "key": "npc_hooded_stranger",
+      "location_key": "loc_back_room",
+      "role": "merchant",
+      "archetype": "hooded stranger nursing a drink and watching the room",
+      "disposition": "neutral"
+    }
+  ],
+  "items": [
+    {
+      "key": "item_notice_board",
+      "location_key": "loc_entrance",
+      "npc_key": null,
+      "type": "environmental",
+      "archetype": "notice board covered in job postings and wanted posters",
+      "portable": false,
+      "hidden": false
+    },
+    {
+      "key": "item_sealed_letter",
+      "location_key": null,
+      "npc_key": "npc_hooded_stranger",
+      "type": "quest",
+      "archetype": "sealed letter bearing an unfamiliar wax crest",
+      "portable": true,
+      "hidden": true
+    }
+  ],
+  "knowledge": [
+    {
+      "npc_key": "npc_innkeeper",
+      "about_key": "npc_hooded_stranger",
+      "knowledge_type": "character",
+      "is_secret": true
+    },
+    {
+      "npc_key": "npc_bard",
+      "about_key": "loc_back_room",
+      "knowledge_type": "location",
+      "is_secret": false
+    }
+  ]
+}

--- a/src/tta/world/templates/tavern_inn.json
+++ b/src/tta/world/templates/tavern_inn.json
@@ -98,7 +98,7 @@
       "key": "item_notice_board",
       "location_key": "loc_entrance",
       "npc_key": null,
-      "type": "environmental",
+      "type": "ambient",
       "archetype": "notice board covered in job postings and wanted posters",
       "portable": false,
       "hidden": false

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -120,22 +120,27 @@ def _run_migrations(
         import pytest
 
         combined = (result.stdout + result.stderr).lower()
-        if any(
-            kw in combined
-            for kw in (
-                "connection refused",
-                "could not connect",
-                "connect call failed",
-                "connection timed out",
-                "oserror",
-                "econnrefused",
-                "target server attribute",
-                "password authentication",
-                "authentication failed",
-                "invalid password",
-                "role",
-                "does not exist",
+        # Specific auth-user-missing: FATAL: role "xyz" does not exist
+        _auth_user_missing = (
+            "fatal" in combined and "role" in combined and "does not exist" in combined
+        )
+        if (
+            any(
+                kw in combined
+                for kw in (
+                    "connection refused",
+                    "could not connect",
+                    "connect call failed",
+                    "connection timed out",
+                    "oserror",
+                    "econnrefused",
+                    "target server attribute",
+                    "password authentication",
+                    "authentication failed",
+                    "invalid password",
+                )
             )
+            or _auth_user_missing
         ):
             pytest.skip(
                 f"PostgreSQL unavailable (alembic exit {result.returncode}): "

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -130,6 +130,11 @@ def _run_migrations(
                 "oserror",
                 "econnrefused",
                 "target server attribute",
+                "password authentication",
+                "authentication failed",
+                "invalid password",
+                "role",
+                "does not exist",
             )
         ):
             pytest.skip(

--- a/tests/simulation/test_smart_router.py
+++ b/tests/simulation/test_smart_router.py
@@ -26,7 +26,7 @@ async def test_with_smart_router():
     llm = SmartRouterLLMClient(task_type="simple")
     world_service = InMemoryWorldService()
     template_registry = TemplateRegistry(
-        directory=Path(__file__).resolve().parents[1]
+        directory=Path(__file__).resolve().parents[2]
         / "src"
         / "tta"
         / "world"


### PR DESCRIPTION
## Summary

This PR contains all fixes from the V1 live simulation validation campaign.
All 4 sim scenarios now pass (11/11 turns) against a live Docker stack.

## Changes

### World templates (3 new templates)
- `src/tta/world/templates/tavern_inn.json` — fantasy tavern world
- `src/tta/world/templates/forest_clearing.json` — dark forest world  
- `src/tta/world/templates/mountain_castle.json` — medieval castle world
- Fixed: all templates use `"type": "ambient"` (not `"environmental"`, which is not a valid ItemType value)

### Template registry (`template_registry.py`)
- Added tag-matching loop to `_score_preferences()` so world selection by genre preference works correctly (e.g. `{'genre': 'fantasy'}` → correct template)

### LLM + pipeline timeouts
- `src/tta/llm/roles.py` — GENERATION role timeout raised 30s → 90s
- `src/tta/pipeline/types.py` — GENERATE stage asyncio timeout raised 30s → 90s
- Prevents premature cancellation of LLM calls on free-tier models (~14s avg response time)

### Observability
- `src/tta/observability/pool_metrics.py` — wrapped `in_use_connection_count(address)` in try/except; sets gauge to 0 on Neo4j API mismatch error (positional arg issue)

### Sim harness
- `scripts/sim_runner.py` — per-operation `httpx.Timeout(connect=10, read=120, write=30, pool=5)` to match actual LLM response latencies

### CI fixes
- `aff885a` — tightened integration test skip keywords to avoid masking schema errors
- `05abb8b` — fixed simulation template path and integration skip on DB auth errors

## Sim validation results

```
Scenarios: 4 | Turns: 11/11 ✅
quick:   1/1 turns PASSED
tavern:  3/3 turns PASSED
forest:  3/3 turns PASSED
castle:  4/4 turns PASSED
```

Narrative quality is high — coherent, atmospheric prose across all scenarios.

## V1 limitation noted
Turn-to-turn spatial continuity is imperfect (turn 2 may not pick up exact 
location from turn 1). Flagged as primary concern for v2 planning.

## Quality gate
- ruff format/check: ✅ 0 errors
- pyright standard: ✅ 0 errors