### PR TITLE
docs(specs): add v2.0 foundation specs S29-S39

### DIFF
--- a/specs/29-universe-as-first-class-entity.md
+++ b/specs/29-universe-as-first-class-entity.md
@@ -1,0 +1,476 @@
+# S29 — Universe as First-Class Entity
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v2.0
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 3 — Platform
+> **Dependencies**: v1 S04, v1 S11, v1 S12, v1 S13
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+In v1, every game session implicitly created a world as a side effect. The world lived
+and died with the session. There was no concept of a world that outlasted the player's
+current run, could be picked up later, or could be referenced across contexts. This was
+a correct v1 simplification.
+
+v2 changes this. A **Universe** is a named, identifiable, independently-persistent
+entity that **owns** its world — locations, NPCs, items, factions, conditions. Sessions
+exist *within* a universe; they do not define it. When a session ends, the universe
+persists. When a player returns, they re-enter the same universe they left.
+
+This spec defines what a Universe is, what it contains, how its lifecycle is managed,
+and how every world-scoped entity is tied to it via `universe_id`. It is the root
+dependency of the entire v2 forward-compat architecture.
+
+**Three orthogonal concerns** (each has its own spec):
+- **S29** — *Identity*: a universe is a first-class entity with its own ID and boundary.
+- **S33** — *Persistence*: the versioned envelope mechanism for storing universe state.
+- **S39** — *Composition*: the content vocabulary (themes, tropes, archetypes) that
+  fills a universe.
+
+---
+
+## 2. Design Philosophy
+
+### 2.1 Principles
+
+- **Universes outlive sessions**: a session is an ephemeral visit to a universe, not
+  the container that holds it. This inversion — universe owns session context, not
+  the reverse — is the central shift of this spec.
+- **Forward-compat over convenience**: three intentional under-constraints (no DB
+  UNIQUE on `session.universe_id`, denormalized `universe_id` on every entity, opaque
+  `config` blob) protect v4+ from schema migrations at modest application-code cost.
+  See Appendix B.
+- **Identity without content**: this spec defines what a universe IS and its lifecycle.
+  It deliberately avoids prescribing what fills it (S39) or how that state is stored
+  in full detail (S33).
+- **Minimal new surface**: S29 introduces one new entity (Universe) and one new field
+  (`universe_id` on world-scoped entities). All other behavior — session lifecycle,
+  world queries, persistence — is covered by existing specs, extended here.
+
+---
+
+## 3. User Stories
+
+### Persistence & Ownership
+
+> **US-29.1** — **As a** player, I can stop a game session and trust that my universe
+> will be exactly as I left it when I return — the world does not reset.
+
+> **US-29.2** — **As a** player, I can see a list of all my universes (active, paused,
+> archived) and know which one I was last playing in.
+
+> **US-29.3** — **As a** player, I can archive a universe I no longer want to play,
+> removing it from my active list without losing its data.
+
+### Isolation & Integrity
+
+> **US-29.4** — **As a** player, I know that the entities I encounter in one universe
+> (locations, NPCs, items) exist only there — a character from one story will never
+> appear unexpectedly in another.
+
+> **US-29.5** — **As the** platform, when a player has multiple concurrent sessions,
+> each is unambiguously in its own universe with no world data crossing boundaries.
+
+### Developer & Operator
+
+> **US-29.6** — **As a** developer, I can query all world entities belonging to a
+> specific universe using a single `universe_id` filter — no root-node traversal is
+> required.
+
+> **US-29.7** — **As an** operator, I can inspect a universe's identity, status, and
+> config independently of any active session.
+
+---
+
+## 4. Functional Requirements
+
+### FR-29.01 — Universe Identity Fields
+
+A Universe MUST carry the following fields:
+
+| Field | Type | Nullable | Description |
+|-------|------|----------|-------------|
+| `universe_id` | ULID | No | Globally unique identifier. Primary key. |
+| `display_name` | String (1–100 chars) | No | Human-readable name set by the owner. |
+| `owner_id` | ULID | No | The `player_id` of the owning player. |
+| `status` | Enum | No | One of: `created`, `active`, `paused`, `archived`. |
+| `config` | JSON object | No | Opaque config blob. Schema defined by S39. Default: `{}`. |
+| `created_at` | Datetime (UTC) | No | Set at creation. Immutable thereafter. |
+| `updated_at` | Datetime (UTC) | No | Updated on every status or config change. |
+
+### FR-29.02 — Universe Uniqueness
+
+- **FR-29.02a**: `universe_id` MUST be globally unique. Uniqueness MUST be enforced at
+  the database level.
+- **FR-29.02b**: A player MAY have multiple universes with the same `display_name`. The
+  canonical identifier is `universe_id`, not `display_name`.
+
+### FR-29.03 — Universe Ownership
+
+- **FR-29.03a**: Every universe MUST be owned by exactly one player (`owner_id`).
+- **FR-29.03b**: Ownership transfer is out of scope for v2 (see §10).
+- **FR-29.03c**: When a player account is deleted, all universes owned by that player
+  MUST be processed per the data retention rules in S17.
+
+### FR-29.04 — Universe Lifecycle
+
+Universe status transitions are:
+
+```
+          ┌────────────────────────────────────┐
+          │                                    │
+(new) ──► created ──► active ──► paused ──► active  (resume loop)
+                         │         │
+                         │         ▼
+                         └───► archived ◄─── paused
+                                    │
+                                    ▼
+                                 paused  (explicit unarchival)
+```
+
+| Transition | From | To | Trigger |
+|---|---|---|---|
+| Creation | _(none)_ | `created` | Universe entity is created (before any session). |
+| First open | `created` | `active` | A session is opened in this universe (see S30). |
+| Session end | `active` | `paused` | The active session ends (completed or abandoned). |
+| Resume | `paused` | `active` | A new session is opened in this universe. |
+| Archive | `created` or `paused` | `archived` | Explicit archival by the owner. |
+| Unarchive | `archived` | `paused` | Explicit unarchival by the owner. |
+
+- **FR-29.04a**: Ending a session MUST NOT delete the universe or any of its world
+  entities. The session end MUST transition the universe from `active` to `paused`.
+- **FR-29.04b**: Archival MUST be an explicit owner action — it MUST NOT occur
+  automatically on session end or inactivity.
+- **FR-29.04c**: An `archived` universe MUST NOT accept a new session without explicit
+  unarchival first.
+
+### FR-29.05 — World-Entity Universe Scoping
+
+All **world-scoped entity types** as defined in S04 FR-1.1 (Location, Region, NPC,
+Item, Event, Faction, Condition) MUST carry a non-nullable `universe_id` field.
+
+- **FR-29.05a**: `universe_id` on a world entity MUST reference a valid, existing
+  Universe record.
+- **FR-29.05b**: The system MUST reject creation of any world-scoped entity that lacks
+  a valid `universe_id`. Error code: `universe_id_required`.
+- **FR-29.05c**: `universe_id` on a world entity is immutable after creation. Entities
+  cannot be reassigned to a different universe (cross-universe travel is out of scope;
+  see §10).
+
+**Relationship to v1 `world_id`**: In v1, S13 defined a `World` Neo4j node with
+`world_id` as its root identifier, serving implicitly as the universe boundary. In v2,
+`universe_id` is the canonical root identifier. `world_id` and `universe_id` are
+semantically equivalent; migration from `world_id` to `universe_id` is specified in
+S33. See also Appendix A.
+
+### FR-29.06 — Cross-Universe Isolation
+
+- **FR-29.06a**: Creating a relationship between world entities from different universes
+  is FORBIDDEN. The system MUST reject such attempts. Error code:
+  `cross_universe_entity_reference`.
+- **FR-29.06b**: All world-context queries (nearby, history, diff, region) MUST be
+  scoped to a single universe. A query without a `universe_id` scope is invalid.
+- **FR-29.06c**: No world entity MAY appear in context queries for a universe it does
+  not belong to.
+
+### FR-29.07 — Session↔Universe Association
+
+- **FR-29.07a**: Every game session record MUST carry a `universe_id` FK referencing
+  the universe the session is running in.
+- **FR-29.07b**: `universe_id` on a session record is set at session creation and is
+  immutable thereafter.
+
+**v2 Singleton Policy**: At application level, a universe in `active` status MUST be
+associated with at most one `active` game session at any given time.
+
+- **FR-29.07c**: The database schema MUST NOT enforce uniqueness on `session.universe_id`.
+  The singleton policy is enforced in application code only. This forward-compat design
+  permits multiple simultaneous sessions per universe in v4+ without a schema migration.
+- **FR-29.07d**: Attempting to open a session in a universe that is already `active`
+  MUST return an error. Error code: `universe_already_active`.
+- **FR-29.07e**: The atomic status-check-and-bind protocol (read `active` status, open
+  session, update universe status — race-condition-safe) is specified in S30.
+
+### FR-29.08 — Universe Config
+
+- **FR-29.08a**: The `config` field MUST accept any valid JSON object and persist it
+  without modification.
+- **FR-29.08b**: S29 does not validate the `config` field's contents. Schema validation
+  is deferred to S39 (Universe Composition Model). S29 reserves the field only.
+- **FR-29.08c**: The `config` field MUST be preserved unchanged across all session
+  lifecycle transitions (session open, end, resume).
+- **FR-29.08d**: An empty config (`{}`) is always a valid `config` value.
+
+### FR-29.09 — Universe Enumeration and Lookup
+
+- **FR-29.09a**: The system MUST support enumerating all universes owned by a player,
+  filterable by `status`.
+- **FR-29.09b**: The system MUST support fetching a single universe by `universe_id`.
+  An owner can always access their own universes.
+- **FR-29.09c**: The system MUST support querying world entities filtered by
+  `universe_id` as a top-level predicate (not as a derived traversal from a root node).
+
+---
+
+## 5. Non-Functional Requirements
+
+- **NFR-29.A** — `universe_id` MUST be indexed on all world-scoped entity node labels
+  in Neo4j and on all world-scoped entity tables in PostgreSQL.
+- **NFR-29.B** — Universe entity creation MUST complete within 200 ms (p95) under
+  normal operating load.
+- **NFR-29.C** — Universe enumeration for a player (up to 100 universes) MUST complete
+  within 100 ms (p95).
+- **NFR-29.D** — A `universe_id`-filtered "Nearby" query (see S04 FR-7.2) MUST meet
+  the same 200 ms SLA defined in S04 NFR-4.1.
+
+---
+
+## 6. User Journeys
+
+### Journey 1: Player Pauses and Resumes a Universe
+
+1. Player ends a session in universe "The Iron Coast." Session completes.
+2. Universe transitions: `active → paused`. All locations, NPC states, faction
+   standings, and world conditions are persisted intact.
+3. One week later, the player opens the universe list. "The Iron Coast" appears as
+   `paused` with a last-played timestamp.
+4. Player selects it and opens a new session. Universe transitions: `paused → active`.
+5. The turn pipeline reads world context from the persisted universe. The narrative
+   engine resumes from the correct state — no reset, no re-generation.
+
+### Journey 2: Player Manages Multiple Concurrent Universes
+
+1. Player has three universes: "The Iron Coast" (paused), "Shattered Peaks" (paused),
+   "The Endless Library" (archived).
+2. Player opens a session in "The Iron Coast." Universe: `paused → active`.
+3. Player ends that session. Universe: `active → paused`.
+4. Player opens a session in "Shattered Peaks." Universe: `paused → active`.
+5. Player tries to open a second simultaneous session in "The Iron Coast" (from a
+   different device). "The Iron Coast" is `paused`, not `active` — this succeeds.
+6. Both universes are now `active` simultaneously, each in its own session. No world
+   data crosses universes.
+
+### Journey 3: Developer Queries by Universe
+
+1. Developer needs all NPCs in universe `01HX3ABC`. A single Neo4j query:
+   `MATCH (n:NPC {universe_id: "01HX3ABC"}) RETURN n`
+2. No World root-node traversal needed. The `universe_id` index makes this O(1)
+   at any world size.
+3. Developer verifies isolation: no NPC from universe `01HX3DEF` appears.
+
+---
+
+## 7. Edge Cases & Failure Modes
+
+| ID | Scenario | Expected Behavior |
+|----|----------|-------------------|
+| EC-29.01 | Universe status transition (`active → paused`) fails mid-write | Universe remains `active`. Subsequent session-open is blocked by singleton policy. Operator can reset via admin API. Status inconsistency is detectable. |
+| EC-29.02 | Player archives a universe while it is `active` | System rejects with `universe_already_active`. Player must end the session first. |
+| EC-29.03 | World entity created without `universe_id` | System rejects with `universe_id_required`. Entity is not persisted. |
+| EC-29.04 | `universe_id` on world entity references a non-existent universe | System rejects with `universe_not_found`. Universe must exist before any entity can be created in it. |
+| EC-29.05 | Player account deleted while a universe is `active` | The active session is force-ended. Universe and its entities are queued for retention processing per S17. No orphan entities remain. |
+| EC-29.06 | Session attempts to use a universe owned by a different player | System rejects with `universe_not_owned`. Cross-player universe access is out of scope for v2. |
+| EC-29.07 | Race condition: two sessions simultaneously attempt to open in the same universe | The atomic check-and-bind in S30 ensures only one succeeds. The second returns `universe_already_active`. |
+| EC-29.08 | Runtime integrity error: session references universe A but a world entity has universe B | This MUST be impossible by construction (FR-29.05a, FR-29.07b). If detected, the turn pipeline MUST fail with `universe_integrity_error` and log the inconsistency. |
+
+---
+
+## 8. Acceptance Criteria
+
+```gherkin
+Feature: Universe as First-Class Entity
+
+  # ── Identity and Creation ──────────────────────────────────────────────────
+
+  Scenario: AC-29.01 — Universe creation yields a unique, persistent entity
+    Given a player is authenticated
+    When the player creates a universe with display_name "The Iron Coast"
+    Then a universe entity is created with a unique ULID universe_id
+    And the universe status is "created"
+    And the universe config is {}
+    And created_at is set and is immutable
+    And the universe is persisted independently of any session
+
+  Scenario: AC-29.02 — Two universes with the same name are distinct
+    Given a player has a universe with display_name "My World"
+    When the player creates a second universe with display_name "My World"
+    Then both universes are created successfully
+    And they have distinct universe_ids
+    And both appear when the player enumerates their universes
+
+  # ── World-Entity Scoping ───────────────────────────────────────────────────
+
+  Scenario: AC-29.03 — World entities carry the owning universe_id
+    Given a universe U1 with universe_id "01HX3ABC"
+    And a session is active in universe U1
+    When the world engine creates a Location entity in universe U1
+    Then the Location entity has universe_id = "01HX3ABC"
+    And the Location cannot be saved without universe_id
+
+  Scenario: AC-29.04 — World entity creation without universe_id is rejected
+    When a world entity is created without a universe_id
+    Then the system returns an error with code "universe_id_required"
+    And the entity is not persisted
+
+  Scenario: AC-29.05 — Cross-universe entity relationships are forbidden
+    Given universe U1 containing Location L1
+    And universe U2 containing NPC N1
+    When the world engine attempts to create a relationship between L1 and N1
+    Then the system returns an error with code "cross_universe_entity_reference"
+    And the relationship is not created
+
+  # ── Lifecycle ─────────────────────────────────────────────────────────────
+
+  Scenario: AC-29.06 — Universe persists after session ends
+    Given universe U1 is active in session S1
+    And the world contains locations, NPCs, and items scoped to U1
+    When session S1 ends (completed)
+    Then universe U1 status becomes "paused"
+    And all world entities with universe_id = U1 remain persisted
+    And universe U1 is fetchable by universe_id
+
+  Scenario: AC-29.07 — Paused universe can be resumed in a new session
+    Given universe U1 with status "paused"
+    When a player opens a new session in universe U1
+    Then the session is created with universe_id = U1
+    And universe U1 status becomes "active"
+    And world entities previously created in U1 are accessible within the new session
+
+  Scenario: AC-29.08 — Archival does not happen automatically on session end
+    Given universe U1 is active in session S1
+    When session S1 ends
+    Then universe U1 status is "paused"
+    And universe U1 status is NOT "archived"
+    And an explicit archival call is required to reach "archived"
+
+  # ── Singleton Policy ──────────────────────────────────────────────────────
+
+  Scenario: AC-29.09 — Universe cannot be active in two sessions simultaneously
+    Given universe U1 has status "active" bound to session S1
+    When session S2 attempts to open in universe U1
+    Then the system returns an error with code "universe_already_active"
+    And session S2 is not created
+    And universe U1 remains bound to session S1 only
+
+  Scenario: AC-29.10 — Schema permits multiple session rows per universe
+    Given universe U1 with one historical (ended) session S1
+    When a developer inspects the session table schema
+    Then no database-level UNIQUE constraint exists on the universe_id column
+    And multiple session rows may reference the same universe_id
+    And the singleton policy (AC-29.09) is enforced exclusively in application code
+
+  # ── Config Persistence ────────────────────────────────────────────────────
+
+  Scenario: AC-29.11 — Universe config survives session lifecycle transitions
+    Given universe U1 with config {"genre": "gothic", "tone": "melancholic"}
+    When session S1 is opened in U1, completes, and session S2 is subsequently opened
+    Then universe U1 config is still {"genre": "gothic", "tone": "melancholic"} in S2
+    And the config value is identical to what it was in S1
+
+  # ── Enumeration ───────────────────────────────────────────────────────────
+
+  Scenario: AC-29.12 — Player can enumerate their universes filtered by status
+    Given a player owns universe U1 (active), U2 (paused), U3 (archived)
+    When the player requests their universe list filtered by status "paused"
+    Then the response contains U2 only
+    And each entry includes universe_id, display_name, status, and created_at
+
+  Scenario: AC-29.13 — World entities are queryable by universe_id
+    Given universe U1 containing 3 locations and universe U2 containing 2 locations
+    When the system queries locations with universe_id = U1
+    Then exactly 3 locations are returned
+    And no locations from U2 appear in the result set
+```
+
+---
+
+## 9. Dependencies & Integration Boundaries
+
+| Boundary | Spec | Notes |
+|----------|------|-------|
+| World entity types | v1 S04 | FR-29.05 adds `universe_id` to all entity types in S04 FR-1.1. S29 does not modify any existing S04 FR or AC; it extends them. |
+| Game session record | v1 S11 | FR-29.07 adds a `universe_id` FK to the session record defined in S11. |
+| Persistence tier | v1 S12 | Universe is a new durable entity type. S12 §4.1 data-category table gains a "Universe" row (durable, PostgreSQL). |
+| World graph schema | v1 S13 | `universe_id` aligns with and supersedes v1 `world_id`. S29 establishes the semantic equivalence. Full migration DDL is in S33. |
+| Session↔Universe binding | S30 | S29 defines the Universe entity and singleton policy. S30 defines the atomic binding contract, lifecycle handshake, and race-condition-safe status check. |
+| Actor portability | S31 | S29 defines the universe boundary. S31 defines how actor IDs remain universe-agnostic and how actor state is scoped per universe. |
+| Universe persistence schema | S33 | S29 defines the Universe entity semantics. S33 defines the full DDL, migration path from `world_id`, and state envelope format. |
+| Universe composition | S39 | S29 reserves the `config` field without specifying its schema. S39 defines the config content (themes, tropes, archetypes). |
+| Privacy / data retention | v1 S17 | Universe deletion on account deletion is governed by S17. S29 establishes `owner_id` as the FK S17 needs to identify universe records scoped to a player. |
+
+---
+
+## 10. Open Questions
+
+| ID | Question | Impact | Responsible |
+|----|----------|--------|-------------|
+| OQ-29.01 | Does `config: {}` have semantic meaning ("use platform defaults"), or must S39 always pre-populate at least a content type before a session can open in the universe? This affects the genesis flow that wires S29 and S39 together. | AC-29.11 and S39 composition spec. | S39 author |
+| OQ-29.02 | Should `archived` universes be hard-deletable by the player? This intersects GDPR right-to-erasure (S17) and long-term storage costs. Soft-delete with a retention window may be sufficient. | S17 retention rules must explicitly cover universe records. | S17 / privacy review |
+| OQ-29.03 | The roadmap specifies the singleton policy as app-level (no DB UNIQUE constraint). This question confirms that choice. If reversed, retrofitting a DB constraint is an additive migration; removing one later is harder. | FR-29.07c; architecture review. | Architecture review |
+
+---
+
+## 11. Out of Scope
+
+The following are explicitly NOT part of S29:
+
+| Topic | Spec |
+|-------|------|
+| Session↔Universe binding contract and atomic lifecycle handshake | S30 |
+| Actor identity portability across universes | S31 |
+| Transport abstraction (SSE → `NarrativeTransport` interface) | S32 |
+| Universe persistence DDL and `world_id → universe_id` migration | S33 |
+| Universe composition vocabulary (config schema, themes, tropes) | S39 |
+| Concurrent universe loading in one process | S50 |
+| Cross-universe actor travel | S51 |
+| Nexus as a special universe type | S52, S53 |
+| Multiplayer shared universes (multiple actors simultaneously) | S57–S59 |
+| Universe ownership transfer between players | Future; single-owner in v2 |
+| Universe-level analytics or operator dashboards | S26 (Admin & Operator Tooling) |
+
+---
+
+## 12. Appendix
+
+### A — Relationship to v1 `world_id`
+
+In v1, S13 defines a `World` Neo4j node with `world_id` (ULID) as its unique identifier.
+That node was the implicit root of the game world. S29 formalizes and promotes this
+concept:
+
+| v1 concept | v2 equivalent | Change |
+|---|---|---|
+| `World` Neo4j node | `Universe` PostgreSQL entity (+ aligned Neo4j root node) | Promoted to first-class entity with lifecycle and ownership |
+| `world_id` (S13) | `universe_id` | Renamed; semantically equivalent; migration DDL in S33 |
+| Implicit per-session scope | Explicitly owned by a player; session is a visitor | Ownership and independent lifecycle added |
+| No config | `config: JSON` | Config field reserved; schema defined in S39 |
+| Status: "draft", "active", "archived" | Status: "created", "active", "paused", "archived" | Added `paused` to distinguish "session ended" from "explicitly archived" |
+
+### B — Forward-compat design rationale
+
+Three intentional under-constraints in S29 preserve v4+ optionality:
+
+1. **No DB UNIQUE on `session.universe_id`** (FR-29.07c): In v4+, multiple actors from
+   different sessions share one universe (multiplayer). Adding this without a DB
+   migration requires no constraint was ever added.
+
+2. **`universe_id` denormalized on every world entity** (FR-29.05): In v4+, cross-actor
+   queries ("all NPCs in universe X who have met any actor") must be efficient.
+   Traversal from a single World root is O(world size); a `universe_id` index lookup
+   is O(1) regardless of world size.
+
+3. **`config` is an opaque blob** (FR-29.08b): In v4+, universe composition may extend
+   in unpredictable ways (Bleedthrough parameters, Resonance coefficients, cross-universe
+   rules). An opaque blob with a versioned schema (governed by S39) never requires an
+   ALTER COLUMN migration for new config keys.
+
+---
+
+## Changelog
+
+- 2026-04-21: Initial draft. Authored by GitHub Copilot continuing from Claude Code
+  rate-limited session. Based on roadmap doc §3.1 and v1 specs S04, S11, S12, S13.

--- a/specs/29-universe-as-first-class-entity.md
+++ b/specs/29-universe-as-first-class-entity.md
@@ -96,7 +96,7 @@ A Universe MUST carry the following fields:
 |-------|------|----------|-------------|
 | `universe_id` | ULID | No | Globally unique identifier. Primary key. |
 | `display_name` | String (1–100 chars) | No | Human-readable name set by the owner. |
-| `owner_id` | ULID | No | The `player_id` of the owning player. |
+| `owner_id` | UUID | No | The `player_id` of the owning player. References `players.id`. |
 | `status` | Enum | No | One of: `created`, `active`, `paused`, `archived`. |
 | `config` | JSON object | No | Opaque config blob. Schema defined by S39. Default: `{}`. |
 | `created_at` | Datetime (UTC) | No | Set at creation. Immutable thereafter. |

--- a/specs/30-session-universe-binding.md
+++ b/specs/30-session-universe-binding.md
@@ -368,7 +368,7 @@ Feature: Session↔Universe Binding
 | Column | Change | Notes |
 |---|---|---|
 | `world_seed` (v1 JSONB) | Deprecated, kept for migration | v1 world configuration; superseded by `universe_id` FK + S33 snapshot mechanism |
-| `universe_id` (new UUID FK) | Added — NOT NULL after backfill | References `universes.universe_id` |
+| `universe_id` (new TEXT FK; ULID) | Added — NOT NULL after backfill | Stores ULID text; references `universes.universe_id` |
 | `actors` (new JSONB) | Added — default `'[]'::jsonb` | List of ActorId strings; length=1 in v2 |
 
 Full migration DDL is in S33.

--- a/specs/30-session-universe-binding.md
+++ b/specs/30-session-universe-binding.md
@@ -1,0 +1,381 @@
+# S30 — Session↔Universe Binding
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v2.0
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 3 — Platform
+> **Dependencies**: v2 S29, v1 S11
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+v1 S11 defined game sessions with a `world_seed` blob that initiated world creation as
+a side effect. The session implicitly owned its world — the two lived and died together,
+with no explicit binding contract and no atomicity guarantee around their creation.
+
+v2 changes this. With S29 introducing Universe as a first-class persistent entity, a
+session must explicitly **bind** to a universe at creation time. S30 defines:
+
+- What fields the session record carries to record the binding
+- The atomicity guarantee that prevents two sessions from binding to the same universe
+  simultaneously (the race-condition protection from S29 EC-29.07)
+- The `actors` field structure that makes v4+ multi-actor sessions an additive schema
+  change rather than a breaking migration
+- How the universe's lifecycle status is kept in sync with the session's lifecycle
+
+This spec **extends** v1 S11 — it does not replace it. The base session model (player
+auth, JWT, session lifecycle states, rate limits, anonymous player handling) remains
+governed by v1 S11. S30 governs only the universe-binding contract layer on top of that
+model.
+
+---
+
+## 2. Design Philosophy
+
+**Explicit binding**: no universe can become `active` without a session explicitly
+claiming it. There is no implicit or deferred binding.
+
+**Atomic check-and-set**: the "is the universe available?" check and the "mark it active"
+write happen in a single database transaction. An application-level read-then-write is
+explicitly prohibited (see FR-30.02c).
+
+**Append-oriented `actors` list**: v2 creates sessions with exactly one actor
+(`["<actor_id>"]`). v4+ creates sessions with multiple actors. The schema structure is
+identical — only the application-level cardinality policy changes between versions.
+
+**Session end is declarative**: when a session ends, the bound universe transitions to
+`paused`. The session makes no assumption about what the player intends to do next —
+the universe simply waits, ready for a new binding.
+
+---
+
+## 3. User Stories
+
+- **US-30.1** — **As a** player, **I want** starting a game to exclusively claim my
+  universe for the session, **so that** no other session or process modifies my world
+  while I'm playing.
+
+- **US-30.2** — **As a** player, **I want** ending a session to preserve my universe in
+  a paused state, **so that** I can resume it in a future session.
+
+- **US-30.3** — **As a** player, **I want** to be clearly told when my universe is
+  already active, **so that** I do not accidentally create a second session for it.
+
+- **US-30.4** — **As a** developer, **I want** any session record to carry both
+  `universe_id` and `actors`, **so that** I can understand the full binding without
+  joining multiple tables.
+
+- **US-30.5** — **As a** developer, **I want** the invariant "if universe.status ==
+  'active', exactly one non-terminal session references it" to be enforceable and
+  auditable, **so that** I can detect and fix any binding inconsistencies.
+
+---
+
+## 4. Functional Requirements
+
+### FR-30.01 — Session Record Extension
+
+- **FR-30.01a**: Every `game_sessions` record MUST carry a `universe_id` FK referencing
+  the `universes` table. This column is NOT NULL after v2 migration.
+  (S29 FR-29.07 introduced the concept; S30 is the authoritative contract for its
+  semantics and lifecycle.)
+- **FR-30.01b**: Every `game_sessions` record MUST carry an `actors` column (JSONB array
+  of ActorId strings). `actors` MUST be non-null and MUST default to an empty array
+  (`'[]'::jsonb`) at the DB level.
+- **FR-30.01c**: Both `universe_id` and `actors` are set at session creation time.
+  Neither may be updated after the session row is inserted. Any attempt to update these
+  fields MUST be rejected.
+
+### FR-30.02 — Binding Atomicity
+
+- **FR-30.02a**: Session creation MUST, within a single database transaction:
+  1. Read the target universe's `status`
+  2. Verify that `status` is NOT `active` AND NOT `archived`
+  3. Set `universe.status = 'active'`
+  4. Insert the new session row with `universe_id` and `actors` populated
+
+- **FR-30.02b**: If step 2 fails (universe is `active` or `archived`), the transaction
+  MUST be rolled back and the session MUST NOT be created. The appropriate error code
+  is returned (`universe_already_active` or `universe_archived`).
+
+- **FR-30.02c**: The check-and-set MUST use a database-level mechanism to prevent
+  concurrent transactions from observing stale status. Acceptable approaches:
+  `SELECT ... FOR UPDATE` on the universe row, or a conditional `UPDATE universes SET
+  status = 'active' WHERE universe_id = ? AND status NOT IN ('active', 'archived')`
+  with row-count verification. Application-level read-then-write (two separate
+  transactions) is NOT sufficient.
+
+- **FR-30.02d**: If any step in the transaction fails after step 3 (universe marked
+  active but session insert fails), the transaction MUST roll back. The universe returns
+  to its pre-transaction status. No orphan "active" universes are permitted.
+
+### FR-30.03 — v2 Actor Constraint
+
+- **FR-30.03a**: In v2, the `actors` JSONB array on a new session MUST contain exactly
+  one ActorId.
+- **FR-30.03b**: The database schema MUST NOT enforce a cardinality constraint on the
+  `actors` array (no check constraint on array length). The v2 cardinality policy is
+  enforced at application level only, preserving forward-compat for v4+ multi-actor
+  sessions.
+- **FR-30.03c**: In v2, the application layer MUST reject session creation if the
+  provided `actors` list is empty or contains more than one element, returning
+  `actors_invalid`.
+- **FR-30.03d**: The ActorId in `actors[0]` MUST correspond to an existing actor record
+  (as defined in S31). The system MUST reject session creation with `actor_not_found` if
+  the ActorId does not exist.
+
+### FR-30.04 — Universe Status Sync on Session Termination
+
+- **FR-30.04a**: When a session transitions to `ended`, the system MUST atomically
+  transition the bound universe from `active` to `paused`, within the same database
+  transaction as the session status update.
+- **FR-30.04b**: When a session transitions to `abandoned` (v1 S11 FR-11.41), the system
+  MUST atomically transition the bound universe from `active` to `paused`, within the
+  same transaction.
+- **FR-30.04c**: When a session transitions to `paused` (temporary player pause, not
+  session end), the bound universe's status MUST remain `active`. A paused session still
+  holds the exclusive claim on its universe. The universe is only released on session
+  termination (`ended` or `abandoned`).
+- **FR-30.04d**: If the universe status sync fails (e.g., universe record not found at
+  transition time), the session status update MUST also fail. The operator must resolve
+  the inconsistency via the admin API.
+
+### FR-30.05 — Binding Invariant
+
+- **FR-30.05a**: At no point MUST a universe in `active` status exist without a
+  corresponding session in `created`, `active`, or `paused` state referencing it.
+- **FR-30.05b**: At no point MUST two or more sessions in `created`, `active`, or
+  `paused` state share the same `universe_id`. (This is the session-level enforcement of
+  the S29 singleton policy.)
+- **FR-30.05c**: A violation of FR-30.05a or FR-30.05b constitutes a `universe_integrity_error`.
+  When detected, the system MUST log the violation at ERROR severity with the
+  `universe_id`, `session_id(s)`, and observed statuses. Operator correction via admin
+  API is required.
+
+---
+
+## 5. Non-Functional Requirements
+
+- **NFR-30.A** — The atomic session-creation-and-universe-activation transaction MUST
+  complete within 200 ms (p95) under normal load.
+- **NFR-30.B** — The universe status sync on session termination MUST complete within
+  100 ms (p95).
+- **NFR-30.C** — The binding invariant check (FR-30.05) MUST be detectable via a
+  lightweight query (O(sessions with non-terminal status)) to support periodic operator
+  health audits without table scans.
+
+---
+
+## 6. User Journeys
+
+### Journey 1: Player Opens First Session in a New Universe
+
+**Trigger**: Player calls `POST /api/v1/games` with `{ universe_id: "univ_01...", actors: ["actor_01..."] }`
+
+1. System validates player is authenticated and actor belongs to the player.
+2. System begins a DB transaction.
+3. `SELECT universe_id, status FROM universes WHERE universe_id = ? FOR UPDATE`
+   → returns status `created`.
+4. `UPDATE universes SET status = 'active' WHERE universe_id = ?`
+5. `INSERT INTO game_sessions (player_id, universe_id, actors, status) VALUES (...)`
+6. Transaction commits.
+7. Response: `{ game_id: "...", universe_id: "...", actors: [...], status: "created" }`
+
+### Journey 2: Player Attempts Second Session in an Active Universe
+
+**Trigger**: Player calls `POST /api/v1/games` for a universe already owned by an active
+session.
+
+1. System begins transaction.
+2. `SELECT ... FOR UPDATE` returns status `active`.
+3. Transaction rolls back immediately.
+4. Response: `400 Bad Request`, error `universe_already_active`.
+
+### Journey 3: Player Ends a Session
+
+**Trigger**: Player calls `POST /api/v1/games/{game_id}/end`
+
+1. System verifies session belongs to calling player.
+2. System begins transaction.
+3. `UPDATE game_sessions SET status = 'ended', ended_at = now() WHERE id = ?`
+4. `UPDATE universes SET status = 'paused', paused_at = now() WHERE universe_id = ?`
+   (universe_id from session record)
+5. S33's snapshot write executes (same transaction; see S33 FR-33.02b).
+6. Transaction commits.
+7. Universe is now `paused`, ready for a future session to bind to it.
+
+### Journey 4: Player Pauses (Not Ends) a Session
+
+**Trigger**: Player calls `POST /api/v1/games/{game_id}/pause` or disconnects mid-turn.
+
+1. `UPDATE game_sessions SET status = 'paused', paused_at = now() WHERE id = ?`
+2. Universe status is NOT touched — remains `active`.
+3. Player can resume by calling `POST /api/v1/games/{game_id}/resume`.
+4. On resume: `UPDATE game_sessions SET status = 'active'` — universe already `active`,
+   no universe update needed.
+
+---
+
+## 7. Edge Cases & Failure Modes
+
+| # | Scenario | Expected Behavior |
+|---|----------|-------------------|
+| EC-30.01 | Universe is `archived` at session creation | Rejected: `universe_archived`. Player must unarchive first. |
+| EC-30.02 | Universe is `paused` at session creation | SUCCEEDS: `paused → active` transition valid; new session creates and binds. |
+| EC-30.03 | Universe does not exist | Rejected: `universe_not_found`. |
+| EC-30.04 | Universe owned by different player | Rejected: `universe_not_owned`. |
+| EC-30.05 | `actors` list is empty | Rejected: `actors_invalid`. |
+| EC-30.06 | `actors[0]` references non-existent actor | Rejected: `actor_not_found`. |
+| EC-30.07 | Transaction fails after universe marked `active` but before session insert | Transaction rolls back. Universe reverts to pre-transaction status. No orphan active universe. |
+| EC-30.08 | Two concurrent session-creation requests for same universe | Exactly one succeeds (serialized by `SELECT FOR UPDATE`). Other returns `universe_already_active`. |
+| EC-30.09 | Session end transaction fails | Session remains in prior status; universe remains `active`. Operator alert. No partial state committed. |
+| EC-30.10 | Universe not found at session-end time (deleted out of band) | Session end rejected: `universe_not_found`. Integrity alarm raised; operator must resolve. |
+
+---
+
+## 8. Acceptance Criteria
+
+```gherkin
+Feature: Session↔Universe Binding
+
+  Scenario: AC-30.01 — Session creation with universe in created status succeeds
+    Given a universe in "created" status
+    When a player creates a new session bound to that universe with 1 actor
+    Then the session is created successfully
+    And the universe status transitions to "active"
+    And the session record carries universe_id and actors = [<actor_id>]
+
+  Scenario: AC-30.02 — Session creation with universe in paused status succeeds (resume)
+    Given a universe in "paused" status
+    When a player creates a new session bound to that universe with 1 actor
+    Then the session is created successfully
+    And the universe status transitions to "active"
+
+  Scenario: AC-30.03 — Session creation with universe already active is rejected
+    Given a universe in "active" status
+    When a player attempts to create a session bound to that universe
+    Then the response is 400 Bad Request
+    And the error code is "universe_already_active"
+    And no new session row is inserted
+
+  Scenario: AC-30.04 — Session creation with archived universe is rejected
+    Given a universe in "archived" status
+    When a player attempts to create a session bound to that universe
+    Then the response is 400 Bad Request
+    And the error code is "universe_archived"
+
+  Scenario: AC-30.05 — universe_id on session is set at creation and is immutable
+    Given an existing session S with universe_id = U
+    When an API call attempts to update session S's universe_id to U2
+    Then the update is rejected
+    And session S still carries universe_id = U
+
+  Scenario: AC-30.06 — actors list contains exactly one element in v2
+    Given a valid universe and actor in v2
+    When the player creates a new session
+    Then the session's actors field contains exactly one ActorId
+
+  Scenario: AC-30.07 — DB schema does not constrain actors array length
+    Given the universe_snapshots schema
+    When a row is inserted into game_sessions with actors = ["id1", "id2"]
+    Then the insert succeeds (schema accepts arrays of any length)
+
+  Scenario: AC-30.08 — Ending a session transitions universe to paused
+    Given an active session bound to universe U (universe is "active")
+    When the player ends the session
+    Then the session status is "ended"
+    And universe U status is "paused"
+    And both changes occur in the same transaction
+
+  Scenario: AC-30.09 — Pausing a session does not change universe status
+    Given an active session bound to universe U (universe is "active")
+    When the player pauses the session
+    Then the session status is "paused"
+    And universe U status remains "active"
+
+  Scenario: AC-30.10 — Race condition: only one of two concurrent opens succeeds
+    Given a universe in "paused" status
+    When two concurrent session-creation requests arrive simultaneously
+    Then exactly one session is created and the universe transitions to "active"
+    And the other request returns 400 "universe_already_active"
+```
+
+---
+
+## 9. Dependencies & Integration Boundaries
+
+| Dependency | Spec | Integration Notes |
+|---|---|---|
+| Universe entity + lifecycle | v2 S29 | S30 consumes `universe.status` and the `universes` table. S29 FR-29.04 defines the lifecycle transitions; S30 enforces them atomically at session-create and session-end. |
+| Session lifecycle model | v1 S11 | S30 adds `universe_id` and `actors` to the session schema defined in S11. S11's session state machine governs when sessions enter `ended`/`abandoned`; S30 adds the universe sync obligation at those transitions. |
+| Actor identity | v2 S31 | S30 FR-30.03d requires actor records to exist (defined in S31). Actor creation is S31's responsibility; S30 only references actor_ids. |
+| Snapshot write on session end | v2 S33 | FR-30.04 and S33 FR-33.02b specify that universe snapshot write is co-transactional with session end. S30 mandates the atomicity; S33 defines what is written. |
+| Error taxonomy | v1 S23 | New error codes introduced by S30: `universe_already_active`, `universe_archived`, `universe_not_owned`, `actor_not_found`, `actors_invalid`, `universe_integrity_error` (shared with S29). |
+| Admin API | v1 S26 | FR-30.05c requires operator resolution of binding invariant violations. S26 admin API must expose a universe binding audit endpoint. |
+
+---
+
+## 10. Open Questions
+
+| # | Question | Impact | Owner |
+|---|---|---|---|
+| OQ-30.01 | Should the `SELECT ... FOR UPDATE` be at `SERIALIZABLE` isolation or `REPEATABLE READ` with explicit row lock? The two behave differently under concurrent workloads; `SERIALIZABLE` is safer but slower. | FR-30.02c atomicity guarantee | Architecture review |
+| OQ-30.02 | When a session is `abandoned`, should the universe go to `paused` or back to `created`? The current spec says `paused` (since the universe was activated when the session was created). If genesis was never run, `created` might be more accurate semantically. | FR-30.04b | S40 Genesis v2 author |
+| OQ-30.03 | What is the API surface for binding? Does `POST /api/v1/games` accept `universe_id` as a parameter, or does creating a game always create a new universe? If the latter, S30 and S29 need a "create universe and open session in one call" composite operation. | API design | v1 S10 / S29 |
+
+---
+
+## 11. Out of Scope
+
+- **Universe creation during session open** — creating a universe as an implicit side
+  effect of session creation is explicitly prohibited in v2. Universe creation is always
+  a separate, explicit operation (S29). This spec does not cover that flow.
+- **Multi-actor session semantics** — the `actors` list with more than one element is
+  a v4+ concern. S30 only specifies the v2 cardinality policy and the forward-compat
+  constraint (no DB uniqueness on actors count). v4+ multi-actor binding rules are
+  governed by S57.
+- **Actor-to-universe routing** — deciding which universe an actor enters, or listing
+  which universes an actor has character states in, is covered by S31.
+- **Session resume mechanics** — the "welcome back" narrative, context reconstruction,
+  and hot-cache reload on resume are governed by v1 S11 FR-11.43 and S33 (snapshot
+  load lifecycle).
+- **Cross-universe session transfers** — an actor moving from Universe A to Universe B
+  requires ending one session and opening another. The transfer mechanics, state
+  translation, and arrival onboarding are governed by S51 (Cross-Universe Travel
+  Protocol).
+- **Session hijacking / device conflict** — multiple devices attempting to connect to
+  the same session is governed by v1 S11 FR-11.52 (`session_taken` event).
+
+---
+
+## 12. Appendix
+
+### A — Error Codes Introduced by S30
+
+| Code | HTTP Status | When Returned |
+|---|---|---|
+| `universe_already_active` | 400 | Session creation attempted on an `active` universe |
+| `universe_archived` | 400 | Session creation attempted on an `archived` universe |
+| `universe_not_owned` | 403 | Session created for universe owned by different player |
+| `actor_not_found` | 400 | `actors[0]` ActorId does not exist |
+| `actors_invalid` | 400 | `actors` is empty or contains more than one element (v2) |
+| `universe_integrity_error` | 500 | Binding invariant violated; operator action required |
+
+### B — Session Schema Changes from v1 to v2
+
+| Column | Change | Notes |
+|---|---|---|
+| `world_seed` (v1 JSONB) | Deprecated, kept for migration | v1 world configuration; superseded by `universe_id` FK + S33 snapshot mechanism |
+| `universe_id` (new UUID FK) | Added — NOT NULL after backfill | References `universes.universe_id` |
+| `actors` (new JSONB) | Added — default `'[]'::jsonb` | List of ActorId strings; length=1 in v2 |
+
+Full migration DDL is in S33.
+
+---
+
+## Changelog
+
+- 2026-04-21: Initial draft. Authored by GitHub Copilot continuing from Claude Code
+  rate-limited session. Based on roadmap doc §3.1 S30 summary and v1 specs S11, S29.

--- a/specs/31-actor-identity-portability.md
+++ b/specs/31-actor-identity-portability.md
@@ -123,7 +123,7 @@ player in v4+ is an additive migration.
   | Field | Type | Required | Notes |
   |---|---|---|---|
   | `actor_id` | ULID FK | Yes | References `actors.actor_id` |
-  | `universe_id` | UUID FK | Yes | References `universes.universe_id` |
+  | `universe_id` | ULID FK (TEXT) | Yes | References `universes.universe_id` |
   | `character_name` | String | Yes | In-world name in this universe; may differ from `actor.display_name` |
   | `traits` | JSONB | Yes | From S06 FR-1.1; evolves through play |
   | `inventory` | JSONB | Yes | From S06 FR-1.1 |

--- a/specs/31-actor-identity-portability.md
+++ b/specs/31-actor-identity-portability.md
@@ -1,0 +1,376 @@
+# S31 — Actor Identity Portability
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v2.0
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 3 — Platform
+> **Dependencies**: v2 S29, v1 S06, v1 S11
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+In v1, the player character was implicitly coupled to a session. Character state was
+stored in `game_snapshots` as part of the per-turn world blob — there was no independent
+identity for "the player's in-world self." A player was their character, and their
+character was their session.
+
+v2 separates two concepts that v1 conflated:
+
+- **Actor**: the player's in-world persona — a stable, globally unique entity with its
+  own identity record. An actor exists independently of any universe or session.
+- **Character state**: the universe-scoped attributes that represent *how the actor
+  exists in a particular universe* — traits, reputation, inventory, conditions, and
+  relationships that evolved through play.
+
+This separation is the minimum footwork required to enable S51 (Cross-Universe Travel)
+in v4+: when an actor travels between universes, the actor identity is preserved while
+the character state is transferred, reset, or translated per rules defined in S51.
+
+v2 constraint: in v2, each player has exactly one actor, and each actor exists in at
+most one universe at a time. The data model does **not** enforce this — it is
+deliberately designed to accommodate v4+, where one actor may have character states in
+multiple universes simultaneously (multi-universe residency).
+
+This spec **extends** v1 S06 (Character System) by introducing the Actor identity layer.
+v1 S06's character state fields (traits, inventory, conditions, emotional state,
+reputation, relationships) become the content of `CharacterState` in v2. S06 remains the
+authority on what those fields *mean*; S31 governs *where* they are stored and *how* the
+actor-universe separation is maintained.
+
+---
+
+## 2. Design Philosophy
+
+**Identity is universe-agnostic**: `actor_id` is stable regardless of which universe
+is being queried. The same actor can exist across many universes; the actor identity
+record itself carries no universe reference.
+
+**State is universe-scoped**: character state is a function of (actor, universe). The
+same actor may be a revered scholar in Universe A and a hunted fugitive in Universe B.
+These are distinct `CharacterState` records, not variants of a single record.
+
+**One-way linkage**: `CharacterState` references both `actor_id` and `universe_id`, but
+neither `Actor` nor `Universe` references `CharacterState` directly. This prevents
+circular schema dependencies and preserves clean deletion cascades.
+
+**v2 simplification without v4+ lock-in**: one actor per player is enforced at
+application level; the schema carries no such constraint. Adding a second actor per
+player in v4+ is an additive migration.
+
+---
+
+## 3. User Stories
+
+### Identity & Portability
+
+- **US-31.1** — **As a** player, **I want** my actor identity to be stable across all
+  my universes, **so that** I know I'm "the same traveler" even when my characters have
+  diverged between worlds.
+
+- **US-31.2** — **As a** player, **I want** my character's state (traits, reputation,
+  inventory) to reflect my play in this specific universe, **so that** each universe
+  feels like a distinct experience, not a copy.
+
+### Developer & Operator
+
+- **US-31.3** — **As a** developer, **I want** to look up all character states for a
+  given actor across all universes, **so that** I can support export, backup, and
+  cross-universe transfer (S51) without full-table scans.
+
+- **US-31.4** — **As a** developer, **I want** to look up all actors currently present
+  in a given universe, **so that** I can support multi-actor worlds in v4+ without
+  schema migration.
+
+- **US-31.5** — **As an** operator, **I want** deleting an actor to cascade-delete all
+  character states for that actor, **so that** no orphan state records exist after a
+  player account deletion.
+
+---
+
+## 4. Functional Requirements
+
+### FR-31.01 — Actor Identity Record
+
+- **FR-31.01a**: Every player MUST have an `Actor` record with the following fields:
+
+  | Field | Type | Required | Notes |
+  |---|---|---|---|
+  | `actor_id` | ULID | Yes | Globally unique; assigned at creation |
+  | `player_id` | UUID FK | Yes | References `players.id`; NOT NULL |
+  | `display_name` | String | Yes | Cross-universe handle; may differ from in-world character name |
+  | `created_at` | Timestamp | Yes | When the actor record was created |
+
+- **FR-31.01b**: `actor_id` MUST be a ULID (Universally Unique Lexicographically
+  Sortable Identifier), independent of and not derived from `player_id`.
+- **FR-31.01c**: In v2, the system MUST create exactly one `Actor` record per player at
+  player registration time. If actor creation fails, player registration MUST be rolled
+  back entirely.
+- **FR-31.01d**: The database schema MUST NOT enforce a uniqueness constraint on
+  `actors.player_id`. The v2 "one actor per player" policy is enforced at application
+  level only. (v4+ allows multiple actors per player without schema migration.)
+- **FR-31.01e**: `actor_id` is immutable after creation. `display_name` and `player_id`
+  are also immutable. No update path for actor records exists in v2.
+
+### FR-31.02 — Character State Record
+
+- **FR-31.02a**: Every actor that has participated in a universe MUST have at most one
+  `CharacterState` record per (actor_id, universe_id) pair.
+
+- **FR-31.02b**: A `CharacterState` record MUST carry the following fields:
+
+  | Field | Type | Required | Notes |
+  |---|---|---|---|
+  | `actor_id` | ULID FK | Yes | References `actors.actor_id` |
+  | `universe_id` | UUID FK | Yes | References `universes.universe_id` |
+  | `character_name` | String | Yes | In-world name in this universe; may differ from `actor.display_name` |
+  | `traits` | JSONB | Yes | From S06 FR-1.1; evolves through play |
+  | `inventory` | JSONB | Yes | From S06 FR-1.1 |
+  | `conditions` | JSONB | Yes | From S06 FR-1.1 (active states: injured, cursed, etc.) |
+  | `emotional_state` | JSONB | Yes | From S06 FR-1.1 |
+  | `reputation` | JSONB | Yes | From S06 FR-1.1 |
+  | `last_active_at` | Timestamp | Yes | When this CharacterState was last updated |
+
+  The content structure of `traits`, `inventory`, `conditions`, `emotional_state`, and
+  `reputation` is governed by v1 S06. S31 governs where they are stored, not what they
+  contain.
+
+- **FR-31.02c**: The composite key `(actor_id, universe_id)` MUST be enforced by a
+  database UNIQUE constraint. (Unlike the session↔universe binding in S30, this IS a
+  hard uniqueness constraint — one character state per actor per universe is always true,
+  regardless of the number of sessions that have occurred in that universe.)
+- **FR-31.02d**: `CharacterState` is created lazily at the start of the actor's first
+  session in a given universe. It is NOT created at actor registration time.
+- **FR-31.02e**: `CharacterState` is updated after each turn completes. The turn
+  pipeline writes the updated character state as part of the per-turn persistence cycle
+  (S12 FR-12.18 sequence, step 8).
+- **FR-31.02f**: `CharacterState` is NOT created for a universe in `archived` status.
+  Attempting to open a session in an archived universe is rejected before character state
+  creation is reached (S30 FR-30.02b).
+
+### FR-31.03 — Separation Invariant
+
+- **FR-31.03a**: No `Actor` record MUST carry a `universe_id` field. Actor identity is
+  universe-agnostic.
+- **FR-31.03b**: No `Universe` record MUST carry an `actor_id` field. Universe identity
+  is actor-agnostic.
+- **FR-31.03c**: The linkage between actors and universes MUST be expressed exclusively
+  through: (1) `CharacterState(actor_id, universe_id)` for character data, and (2) the
+  `actors` JSONB field on `game_sessions` for session-participation data.
+- **FR-31.03d**: The turn pipeline MUST always reference character state via
+  `(actor_id, universe_id)` — never via a session-scoped query alone. This ensures
+  the character state is portable even if session IDs change between sessions.
+
+### FR-31.04 — Actor and Character State Lookup
+
+- **FR-31.04a**: The system MUST support lookup of an actor by `actor_id` (indexed).
+- **FR-31.04b**: The system MUST support lookup of the actor(s) belonging to a given
+  `player_id` (indexed on `actors.player_id`).
+- **FR-31.04c**: The system MUST support lookup of all `CharacterState` records for a
+  given `actor_id`, across all universes (indexed on `character_states.actor_id`).
+- **FR-31.04d**: The system MUST support lookup of the single `CharacterState` for a
+  given `(actor_id, universe_id)` pair (composite index, unique).
+- **FR-31.04e**: The system MUST support lookup of all `CharacterState` records for a
+  given `universe_id`, across all actors (indexed on `character_states.universe_id`).
+  This query supports multi-actor universe loading in v4+.
+
+### FR-31.05 — Deletion Cascades
+
+- **FR-31.05a**: Deleting a player (S11 FR-11.60 GDPR path) MUST cascade-delete all
+  `Actor` records for that player.
+- **FR-31.05b**: Deleting an actor MUST cascade-delete all `CharacterState` records for
+  that actor.
+- **FR-31.05c**: Deleting a universe (operator action, S26) MUST cascade-delete all
+  `CharacterState` records for that universe. `Actor` records are NOT deleted — the
+  actor exists independently and may have character states in other universes.
+- **FR-31.05d**: Deletion cascades MUST be enforced by database-level `ON DELETE
+  CASCADE` foreign key constraints, not application-level cascade logic.
+
+---
+
+## 5. Non-Functional Requirements
+
+- **NFR-31.A** — Actor lookup by `actor_id` MUST complete within 10 ms (p95), B-tree
+  indexed primary key query.
+- **NFR-31.B** — `CharacterState` lookup by `(actor_id, universe_id)` MUST complete
+  within 10 ms (p95), composite unique index query.
+- **NFR-31.C** — All `CharacterState` records for a given actor (cross-universe index)
+  MUST be retrievable in under 50 ms for a player with up to 100 universes.
+- **NFR-31.D** — Actor creation as part of player registration MUST add no more than
+  50 ms to registration latency (p95).
+
+---
+
+## 6. User Journeys
+
+### Journey 1: Player Registers — Actor Created Automatically
+
+**Trigger**: `POST /api/v1/auth/register`
+
+1. Player registration creates a `players` row.
+2. Within the same transaction, a `actors` row is created:
+   `actor_id = new_ulid()`, `player_id = new_player.id`,
+   `display_name = player.handle` (or player-chosen name at registration).
+3. Transaction commits; player and actor are created atomically.
+4. JWT contains `player_id`; `actor_id` is retrievable via `GET /api/v1/me/actor`.
+
+### Journey 2: Player Opens First Session in Universe X — CharacterState Created
+
+**Trigger**: Session created (S30) for the actor's first time in Universe X.
+
+1. Session creation (S30) completes; session row has `actors = ["actor_01..."]`.
+2. System checks: does `CharacterState(actor_id="actor_01...", universe_id=X)` exist?
+3. It does not. System creates `CharacterState` with default empty fields.
+4. Genesis flow (S40) populates `character_name`, initial `traits`, etc.
+5. `CharacterState` is updated with genesis output.
+
+### Journey 3: Player Resumes Universe X in a New Session — CharacterState Reused
+
+**Trigger**: Player opens second session in Universe X (previous session `ended`).
+
+1. Session creation (S30) succeeds; universe transitions from `paused` to `active`.
+2. System checks: does `CharacterState(actor_id="actor_01...", universe_id=X)` exist?
+3. It does. System loads existing `CharacterState` from DB into hot cache.
+4. The player resumes exactly where they left off in terms of character state.
+5. No new `CharacterState` row is created.
+
+### Journey 4: Developer Queries Actor's Cross-Universe History
+
+**Trigger**: `GET /api/v1/actors/{actor_id}/character-states`
+
+1. System retrieves all `CharacterState` records for `actor_id`.
+2. Response includes: for each universe — `universe_id`, `character_name`,
+   `traits`, `last_active_at`.
+3. Developer can compare how the actor evolved across their parallel universes.
+
+---
+
+## 7. Edge Cases & Failure Modes
+
+| # | Scenario | Expected Behavior |
+|---|----------|-------------------|
+| EC-31.01 | Actor creation fails at registration | Player registration rolls back entirely. Both player and actor rows are absent. |
+| EC-31.02 | `CharacterState` creation fails at first session open | Session creation fails; no orphan session row. `CharacterState` is also absent. |
+| EC-31.03 | Duplicate `CharacterState` creation attempt (race or retry) | DB UNIQUE constraint on `(actor_id, universe_id)` rejects the duplicate. System returns existing `CharacterState` (idempotent). |
+| EC-31.04 | Actor referenced in `game_sessions.actors` but actor record deleted | Integrity violation: `actor_not_found`. Operator action required. |
+| EC-31.05 | Player deleted (GDPR) — cascades | All actor records deleted; all `CharacterState` records for each actor deleted. `game_sessions.actors` JSONB is not FK-constrained (JSONB array); clean-up verified by GDPR job (S17). |
+| EC-31.06 | v1 player with no actor record (pre-migration) | Migration (S33) creates actor records for all existing players. If a v1 player accesses the system post-migration before actor row exists, system returns `actor_not_found`. This state should not occur after migration completes. |
+| EC-31.07 | Two universes share the same actor's CharacterState (impossible by unique constraint) | Cannot occur. If detected, constitutes DB corruption. |
+
+---
+
+## 8. Acceptance Criteria
+
+```gherkin
+Feature: Actor Identity Portability
+
+  Scenario: AC-31.01 — Player registration creates an actor record
+    Given a new player registers
+    When the registration transaction commits
+    Then an Actor row exists with a unique actor_id
+    And the Actor row's player_id matches the new player's id
+
+  Scenario: AC-31.02 — actor_id is independent of player_id
+    Given an actor row
+    When the actor_id is inspected
+    Then actor_id is a ULID distinct from player_id
+    And the actor_id contains no derivation of player_id
+
+  Scenario: AC-31.03 — CharacterState created lazily on first session in a universe
+    Given an actor with no prior sessions in Universe X
+    When a session is opened in Universe X
+    Then a CharacterState row exists for (actor_id, universe_id = X)
+    And the CharacterState was not present before session creation
+
+  Scenario: AC-31.04 — Second session in same universe reuses existing CharacterState
+    Given an actor with an existing CharacterState in Universe X
+    When a second session is opened in Universe X (prior session ended)
+    Then no new CharacterState row is created
+    And the session reads from the existing CharacterState for (actor_id, universe X)
+
+  Scenario: AC-31.05 — Composite unique key prevents duplicate CharacterState
+    Given an existing CharacterState for (actor_id = A, universe_id = X)
+    When the system attempts to create a second CharacterState for (A, X)
+    Then the insert is rejected by the DB UNIQUE constraint
+    And the existing CharacterState is preserved unchanged
+
+  Scenario: AC-31.06 — Deleting an actor cascade-deletes all CharacterStates
+    Given an actor with CharacterState records in 3 universes
+    When the actor is deleted
+    Then all 3 CharacterState rows are deleted
+    And no orphan CharacterState rows reference the deleted actor_id
+
+  Scenario: AC-31.07 — Deleting a universe cascade-deletes CharacterState; actor intact
+    Given universe U with a CharacterState for actor A
+    When universe U is deleted (operator action)
+    Then the CharacterState for (actor A, universe U) is deleted
+    And the Actor row for actor A is NOT deleted
+    And any CharacterState records for actor A in other universes are NOT deleted
+
+  Scenario: AC-31.08 — Actor lookup by player_id returns correct actor(s)
+    Given a player P with exactly one actor A
+    When the system looks up actors by player_id = P
+    Then the result contains exactly Actor A
+
+  Scenario: AC-31.09 — CharacterState lookup returns correct universe-scoped state
+    Given actor A with CharacterState in Universe X (character_name = "Serin")
+    And actor A with CharacterState in Universe Y (character_name = "Dust")
+    When the system looks up CharacterState for (actor_id = A, universe_id = X)
+    Then the result has character_name = "Serin"
+    And the Universe Y CharacterState is not included
+```
+
+---
+
+## 9. Dependencies & Integration Boundaries
+
+| Dependency | Spec | Integration Notes |
+|---|---|---|
+| Universe identity | v2 S29 | `CharacterState.universe_id` FK references the `universes` table defined in S29. |
+| Session binding | v2 S30 | S30's `game_sessions.actors` JSONB contains ActorId values defined here. S30 FR-30.03d requires actor records to exist before session creation. |
+| Character state content schema | v1 S06 | The fields within `traits`, `inventory`, `conditions`, `emotional_state`, and `reputation` are defined by S06 FR-1.1. S31 governs storage, not content semantics. |
+| Player identity | v1 S11 | `Actor.player_id` FK references `players.id` (S11). Player registration and deletion lifecycles drive actor creation (FR-31.01c) and deletion (FR-31.05a). |
+| GDPR deletion | v1 S17 | S17's right-to-erasure pipeline must cover actor and character_state records for deleted players. FR-31.05a cascade handles database-level removal; S17 governs any audit trail requirements. |
+| Cross-universe travel | v4+ S51 | S31 creates the data model that S51 will use when defining which character state fields transfer, reset, or translate between universes. S51 is out of scope for v2. |
+| Persistence migration | v2 S33 | S33 contains the migration DDL that creates the `actors` and `character_states` tables and backfills actor records for all v1 players. |
+
+---
+
+## 10. Open Questions
+
+| # | Question | Impact | Owner |
+|---|---|---|---|
+| OQ-31.01 | What is the source of `actor.display_name` at registration? Options: (a) same as `players.handle`, (b) player chooses a separate traveler name during registration, (c) generated. Choice affects Genesis v2 (S40) onboarding flow. | FR-31.01a `display_name` | S40 author / UX |
+| OQ-31.02 | Should `CharacterState` include NPC relationship state (from S06 FR-5)? In v2, NPC relationships were stored per-world in Neo4j (not in the SQL character state blob). Migrating them to SQL `CharacterState` would enable cross-universe relationship portability in v4+, but adds scope. | FR-31.02b field list | S38 NPC Memory / S51 |
+| OQ-31.03 | In v1, S06's OQ-6.4 asked about "persistent cross-world character identity" (deferred). S31 answers the identity question but defers the content-transfer question. Confirm that S51 (not S31) is the right home for content-transfer rules. | Boundary with S51 | S51 author |
+
+---
+
+## 11. Out of Scope
+
+- **Content-transfer rules between universes** — which fields of `CharacterState`
+  persist, reset, or translate when an actor crosses universes is governed by S51
+  (Cross-Universe Travel Protocol), not this spec.
+- **Multiple actors per player** — the mechanics of creating and managing a second actor
+  for the same player are a v4+ concern. S31 only specifies the v2 policy (one actor per
+  player) and the forward-compat schema (no DB uniqueness constraint on
+  `actors.player_id`).
+- **Actor-to-actor interactions** — how two actors in the same universe perceive or
+  affect each other's character state is governed by S57 (Multi-Actor Universe Model,
+  v4+).
+- **NPC actor identity** — NPCs are not actors in the S31 sense. NPC identity and state
+  are governed by v1 S06 and v2 S35 (NPC Autonomy). This spec covers player actors only.
+- **Character creation UI** — how the player names and configures their character at
+  Genesis is governed by S40 (Genesis v2). S31 specifies the storage contract; S40
+  specifies the onboarding experience.
+- **Actor soft-delete or account suspension** — disabling a player account without
+  destroying actor records is governed by v1 S11 and S26. S31 only covers hard deletion
+  cascades.
+
+---
+
+## Changelog
+
+- 2026-04-21: Initial draft. Authored by GitHub Copilot continuing from Claude Code
+  rate-limited session. Based on roadmap doc §3.1 S31 summary and v1 specs S06, S11.

--- a/specs/32-transport-abstraction.md
+++ b/specs/32-transport-abstraction.md
@@ -1,0 +1,409 @@
+# S32 — Transport Abstraction
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v2.0
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 3 — Platform
+> **Dependencies**: v1 S10
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+v1's narrative delivery code is tightly coupled to Server-Sent Events (SSE). The
+`stream_turn` route handler directly constructs `NarrativeEvent`, `HeartbeatEvent`, and
+`NarrativeEndEvent` model instances, calls `SseEventBuffer.append()`, and formats raw
+SSE wire strings. This hard-coupling means that adding WebSocket support (planned for
+S59 in v4+) would require modifying the route handler and any other code that orchestrates
+delivery — a violation of the v1 S21 constraint 4 (SSE→WS migration path) that was
+documented as unmet at v1 closeout.
+
+S32 introduces `NarrativeTransport`: a Python `Protocol` that represents the abstract
+contract for delivering narrative events to a connected client. SSE becomes one
+implementation of this protocol (`SSETransport`). Any future transport — WebSocket
+(S59), long-polling, local in-process (testing) — implements the same protocol without
+touching pipeline or route logic above the transport boundary.
+
+The boundary is explicit: **no code above the transport module shall import from
+`tta.api.sse` or directly construct `SSEEvent` subclasses for the purpose of narrative
+delivery**. Code above the transport boundary communicates only via `NarrativeTransport`
+method calls.
+
+---
+
+## 2. Design Philosophy
+
+**Protocol over inheritance**: `NarrativeTransport` is a `typing.Protocol`, not an ABC.
+Implementations need not inherit from a base class — duck typing is sufficient. This
+allows `SSETransport` to remain a clean implementation class with no forced hierarchy.
+
+**Method-per-event-type**: the protocol exposes one method per logical event type
+(`send_narrative`, `send_end`, `send_error`, `send_heartbeat`, `send_state_update`,
+`send_moderation`). This makes the transport boundary explicit: callers name what they
+want to send, not what wire format to use.
+
+**Transport owns chunking**: the responsibility for splitting a narrative string into
+sentence-aligned chunks (currently `_split_narrative()` in `games.py`) moves inside
+`SSETransport.send_narrative()`. Callers pass the full narrative string; the transport
+decides how to chunk it and how many chunks were emitted.
+
+**Return total_chunks from send_narrative**: `send_narrative()` returns the number of
+chunks emitted, so the caller can immediately call `send_end(total_chunks=n)` without
+re-counting.
+
+**No async generator leakage**: the `SSETransport` internally manages the async
+generator or callback that feeds `StreamingResponse`. The route handler's `event_stream`
+generator delegates entirely to the transport, yielding only what the transport returns.
+
+---
+
+## 3. User Stories
+
+### Developer-Facing
+
+- **US-32.1** — **As a** backend developer adding WebSocket support in v4+, **I want**
+  to implement one Python class that conforms to `NarrativeTransport`, **so that** I
+  do not need to touch the turn pipeline, route logic, or any other delivery code.
+
+- **US-32.2** — **As a** backend developer writing integration tests, **I want** to
+  inject a mock `NarrativeTransport` that records all sent events, **so that** I can
+  assert delivery behavior without spinning up an SSE connection.
+
+- **US-32.3** — **As a** backend developer on-call, **I want** the transport boundary
+  to be clearly defined and documented, **so that** I can quickly understand which layer
+  is responsible for a streaming bug.
+
+### Player-Facing (unchanged from v1)
+
+- **US-32.4** — **As a** player, I receive streamed narrative chunks in the same SSE
+  format as v1, with no visible change to the player-facing API.
+
+---
+
+## 4. Functional Requirements
+
+### FR-32.01 — `NarrativeTransport` Protocol
+
+- **FR-32.01a**: The system MUST define a `NarrativeTransport` class in
+  `src/tta/transport/protocol.py` using `typing.Protocol` with
+  `@runtime_checkable`.
+
+- **FR-32.01b**: `NarrativeTransport` MUST declare the following async methods:
+
+  | Method | Signature | Returns | Notes |
+  |---|---|---|---|
+  | `send_narrative` | `(text: str, turn_id: str) -> int` | `int` — number of chunks emitted | Transport owns chunking |
+  | `send_end` | `(turn_id: str, total_chunks: int) -> None` | `None` | Signals turn narrative is complete |
+  | `send_error` | `(code: str, message: str, turn_id: str \| None, correlation_id: str \| None, retry_after_seconds: int \| None) -> None` | `None` | Delivers an error event |
+  | `send_heartbeat` | `() -> None` | `None` | Keepalive pulse |
+  | `send_state_update` | `(changes: list[WorldChange]) -> None` | `None` | World-state diff post-turn |
+  | `send_moderation` | `(reason: str) -> None` | `None` | Moderation redirect notice |
+
+  All methods MUST be `async def` (awaitable). Synchronous implementations MUST
+  use `asyncio.coroutine` wrappers or `async def` with synchronous bodies.
+
+- **FR-32.01c**: `NarrativeTransport` MUST declare a read-only `is_connected`
+  property returning `bool`. A transport where `is_connected == False` MUST silently
+  discard all `send_*` calls without raising.
+
+- **FR-32.01d**: The `typing.runtime_checkable` decorator MUST be applied to
+  `NarrativeTransport` so that `isinstance(transport, NarrativeTransport)` works in
+  tests and guards.
+
+### FR-32.02 — `SSETransport` Implementation
+
+- **FR-32.02a**: The system MUST provide a class `SSETransport` in
+  `src/tta/transport/sse.py` that satisfies the `NarrativeTransport` protocol.
+
+- **FR-32.02b**: `SSETransport` MUST accept the following at construction time:
+  - `redis: Redis` — the async Redis client for the `SseEventBuffer`
+  - `game_id: str` — used as the buffer namespace key
+  - An `emit` callable: `Callable[[SSEEvent], Awaitable[str]]` — the callback that
+    formats and appends an event to the buffer and returns the raw SSE string.
+
+  The `emit` callable is provided by the route handler (it is the existing `_emit`
+  closure), keeping `SSETransport` free of direct dependency on FastAPI request state.
+
+- **FR-32.02c**: `SSETransport.send_narrative()` MUST:
+  1. Split `text` into sentence-aligned chunks using the same algorithm as v1
+     `_split_narrative()` (sentence boundaries, max-chunk-size guard from
+     `settings.sse_chunk_max_chars`).
+  2. Call `emit(NarrativeEvent(text=chunk, turn_id=turn_id, sequence=i))` for each
+     chunk.
+  3. Return the number of chunks emitted.
+
+- **FR-32.02d**: `SSETransport.send_end()` MUST call
+  `emit(NarrativeEndEvent(turn_id=turn_id, total_chunks=total_chunks))`.
+
+- **FR-32.02e**: `SSETransport.send_error()` MUST call
+  `emit(ErrorEvent(code=code, message=message, ...))`.
+
+- **FR-32.02f**: `SSETransport.send_heartbeat()` MUST call
+  `emit(HeartbeatEvent())`.
+
+- **FR-32.02g**: `SSETransport.send_state_update()` MUST call
+  `emit(StateUpdateEvent(changes=changes))`.
+
+- **FR-32.02h**: `SSETransport.send_moderation()` MUST call
+  `emit(ModerationEvent(reason=reason))`.
+
+- **FR-32.02i**: `SSETransport.is_connected` MUST return `True` after construction
+  and `False` after `close()` is called or a client-disconnect is detected.
+
+### FR-32.03 — `MemoryTransport` (Testing Utility)
+
+- **FR-32.03a**: The system MUST provide a `MemoryTransport` class in
+  `src/tta/transport/memory.py` that satisfies `NarrativeTransport` and records all
+  sent events in an ordered list (`events: list[dict]`).
+
+- **FR-32.03b**: `MemoryTransport` MUST NOT depend on Redis, FastAPI, or any I/O.
+  All `send_*` methods append a structured record to `self.events` and return
+  immediately (no I/O).
+
+- **FR-32.03c**: `MemoryTransport` MUST expose a `clear()` method to reset the
+  events list between test scenarios.
+
+- **FR-32.03d**: `MemoryTransport.send_narrative()` MUST still apply the chunking
+  algorithm (or accept a `split: bool = True` parameter to skip it in unit tests that
+  want raw text).
+
+### FR-32.04 — Module Layout
+
+- **FR-32.04a**: The transport package MUST be located at `src/tta/transport/` with
+  the following structure:
+
+  ```
+  src/tta/transport/
+    __init__.py          # re-exports NarrativeTransport, SSETransport, MemoryTransport
+    protocol.py          # NarrativeTransport Protocol definition
+    sse.py               # SSETransport implementation
+    memory.py            # MemoryTransport for testing
+  ```
+
+- **FR-32.04b**: `src/tta/transport/__init__.py` MUST re-export `NarrativeTransport`,
+  `SSETransport`, and `MemoryTransport` so callers import from `tta.transport`.
+
+### FR-32.05 — Delivery Layer Constraint (Import Rule)
+
+- **FR-32.05a**: The `stream_turn` route handler in `games.py` MUST NOT directly
+  import or instantiate `NarrativeEvent`, `NarrativeEndEvent`, `HeartbeatEvent`,
+  `ErrorEvent`, `StateUpdateEvent`, or `ModerationEvent` for the purpose of emitting
+  narrative. These imports are permitted only within `SSETransport.send_*` methods.
+
+- **FR-32.05b**: The `stream_turn` route handler MUST construct an `SSETransport`
+  and call its methods. The pattern MUST be:
+
+  ```python
+  transport = SSETransport(redis=redis, game_id=game_id_str, emit=_emit)
+  total_chunks = await transport.send_narrative(result.narrative_output, turn_id)
+  await transport.send_end(turn_id, total_chunks)
+  ```
+
+- **FR-32.05c**: All existing direct event emissions in `games.py` (moderation,
+  state_update, heartbeat, error) MUST be refactored to call the corresponding
+  `transport.send_*()` method.
+
+- **FR-32.05d**: The `_split_narrative()` free function in `games.py` MUST be moved
+  to `src/tta/transport/sse.py` or `src/tta/transport/_chunking.py` and MUST NOT
+  remain in the route handler module. It MAY be re-exported from `tta.transport` for
+  use in tests.
+
+### FR-32.06 — `PipelineDeps` Transport Slot
+
+- **FR-32.06a**: `PipelineDeps` in `src/tta/pipeline/types.py` MUST gain an optional
+  field `transport: NarrativeTransport | None = None`. Default is `None`; injection
+  is done at route-handler construction time.
+
+- **FR-32.06b**: In v2.0, NO pipeline stage (understand, context, generate, deliver)
+  calls `transport.send_*()` directly. The transport slot is reserved for a future
+  streaming-native generate stage that calls `send_narrative` token-by-token during
+  LLM generation (deferred to v3+). In v2.0, the route handler calls the transport
+  after the pipeline returns.
+
+- **FR-32.06c**: The `deliver_stage` MUST NOT be modified for S32. It continues to
+  mark the turn as complete; narrative delivery is the route handler's responsibility.
+
+---
+
+## 5. Non-Functional Requirements
+
+- **NFR-32.A** — `SSETransport` MUST add no more than 1 ms of overhead per `send_*`
+  call compared to the equivalent direct `_emit()` call (p95). The abstraction must be
+  zero-cost for SSE delivery.
+- **NFR-32.B** — `MemoryTransport.send_*()` methods MUST complete within 0.1 ms (p99)
+  with no I/O.
+- **NFR-32.C** — The `stream_turn` handler's end-to-end SSE delivery latency (first
+  chunk to client) MUST remain within the v1 baseline ± 5 ms after refactoring.
+- **NFR-32.D** — No existing v1 SSE wire format is changed. Clients receive identical
+  event names, data structures, and ordering as v1.
+- **NFR-32.E** — The `NarrativeTransport` protocol MUST be Pyright `standard`-clean
+  with no type: ignore comments. `SSETransport` and `MemoryTransport` MUST pass Pyright
+  checks as satisfying the Protocol.
+
+---
+
+## 6. User Journeys
+
+### Journey 1: v2.0 SSE Delivery (No Change for Clients)
+
+1. Client opens SSE connection: `GET /api/v1/games/{id}/stream`.
+2. Client submits turn: `POST /api/v1/games/{id}/turns`.
+3. Route handler runs pipeline → gets `TurnState` with `narrative_output`.
+4. Route handler constructs `SSETransport(redis=..., game_id=..., emit=_emit)`.
+5. Route handler calls `await transport.send_narrative(result.narrative_output, turn_id)`.
+6. `SSETransport` splits narrative, emits `NarrativeEvent` chunks via `_emit`.
+7. Route handler calls `await transport.send_end(turn_id, total_chunks)`.
+8. Route handler calls `await transport.send_state_update(result.world_state_updates)` if present.
+9. Client receives identical SSE wire format as v1.
+
+### Journey 2: Integration Test Using MemoryTransport
+
+1. Test instantiates `MemoryTransport()`.
+2. Test injects transport into route handler (via dependency override).
+3. Test submits a turn.
+4. Test asserts `transport.events` contains: narrative chunks in order, narrative_end with correct `total_chunks`, no error events.
+5. No Redis, no SSE connection required.
+
+### Journey 3: v4+ WebSocket Transport (Future, Not Implemented in v2)
+
+1. Developer creates `WebSocketTransport` in `src/tta/transport/websocket.py`.
+2. `WebSocketTransport` satisfies `NarrativeTransport` protocol.
+3. Route handler for WebSocket connections constructs `WebSocketTransport` and passes it
+   to the same delivery logic used by the SSE handler.
+4. No changes to pipeline stages, `PipelineDeps`, or any module above the transport.
+
+---
+
+## 7. Edge Cases & Failure Modes
+
+| # | Scenario | Expected Behavior |
+|---|----------|-------------------|
+| EC-32.01 | Client disconnects mid-stream | `SSETransport.is_connected` returns `False`; subsequent `send_*` calls are silently discarded; route handler exits generator cleanly. |
+| EC-32.02 | `send_narrative` called with empty string | Transport emits zero chunks; returns 0; caller passes `total_chunks=0` to `send_end`. |
+| EC-32.03 | `send_narrative` called with very long text (> buffer max) | Chunking algorithm applies max-chunk guard; emits `N` chunks each within the configured size limit. |
+| EC-32.04 | `emit` callback raises during `send_narrative` | Exception propagates to the route handler; the generator's error handler calls `send_error()` via the same transport — which also raises. The generator falls back to raw error SSE string. |
+| EC-32.05 | `MemoryTransport` used in production (configuration error) | `MemoryTransport.is_connected` always returns `True`; events are silently dropped in memory. Operator-level monitoring should alert on missing SSE client connections. |
+| EC-32.06 | Pipeline stage accidentally calls `deps.transport.send_narrative()` in v2.0 | Pyright detects `NarrativeTransport | None` and requires a None-check. Test transport captures the call; code review policy flags direct stage→transport calls as a violation. |
+
+---
+
+## 8. Acceptance Criteria
+
+```gherkin
+Feature: Transport Abstraction
+
+  Scenario: AC-32.01 — SSETransport satisfies NarrativeTransport protocol
+    Given SSETransport is instantiated with a mock emit callback
+    When isinstance(transport, NarrativeTransport) is evaluated
+    Then the result is True (runtime_checkable Protocol check passes)
+
+  Scenario: AC-32.02 — send_narrative returns chunk count
+    Given an SSETransport with a recording emit callback
+    When send_narrative("First sentence. Second sentence.", turn_id="t1") is called
+    Then send_narrative returns 2 (two chunks emitted)
+    And emit was called twice with NarrativeEvent instances
+    And the first NarrativeEvent has sequence=0 and text="First sentence."
+    And the second NarrativeEvent has sequence=1 and text="Second sentence."
+
+  Scenario: AC-32.03 — send_end emits NarrativeEndEvent
+    Given an SSETransport with a recording emit callback
+    When send_end(turn_id="t1", total_chunks=2) is called
+    Then emit was called once with a NarrativeEndEvent with total_chunks=2
+
+  Scenario: AC-32.04 — send_heartbeat emits HeartbeatEvent
+    Given an SSETransport with a recording emit callback
+    When send_heartbeat() is called
+    Then emit was called once with a HeartbeatEvent instance
+
+  Scenario: AC-32.05 — games.py does not directly import SSE event classes for delivery
+    Given the games.py source file
+    When the import statements are inspected
+    Then NarrativeEvent, NarrativeEndEvent, HeartbeatEvent, ErrorEvent, StateUpdateEvent,
+         and ModerationEvent are NOT imported at the top level of games.py for delivery purposes
+
+  Scenario: AC-32.06 — MemoryTransport records events without I/O
+    Given a MemoryTransport instance
+    When send_narrative("Hello world.", "t1") is called
+    And send_end("t1", 1) is called
+    Then MemoryTransport.events contains exactly 2 entries
+    And no Redis or network calls were made
+
+  Scenario: AC-32.07 — MemoryTransport satisfies NarrativeTransport protocol
+    Given MemoryTransport is instantiated
+    When isinstance(transport, NarrativeTransport) is evaluated
+    Then the result is True
+
+  Scenario: AC-32.08 — Disconnected transport discards sends silently
+    Given an SSETransport where is_connected returns False
+    When send_narrative("text", "t1") is called
+    Then no exception is raised
+    And emit was NOT called
+    And send_narrative returns 0
+
+  Scenario: AC-32.09 — SSE wire format is unchanged from v1
+    Given an SSETransport with the real SseEventBuffer
+    When a full turn is delivered via the transport
+    Then the emitted SSE event names (narrative, narrative_end, heartbeat, error, etc.)
+         are identical to those specified in v1 S10 §6.2
+    And existing SSE client code receives correct events without modification
+
+  Scenario: AC-32.10 — Pyright passes on transport module
+    Given the src/tta/transport/ package
+    When pyright is run with mode=standard
+    Then zero type errors are reported
+    And SSETransport and MemoryTransport are recognised as satisfying NarrativeTransport
+```
+
+---
+
+## 9. Dependencies & Integration Boundaries
+
+| Dependency | Spec | Integration Notes |
+|---|---|---|
+| API & SSE contract | v1 S10 | The SSE wire format (event names, data schemas, `Last-Event-ID` replay) is defined by S10. S32 wraps that contract; it does not change it. All S10 FRs and ACs remain normative. |
+| Turn pipeline | v1 S08 | `PipelineDeps` gains a `transport` slot (FR-32.06a). No pipeline stage is modified in v2.0. |
+| SSE event models | v1 internal | `src/tta/models/events.py` (NarrativeEvent, etc.) is used ONLY inside `SSETransport`. Route handlers do not import from it for delivery. |
+| SSE buffer | v1 internal | `SseEventBuffer` and `format_sse` are used ONLY inside `SSETransport`. They remain in `src/tta/api/sse.py` and are not moved. |
+| WebSocket transport | v4+ S59 | S59 provides `WebSocketTransport` implementing `NarrativeTransport`. S32 defines the protocol contract S59 must satisfy. |
+| Content moderation | v1 S24 | `send_moderation()` delivers the player-safe moderation notice. The route handler detects `TurnStatus.moderated` and calls `transport.send_moderation(reason)`. |
+
+---
+
+## 10. Open Questions
+
+| # | Question | Impact | Owner |
+|---|----------|--------|-------|
+| OQ-32.01 | Should `_split_narrative()` be configurable per-transport (e.g., WebSocket transport might prefer unsplit full text)? Or should chunking always be enforced at the transport level? | `send_narrative` contract (FR-32.01b) | S59 author |
+| OQ-32.02 | Should the `emit` callback be part of the `NarrativeTransport` Protocol or an implementation detail of `SSETransport`? The current design embeds the `emit` callable in `SSETransport.__init__`, but a future transport might not need it. | FR-32.02b constructor signature | v2 tech lead |
+| OQ-32.03 | v3+ may add a streaming-native generate stage that calls `transport.send_narrative()` token-by-token during LLM generation, requiring the transport to exist in `PipelineDeps` and be called from within the pipeline. Should S32 already define the `PipelineDeps.transport` field as an active call site, or strictly as a reserved slot? | FR-32.06b scope | v3+ LLM pipeline author |
+
+---
+
+## 11. Out of Scope
+
+- **WebSocket implementation** — `WebSocketTransport` is the subject of S59. S32 only
+  defines the protocol that S59 must implement.
+- **Long-polling fallback** — documented as deferred in v1 S10 OQ-10.02. S32 does not
+  address it; long-polling is a future transport implementation if/when needed.
+- **Token-by-token LLM streaming into transport** — the generate stage in v2.0 still
+  returns the full narrative string to the route handler. Real-time token streaming into
+  the transport is a v3+ concern. S32 reserves the `PipelineDeps.transport` slot but
+  does not wire it.
+- **Transport multiplexing** — sending one turn's events to multiple simultaneous
+  transport connections (e.g., browser tab + mobile) is a v4+ concern (S57/S59).
+- **Changes to `SseEventBuffer`** — the Redis-backed replay buffer remains unchanged.
+  `SSETransport` wraps it; S32 does not modify or specify changes to `SseEventBuffer`.
+- **Changes to `src/tta/models/events.py`** — the SSE event model classes remain
+  unchanged. S32 moves their use inside `SSETransport`; it does not alter the models.
+- **Server-side rate-limit headers on SSE responses** — the v1 open item (AC-10.08 gap)
+  is an S10 concern, not S32.
+
+---
+
+## Changelog
+
+- 2026-04-21: Initial draft. Authored by GitHub Copilot continuing from Claude Code
+  rate-limited session. Based on roadmap §3.1 S32 summary, v1 S10 implementation,
+  `src/tta/api/sse.py`, `src/tta/models/events.py`, and `src/tta/api/routes/games.py`
+  delivery section analysis.

--- a/specs/33-universe-persistence-schema.md
+++ b/specs/33-universe-persistence-schema.md
@@ -1,0 +1,602 @@
+# S33 — Universe Persistence Schema
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v2.0
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 3 — Platform
+> **Dependencies**: v2 S29, v2 S31, v1 S12, v1 S13
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+v1 had no explicit concept of a "universe." World state lived in three places:
+
+- **PostgreSQL** `game_sessions.world_seed` — a JSONB blob encoding the initial world
+  parameters used to generate the world at session start.
+- **PostgreSQL** `game_snapshots.world_state` — a per-turn JSONB snapshot capturing the
+  current world state for crash recovery.
+- **Neo4j** — the live knowledge graph containing Location, NPC, Item, Region, Event,
+  and Quest nodes, isolated per session via a `session_id` property.
+
+There was no `universes` table, no `actors` table, and no `character_states` table. The
+player's character state was implicit in the snapshot blob.
+
+This spec defines:
+
+1. The **new PostgreSQL tables** that v2 introduces for universe persistence:
+   `universes`, `actors`, `character_states`, `universe_snapshots`.
+2. The **v1 → v2 migration DDL** — the Alembic migration that adds the new tables,
+   backfills data from existing v1 records, and adds the new FK columns to
+   `game_sessions`.
+3. The **Neo4j schema additions** that add `universe_id` indexing to all world-scoped
+   graph nodes.
+4. The **durable universe snapshot** mechanism (distinct from v1's per-turn
+   `game_snapshots`) that captures cross-session world state at session end.
+
+This spec does NOT define how the turn pipeline uses these tables (that is S08 / S12),
+nor how genesis populates them (S40). This spec defines what exists in the database and
+how v1 data is safely migrated to that state.
+
+---
+
+## 2. Design Philosophy
+
+**Additive migration**: the v1 → v2 migration adds new tables and new FK columns. It
+never drops or renames an existing column. The `world_seed` column on `game_sessions` is
+preserved (read-only after migration), maintaining backward compatibility with v1
+snapshot archives and audit logs.
+
+**Source of truth for migration**: each v1 `game_sessions` row carries `world_seed`
+(the world parameters) and is the source for one `universes` row. The `session_id` is
+the bridge key between PostgreSQL and Neo4j during migration (since `World.session_id`
+is unique in v1 Neo4j).
+
+**One universe per v1 session**: in v1, each game session generated an independent
+world from scratch. There was no universe continuity between sessions. Therefore each v1
+`game_sessions` row becomes a distinct universe in v2, with the v1 session bound to
+that universe (one-session history). This means v1 data does NOT demonstrate cross-
+session universe continuity — it bootstraps the universe graph cleanly.
+
+**ULID for universe_id**: universe IDs are ULIDs (text, 26 chars), matching the S29
+design. PostgreSQL `gen_random_uuid()` is used for the UUIDs on actors and
+character_states (ordinary entities), but `universe_id` uses a ULID generation function
+(see Appendix A).
+
+**No downtime migration**: all DDL steps are safe for rolling deployments:
+(1) new tables with no FK constraints → (2) add nullable FK columns → (3) backfill →
+(4) add NOT NULL constraint → (5) add indexes. Step 4 can be deferred to v2.1 if
+backfill must run offline.
+
+---
+
+## 3. User Stories
+
+### Migration Safety
+
+- **US-33.1** — **As a** developer upgrading from v1 to v2, **I want** the migration to
+  run without dropping data, **so that** all player histories and world states are
+  preserved.
+
+- **US-33.2** — **As a** developer, **I want** a dry-run / validation mode for the
+  migration, **so that** I can verify the backfill row counts match before the final
+  commit.
+
+- **US-33.3** — **As an** operator, **I want** the migration to be idempotent, **so
+  that** I can re-run it safely if it was interrupted.
+
+### Cross-Session Durability
+
+- **US-33.4** — **As a** player, **I want** my universe's state to persist between
+  sessions even if the server restarts, **so that** my story is not lost.
+
+- **US-33.5** — **As a** developer, **I want** to retrieve the last durable universe
+  snapshot for a session, **so that** I can reconstruct the Neo4j graph after a cold
+  restart without replaying all turns.
+
+---
+
+## 4. Functional Requirements
+
+### FR-33.01 — New PostgreSQL Tables
+
+#### FR-33.01a: `universes` table
+
+The migration MUST create the `universes` table with the following columns:
+
+| Column | Type | Required | Notes |
+|---|---|---|---|
+| `universe_id` | TEXT | Yes | ULID, PK; 26-char format |
+| `config` | JSONB | Yes | World parameters (migrated from `world_seed`) |
+| `status` | TEXT | Yes | `created` / `active` / `paused` / `archived`; default `paused` |
+| `created_at` | TIMESTAMPTZ | Yes | Defaults to `now()` |
+| `updated_at` | TIMESTAMPTZ | Yes | Updated on status change |
+
+No FK columns reference other tables. `universe_id` is the root of the v2 object graph.
+
+The `status` default for backfilled rows is `paused` (because v1 sessions are all
+historical — none are currently active).
+
+#### FR-33.01b: `actors` table
+
+The migration MUST create the `actors` table with the following columns:
+
+| Column | Type | Required | Notes |
+|---|---|---|---|
+| `actor_id` | TEXT | Yes | ULID, PK; 26-char format |
+| `player_id` | UUID | Yes | FK → `players.id` ON DELETE CASCADE; NOT NULL |
+| `display_name` | TEXT | Yes | Copied from `players.handle` during backfill |
+| `created_at` | TIMESTAMPTZ | Yes | Defaults to `now()` |
+
+There is NO UNIQUE constraint on `actor_id, player_id` combination. (See S31
+FR-31.01d.)
+
+#### FR-33.01c: `character_states` table
+
+The migration MUST create the `character_states` table with the following columns:
+
+| Column | Type | Required | Notes |
+|---|---|---|---|
+| `actor_id` | TEXT | Yes | FK → `actors.actor_id` ON DELETE CASCADE; part of PK |
+| `universe_id` | TEXT | Yes | FK → `universes.universe_id` ON DELETE CASCADE; part of PK |
+| `character_name` | TEXT | Yes | In-world name; default `'Traveler'` for backfilled v1 rows |
+| `traits` | JSONB | Yes | From S06; default `'{}'::jsonb` for v1 rows |
+| `inventory` | JSONB | Yes | Default `'[]'::jsonb` for v1 rows |
+| `conditions` | JSONB | Yes | Default `'[]'::jsonb` for v1 rows |
+| `emotional_state` | JSONB | Yes | Default `'{}'::jsonb` for v1 rows |
+| `reputation` | JSONB | Yes | Default `'{}'::jsonb` for v1 rows |
+| `last_active_at` | TIMESTAMPTZ | Yes | From `game_sessions.updated_at` during backfill |
+
+Primary key: `(actor_id, universe_id)` — enforces the S31 FR-31.02c uniqueness
+constraint.
+
+#### FR-33.01d: `universe_snapshots` table
+
+The migration MUST create the `universe_snapshots` table with the following columns:
+
+| Column | Type | Required | Notes |
+|---|---|---|---|
+| `id` | UUID | Yes | PK; `gen_random_uuid()` |
+| `universe_id` | TEXT | Yes | FK → `universes.universe_id` ON DELETE CASCADE; NOT NULL |
+| `session_id` | UUID | Yes | FK → `game_sessions.id` ON DELETE SET NULL; NOT NULL |
+| `snapshot_type` | TEXT | Yes | `session_end` / `manual` / `checkpoint`; NOT NULL |
+| `world_state` | JSONB | Yes | Full Neo4j graph export at snapshot time |
+| `narrative_digest` | TEXT | No | Optional summary hash for integrity checking |
+| `created_at` | TIMESTAMPTZ | Yes | Defaults to `now()` |
+
+**Distinction from v1 `game_snapshots`**: `game_snapshots` is a per-turn, per-session
+crash-recovery mechanism. `universe_snapshots` is a per-universe, per-session-boundary
+durability record that captures the world graph state at the moment a session ends. It is
+the source for cold-restart reconstruction and cross-session continuity.
+
+Note: no `universe_snapshots` rows are created during the v1 → v2 migration. They begin
+accumulating with v2 operation.
+
+### FR-33.02 — Modifications to Existing Tables
+
+#### FR-33.02a: `game_sessions.universe_id` column
+
+The migration MUST add a `universe_id TEXT` column to `game_sessions`:
+
+- Initially nullable (to allow online migration with backfill step).
+- After backfill, a `NOT NULL` constraint is added in a subsequent migration step
+  (or deferred to v2.1 online migration).
+- FK: `REFERENCES universes(universe_id) ON DELETE SET NULL` (soft link — deleting a
+  universe sets the session's universe_id to NULL rather than cascade-deleting old
+  sessions).
+
+#### FR-33.02b: `game_sessions.actors` column
+
+The migration MUST add an `actors JSONB` column to `game_sessions`:
+
+- Default: `'[]'::jsonb`
+- Initially nullable for migration safety; `NOT NULL DEFAULT '[]'::jsonb` added after
+  backfill.
+- Backfilled for v1 sessions: `[{"actor_id": "<backfilled_actor_id>"}]` for each
+  session's player.
+- Content schema is defined by S30 FR-30.03.
+
+#### FR-33.02c: `world_seed` column
+
+The existing `game_sessions.world_seed` column MUST NOT be dropped or renamed. It is
+preserved as a historical read-only column after migration. Its contents are copied to
+`universes.config` during backfill.
+
+### FR-33.03 — Backfill Logic
+
+The backfill MUST execute in the following sequence within the migration:
+
+**Step 1 — Create universes from game_sessions**
+
+For each distinct `game_sessions` row (ordered by `created_at` ASC):
+
+```
+INSERT INTO universes (universe_id, config, status, created_at, updated_at)
+SELECT
+  gen_ulid(),                      -- new ULID per session
+  world_seed,                      -- copy world_seed blob verbatim
+  'paused',                        -- all historical universes are paused
+  game_sessions.created_at,
+  game_sessions.updated_at
+FROM game_sessions
+ORDER BY created_at ASC;
+```
+
+Because v1 had no concept of universe continuity, each `game_sessions` row gets a
+distinct `universes` row. This is a 1:1 backfill.
+
+**Step 2 — Backfill game_sessions.universe_id**
+
+```
+UPDATE game_sessions gs
+SET universe_id = u.universe_id
+FROM universes u
+WHERE u.created_at = gs.created_at
+  AND u.config::text = gs.world_seed::text;
+```
+
+Note: if two sessions have identical `world_seed` AND identical `created_at`, this
+UPDATE could match the wrong universe row. The migration MUST add a stable surrogate
+key to the join. See Appendix A for the recommended approach using a temporary mapping
+table.
+
+**Step 3 — Create one actor per player**
+
+```
+INSERT INTO actors (actor_id, player_id, display_name, created_at)
+SELECT
+  gen_ulid(),
+  id,
+  handle,
+  created_at
+FROM players
+ORDER BY created_at ASC;
+```
+
+**Step 4 — Backfill game_sessions.actors JSONB**
+
+```
+UPDATE game_sessions gs
+SET actors = jsonb_build_array(
+  jsonb_build_object('actor_id', a.actor_id)
+)
+FROM actors a
+WHERE a.player_id = gs.player_id;
+```
+
+**Step 5 — Create character_states for all historical sessions**
+
+```
+INSERT INTO character_states
+  (actor_id, universe_id, character_name, traits, inventory,
+   conditions, emotional_state, reputation, last_active_at)
+SELECT
+  a.actor_id,
+  gs.universe_id,
+  'Traveler',          -- default name; v1 had no character name concept
+  '{}'::jsonb,
+  '[]'::jsonb,
+  '[]'::jsonb,
+  '{}'::jsonb,
+  '{}'::jsonb,
+  gs.updated_at
+FROM game_sessions gs
+JOIN actors a ON a.player_id = gs.player_id
+WHERE gs.universe_id IS NOT NULL;
+```
+
+The `character_states.traits` etc. are left empty for v1 rows because v1 did not persist
+character state as a separate entity. The character state exists in the `game_snapshots`
+blob; an optional v2.1 backfill job may extract and populate these fields from the last
+snapshot per session.
+
+### FR-33.04 — Neo4j Schema Additions
+
+#### FR-33.04a: `universe_id` property and index on all world-scoped nodes
+
+The Neo4j migration MUST add `universe_id` as an indexed property to the following node
+types: `World`, `Location`, `NPC`, `Item`, `Region`, `Event`, `Quest`, `Connection`.
+
+```cypher
+CREATE INDEX location_universe_id IF NOT EXISTS
+  FOR (l:Location) ON (l.universe_id);
+-- (and similar for each node type)
+```
+
+#### FR-33.04b: Backfill `universe_id` via session_id bridge
+
+The Neo4j backfill MUST set `universe_id` on all existing world-scoped nodes by joining
+on `session_id`:
+
+```cypher
+// For each session, get its universe_id from PG (via application-layer bridge)
+// and MATCH all nodes with that session_id:
+MATCH (n)
+WHERE n.session_id = $session_id
+  AND (n:Location OR n:NPC OR n:Item OR n:Region OR n:Event OR n:Quest
+       OR n:World OR n:Connection)
+SET n.universe_id = $universe_id
+```
+
+This Cypher is run per-session via an application-layer migration script that reads
+`(session_id → universe_id)` mappings from PostgreSQL after the PG backfill completes.
+
+#### FR-33.04c: Add `universe_id` UNIQUE constraint on `World` node
+
+```cypher
+CREATE CONSTRAINT world_universe_id_unique IF NOT EXISTS
+  FOR (w:World) REQUIRE w.universe_id IS UNIQUE;
+```
+
+Note: the existing `world_session_unique` constraint (`w.session_id IS UNIQUE`) is
+preserved. Both constraints co-exist.
+
+#### FR-33.04d: Cross-universe index on world-scoped nodes
+
+```cypher
+CREATE INDEX location_universe_id IF NOT EXISTS
+  FOR (l:Location) ON (l.universe_id);
+-- Allows "all Locations in universe X" queries required by S29 FR-29.07c.
+```
+
+### FR-33.05 — Migration Idempotency
+
+- **FR-33.05a**: The migration MUST be idempotent. Re-running after partial failure
+  MUST NOT create duplicate `universes`, `actors`, or `character_states` rows.
+- **FR-33.05b**: Each step MUST use `INSERT ... ON CONFLICT DO NOTHING` or
+  `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` guards.
+- **FR-33.05c**: The migration MUST record its completion in the Alembic revision table.
+  On re-run, Alembic's standard mechanism prevents double-execution.
+
+### FR-33.06 — Migration Validation
+
+- **FR-33.06a**: After migration, the system MUST validate:
+  - `COUNT(universes)` ≥ `COUNT(game_sessions)` (each session has a universe)
+  - `COUNT(actors)` = `COUNT(players)` (each player has exactly one actor)
+  - `COUNT(character_states)` = `COUNT(game_sessions WHERE universe_id IS NOT NULL)`
+  - `COUNT(game_sessions WHERE universe_id IS NULL)` = 0
+- **FR-33.06b**: A post-migration validation script MUST be provided in
+  `scripts/migrate_validate_v2.py` that runs these assertions and exits non-zero on
+  failure.
+- **FR-33.06c**: If validation fails, the migration is marked as failed and the operator
+  is notified with the assertion that failed and the discrepancy count.
+
+---
+
+## 5. Non-Functional Requirements
+
+- **NFR-33.A** — The migration MUST complete within 60 minutes on a v1 database with
+  100 000 game sessions, running on a PostgreSQL 16 instance with 4 vCPUs and 16 GB
+  RAM.
+- **NFR-33.B** — The migration MUST NOT acquire table-level locks for more than 1
+  second on `game_sessions`, `players`, or `turns` during online operation. All heavy
+  steps MUST use `CREATE INDEX CONCURRENTLY` and backfill in batches of 1000 rows.
+- **NFR-33.C** — Post-migration read latency for `universes` by `universe_id` MUST be
+  ≤ 5 ms (p95) with the PK index.
+- **NFR-33.D** — Post-migration read latency for `character_states` by
+  `(actor_id, universe_id)` MUST be ≤ 10 ms (p95) with the composite PK index.
+- **NFR-33.E** — The Neo4j `universe_id` backfill script MUST process nodes in batches
+  of 500 per transaction to avoid memory pressure on Neo4j CE.
+
+---
+
+## 6. User Journeys
+
+### Journey 1: Operator Runs v1 → v2 Migration
+
+1. Operator runs `uv run alembic upgrade 011` (migration 011 is the v2 migration).
+2. Alembic applies: create `universes`, `actors`, `character_states`,
+   `universe_snapshots` tables; add `universe_id`, `actors` columns to `game_sessions`.
+3. Backfill runs in batches: `universes` from `game_sessions`, `actors` from `players`,
+   `character_states` from session/actor join.
+4. Alembic marks revision 011 as applied.
+5. Operator runs `uv run python scripts/migrate_validate_v2.py` — all assertions pass.
+6. Operator runs the Neo4j backfill script:
+   `uv run python scripts/migrate_neo4j_universe_id.py`
+7. All Neo4j world nodes now carry `universe_id`.
+8. Operator marks v2 migration as complete; application upgraded to v2 image.
+
+### Journey 2: Application Cold-Restart After Session End
+
+1. v2 session ends; S30 FR-30.04a triggers universe status → `paused`.
+2. The session-end handler writes a `universe_snapshots` row with the full Neo4j
+   world-state JSON.
+3. Service restarts; Neo4j is empty (ephemeral container restart scenario).
+4. On next session open, the turn pipeline detects missing Neo4j nodes for the universe.
+5. System reads the latest `universe_snapshots` row for the universe.
+6. Neo4j graph is reconstructed from the snapshot JSON.
+7. Session resumes; player experiences no data loss.
+
+---
+
+## 7. Edge Cases & Failure Modes
+
+| # | Scenario | Expected Behavior |
+|---|----------|-------------------|
+| EC-33.01 | Two v1 game_sessions have identical world_seed AND created_at | Migration uses temporary mapping table (see Appendix A) to avoid UUID collision in the session→universe join. Each session gets its own unique universe row. |
+| EC-33.02 | A player was deleted before migration runs (CASCADE-deleted session rows) | No orphan sessions; backfill produces correct counts. `COUNT(actors)` = `COUNT(players)` at migration time (post-GDPR deletion). |
+| EC-33.03 | Migration interrupted mid-backfill | Re-run after fix: `ON CONFLICT DO NOTHING` prevents duplicate inserts. Alembic does not re-apply the revision. Operator re-runs migration after fixing root cause. |
+| EC-33.04 | Neo4j backfill script fails mid-run | Re-runnable: nodes already set with `universe_id` are skipped via `WHERE n.universe_id IS NULL`. Script logs completion count per batch. |
+| EC-33.05 | universe_id FK on game_sessions is NULL after backfill | Validation script catches this. Root cause: session row that had no matching universe (orphan session). Operator resolves before marking migration complete. |
+| EC-33.06 | game_snapshots.world_state referenced for character_state backfill | v2.0 leaves character fields empty (`{}`/`[]`); a separate optional v2.1 job extracts S06 fields from the last snapshot per session. |
+| EC-33.07 | universe_snapshots table queried before first v2 session ends | Returns empty result set. Turn pipeline falls back to full Neo4j graph query (no snapshot available). |
+
+---
+
+## 8. Acceptance Criteria
+
+```gherkin
+Feature: Universe Persistence Schema Migration
+
+  Scenario: AC-33.01 — Migration creates universes table and backfills from game_sessions
+    Given a v1 database with N game_sessions rows
+    When migration 011 is applied
+    Then the universes table contains exactly N rows
+    And each universes row has universe_id as a ULID
+    And each universes row has config equal to the corresponding game_sessions.world_seed
+    And all universes rows have status = 'paused'
+
+  Scenario: AC-33.02 — Migration creates one actor per player
+    Given a v1 database with M players rows
+    When migration 011 is applied
+    Then the actors table contains exactly M rows
+    And each actor row has player_id matching a players row
+    And each actor has a unique actor_id ULID
+
+  Scenario: AC-33.03 — game_sessions.universe_id is backfilled for all sessions
+    Given N game_sessions rows
+    When migration 011 completes backfill
+    Then game_sessions.universe_id is NOT NULL for all N rows
+    And each universe_id references an existing universes row
+
+  Scenario: AC-33.04 — character_states created for all historical sessions
+    Given N game_sessions rows after universe_id backfill
+    When character_state backfill runs
+    Then character_states contains exactly N rows
+    And each character_state has actor_id from the session's player's actor
+    And each character_state has universe_id from the session's universe_id
+
+  Scenario: AC-33.05 — Migration is idempotent
+    Given migration 011 was partially applied (interrupted)
+    When migration 011 is re-run
+    Then no duplicate universes, actors, or character_states rows are created
+    And the migration completes without error
+
+  Scenario: AC-33.06 — world_seed column is preserved after migration
+    Given a game_sessions row with world_seed = {"genre": "noir"}
+    When migration 011 runs
+    Then game_sessions.world_seed still equals {"genre": "noir"}
+    And universes.config also equals {"genre": "noir"} for the corresponding universe
+
+  Scenario: AC-33.07 — universe_snapshots table exists and accepts writes
+    Given migration 011 applied
+    When a universe_snapshots row is inserted with valid universe_id and session_id
+    Then the insert succeeds
+    And the row is retrievable by universe_id
+
+  Scenario: AC-33.08 — Deleting a universe cascade-deletes its universe_snapshots
+    Given a universe with 3 universe_snapshots rows
+    When the universe is deleted
+    Then all 3 universe_snapshots rows are deleted
+    And the game_sessions rows referencing that universe have universe_id = NULL
+
+  Scenario: AC-33.09 — Neo4j nodes have universe_id after backfill
+    Given a Neo4j graph with World, Location, NPC nodes for session_id = S
+    When the Neo4j backfill script runs for session S mapped to universe U
+    Then all nodes with session_id = S have universe_id = U
+    And the universe_id UNIQUE constraint on World nodes passes validation
+
+  Scenario: AC-33.10 — Validation script passes after clean migration
+    Given migration 011 applied successfully
+    When scripts/migrate_validate_v2.py is run
+    Then the script exits with code 0
+    And all four row-count assertions pass
+```
+
+---
+
+## 9. Dependencies & Integration Boundaries
+
+| Dependency | Spec | Integration Notes |
+|---|---|---|
+| Universe entity definition | v2 S29 | The `universes` table schema follows S29 FR-29.01's data model. S33 implements it in DDL. |
+| Actor identity definition | v2 S31 | The `actors` and `character_states` table schemas follow S31 FR-31.01–02. S33 implements them in DDL. |
+| Session binding | v2 S30 | S30's `game_sessions.universe_id` and `.actors` columns are added by S33's migration DDL. |
+| Persistence strategy | v1 S12 | `universe_snapshots` complements (not replaces) v1 `game_snapshots`. The turn pipeline uses both tables per S12 FR-12.18's session-end sequence. |
+| World graph schema | v1 S13 | Neo4j node structure (World, Location, NPC, etc.) is governed by S13. S33 adds `universe_id` indexes; it does not alter node properties governed by S13. |
+| GDPR deletion | v1 S17 | The migration's ON DELETE CASCADE chains (player→actor→character_state) satisfy S17's right-to-erasure requirement for the new tables. |
+| Genesis v2 | v2 S40 | S40 uses the tables defined here to write character state after universe creation. S33's backfill leaves character fields empty (`{}`); S40 populates them for new universes. |
+| Admin tooling | v1 S26 | S26 operators DELETE universes; the ON DELETE CASCADE chain here ensures clean removal. |
+
+---
+
+## 10. Open Questions
+
+| # | Question | Impact | Owner |
+|---|----------|--------|-------|
+| OQ-33.01 | Should v1 character state be extracted from `game_snapshots.world_state` JSONB during backfill (v2.0) or deferred to a v2.1 job? The snapshot blob structure was not formally specified in v1, so extraction logic may be fragile. | FR-33.03 Step 5; `character_states.traits` backfill | v2.0 PM / S12 author |
+| OQ-33.02 | Should `universe_snapshots.world_state` store the full Neo4j export (large, potentially > 1 MB per universe) or a normalized format with node/edge lists? Full export is simpler but may stress PostgreSQL JSONB. | FR-33.01d; cold-restart reconstruction performance | S13 author / S40 |
+| OQ-33.03 | The NOT NULL constraint on `game_sessions.universe_id` is deferred to v2.1 to allow online migration. Confirm the v2.0 API accepts sessions with null universe_id (fallback behavior) or whether the app should refuse to serve until migration is confirmed complete. | FR-33.02a nullability | v2 tech lead |
+
+---
+
+## 11. Out of Scope
+
+- **Turn pipeline integration** — how the turn pipeline reads/writes `CharacterState` or
+  `universe_snapshots` during a live session is governed by S08 and S12.
+- **Universe snapshot content format** — the schema of the JSON object stored in
+  `universe_snapshots.world_state` is defined collaboratively by S13 (graph schema) and
+  S40 (genesis/state format). S33 only specifies that the column exists and its type.
+- **Cross-universe character state transfer** — governed by v4+ S51.
+- **Performance tuning of Neo4j backfill script** — the batch size (500 per the NFR)
+  is a recommendation. Actual tuning is operational, not spec-normative.
+- **v2.1 character state extraction job** — extracting S06 fields from v1 snapshots
+  is deferred post-v2.0. S33 only specifies the empty default for v1 rows.
+- **Multi-tenant database isolation** — all tables use row-level isolation via FK
+  constraints, not schema-level multi-tenancy.
+
+---
+
+## Changelog
+
+- 2026-04-21: Initial draft. Authored by GitHub Copilot continuing from Claude Code
+  rate-limited session. Based on roadmap §3.1 S33 summary, migration files 001–010,
+  and Neo4j schema files 001–003.
+
+---
+
+## Appendix A — Recommended Backfill Approach (Mapping Table)
+
+To avoid the edge case where two `game_sessions` rows have identical `world_seed` AND
+`created_at`, the migration MUST use an explicit mapping table rather than a
+content-join:
+
+```sql
+-- 1. Create temp mapping: session_id → new universe_id
+CREATE TEMP TABLE _session_universe_map AS
+SELECT
+  gs.id AS session_id,
+  gen_ulid()::text AS universe_id
+FROM game_sessions gs;
+
+-- 2. Insert universes using the mapping
+INSERT INTO universes (universe_id, config, status, created_at, updated_at)
+SELECT
+  m.universe_id,
+  gs.world_seed,
+  'paused',
+  gs.created_at,
+  gs.updated_at
+FROM _session_universe_map m
+JOIN game_sessions gs ON gs.id = m.session_id
+ON CONFLICT (universe_id) DO NOTHING;
+
+-- 3. Backfill game_sessions using the mapping (never ambiguous)
+UPDATE game_sessions gs
+SET universe_id = m.universe_id
+FROM _session_universe_map m
+WHERE gs.id = m.session_id;
+```
+
+This approach guarantees a 1:1 mapping regardless of content collisions.
+
+The `gen_ulid()` function must be registered in PostgreSQL before the migration runs.
+A helper migration (011a) can create the function from the `pgulid` extension or an
+embedded PL/pgSQL implementation.
+
+---
+
+## Appendix B — Schema Change Summary (v1 → v2)
+
+| Object | Action | Notes |
+|---|---|---|
+| `universes` | **CREATE TABLE** | New root entity for S29 |
+| `actors` | **CREATE TABLE** | New entity for S31 |
+| `character_states` | **CREATE TABLE** | New entity for S31; PK is (actor_id, universe_id) |
+| `universe_snapshots` | **CREATE TABLE** | Cross-session world durability; distinct from `game_snapshots` |
+| `game_sessions.universe_id` | **ADD COLUMN** (TEXT, nullable → NOT NULL in v2.1) | FK → `universes.universe_id` ON DELETE SET NULL |
+| `game_sessions.actors` | **ADD COLUMN** (JSONB, default `[]`) | Actor list per S30 FR-30.03 |
+| `game_sessions.world_seed` | **PRESERVE** (read-only after migration) | Historical archive; not dropped |
+| Neo4j `*.universe_id` | **ADD PROPERTY + INDEX** | All world-scoped nodes; backfilled via session_id bridge |
+| Neo4j `World.universe_id` | **ADD UNIQUE CONSTRAINT** | `w.universe_id IS UNIQUE` (in addition to existing `w.session_id` constraint) |

--- a/specs/33-universe-persistence-schema.md
+++ b/specs/33-universe-persistence-schema.md
@@ -108,15 +108,26 @@ The migration MUST create the `universes` table with the following columns:
 | Column | Type | Required | Notes |
 |---|---|---|---|
 | `universe_id` | TEXT | Yes | ULID, PK; 26-char format |
+| `display_name` | TEXT | Yes | Human-readable universe name required by S29 FR-29.01 |
+| `owner_id` | UUID | Yes | FK → `players.id`; owning player required by S29 FR-29.01 |
 | `config` | JSONB | Yes | World parameters (migrated from `world_seed`) |
 | `status` | TEXT | Yes | `created` / `active` / `paused` / `archived`; default `paused` |
 | `created_at` | TIMESTAMPTZ | Yes | Defaults to `now()` |
 | `updated_at` | TIMESTAMPTZ | Yes | Updated on status change |
 
-No FK columns reference other tables. `universe_id` is the root of the v2 object graph.
+`universe_id` is the root of the v2 object graph. `owner_id` records universe
+ownership consistent with S29 FR-29.01.
 
 The `status` default for backfilled rows is `paused` (because v1 sessions are all
 historical — none are currently active).
+
+For backfilled rows, `display_name` MUST be populated deterministically from the
+legacy session/world metadata so that every migrated universe has a stable,
+human-readable identity.
+
+For backfilled rows, `owner_id` MUST be populated from the owning session/user
+record. If ownership cannot be determined unambiguously during migration, the
+migration MUST fail closed rather than creating an unowned universe row.
 
 #### FR-33.01b: `actors` table
 

--- a/specs/34-diegetic-time.md
+++ b/specs/34-diegetic-time.md
@@ -1,0 +1,416 @@
+# S34 — Diegetic Time
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v2.0
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 2 — Simulation
+> **Dependencies**: S29 (Universe Identity)
+> **Consumed by**: S35 (NPC Autonomy), S36 (Consequence Propagation), S37 (World Memory), S40 (Genesis v2)
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+In v1, time does not exist in the game world. The only time concept is the wall-clock
+timestamp on the session and the monotonic `turn_count` on `GameState`. This was a
+correct v1 simplification.
+
+v2 introduces **Diegetic Time**: an in-world clock that advances as the player acts,
+independent of wall-clock time. The world has a day, a night, and routines that other
+systems can consume. Time is turn-driven — not real-time — so a player who pauses for
+a week returns to exactly the world-time they left.
+
+This spec defines the `WorldTime` type, how time advances per turn, how it is
+configured per universe, the time-of-day label vocabulary, and the skip-ahead mechanic
+(sleep, wait, fast-travel). It is the **foundation primitive** for NPC routines (S35),
+consequence timing (S36), and memory timestamps (S37).
+
+---
+
+## 2. Design Philosophy
+
+### 2.1 Principles
+
+- **Turn-driven, not wall-clock-driven**: One turn = one in-world tick. The player
+  controls the pace of time. There is no background timer. This keeps the game world
+  predictable and respectful of player agency.
+- **Configurable per universe**: A grimdark fantasy may have 16-hour days; a cozy
+  slice-of-life may have 24 equal hours. The mapping is stored in `universes.config`.
+  Sane system defaults allow universes that do not specify time config to work
+  out of the box.
+- **No real-time mapping**: Diegetic time never maps to wall-clock time. Players who
+  sleep on a problem return to the exact in-world moment they left.
+- **Label-first consumption**: The rest of the system consumes `time_of_day_label`
+  (e.g., `"dawn"`, `"midnight"`), not raw `hour`/`minute`. This decouples downstream
+  logic from specific numeric thresholds.
+- **Skip-ahead as a first-class action**: Sleeping, waiting, and fast-travel are
+  legitimate player choices that advance `WorldTime` by multiple ticks atomically.
+  The autonomy processor (S35) MUST run for every skipped tick.
+
+### 2.2 What This Spec Is NOT
+
+- This spec does not define seasons or calendar systems (reserved for v3+).
+- This spec does not define how time is *narrated* (prose of "the sun rises") —
+  that belongs to the generation stage (S36, S40).
+- This spec does not define any real-time or async background job that advances time
+  while the player is offline.
+
+---
+
+## 3. User Stories
+
+> **US-34.1** — **As a** player, when I take an action, I notice the in-world time
+> advances (e.g., "It is now mid-afternoon"), so the world feels alive and temporal.
+
+> **US-34.2** — **As a** player, I can choose to "sleep until morning" and wake up to
+> a world that has changed — NPCs have moved, the market has opened — without taking
+> one turn at a time.
+
+> **US-34.3** — **As a** player, the time of day feels meaningful: shops close at
+> night, guards are less alert at dawn, and the forest is more dangerous after dusk.
+
+> **US-34.4** — **As a** developer, I can query the current `WorldTime` for a session
+> and get a structured object with `day_count`, `hour`, `minute`, and
+> `time_of_day_label`. I do not need to compute these from a raw tick counter.
+
+> **US-34.5** — **As a** universe author, I can configure how quickly in-world time
+> passes via the universe's config, without touching game engine code.
+
+> **US-34.6** — **As an** operator, I can inspect the current `WorldTime` for any
+> active session and verify that time is advancing correctly.
+
+---
+
+## 4. Functional Requirements
+
+### FR-34.01 — WorldTime Type
+
+The `WorldTime` type is a structured, immutable value object with the following fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `total_ticks` | Non-negative integer | Monotonic tick counter. Starts at 0. Advances by 1 per normal turn, by N per skip-ahead of N ticks. Never decreases. |
+| `day_count` | Non-negative integer | Number of complete in-world days elapsed. 0-indexed. |
+| `hour` | Integer [0, hours_per_day) | Current in-world hour within the current day. |
+| `minute` | Integer [0, 60) | Current in-world minute within the current hour. |
+| `time_of_day_label` | String | Human-readable label. See FR-34.04. |
+
+`WorldTime` is immutable. Mutation produces a new `WorldTime` instance.
+
+`WorldTime` with `total_ticks = 0` represents the moment a universe is created —
+before any player turn has been processed. This is a valid state and MUST NOT be
+represented as `None`.
+
+### FR-34.02 — Time Advancement Per Turn
+
+- **FR-34.02a**: At the end of each successfully processed player turn, `WorldTime`
+  MUST advance by exactly `ticks_per_turn` ticks (see FR-34.03).
+- **FR-34.02b**: Advancement MUST be atomic with the session state write. A turn that
+  fails to persist MUST NOT advance `WorldTime`.
+- **FR-34.02c**: Advancement MUST recompute all `WorldTime` fields from the new
+  `total_ticks` using `compute_world_time` (see FR-34.07).
+- **FR-34.02d**: A paused or abandoned session MUST NOT advance `WorldTime`. Time
+  only advances during active turn processing.
+
+### FR-34.03 — Universe Time Configuration
+
+The following fields MUST be supported in `universes.config` under the key `"time"`.
+All fields are optional; defaults are defined below.
+
+| Config Key | Type | Default | Description |
+|------------|------|---------|-------------|
+| `ticks_per_turn` | Positive integer | `1` | In-world ticks advanced per player turn. |
+| `minutes_per_tick` | Positive integer | `60` | In-world minutes advanced per tick. |
+| `hours_per_day` | Positive integer | `24` | Length of an in-world day in hours. |
+| `day_start_hour` | Integer [0, hours_per_day) | `6` | Hour at which "day" begins (used for skip-to-dawn). |
+| `starting_hour` | Integer [0, hours_per_day) | `8` | In-world hour at universe creation (total_ticks = 0). |
+| `starting_day` | Non-negative integer | `0` | In-world day count at universe creation. |
+| `max_skip_ticks` | Positive integer | `48` | Maximum ticks advanced in a single skip-ahead action. |
+| `tod_boundaries` | Object or null | null (use defaults) | Map of label → start fraction of hours_per_day. |
+
+With system defaults: one player turn advances the world by 60 in-world minutes
+(1 hour) on a 24-hour day starting at 08:00 on day 0.
+
+A `ticks_per_turn` value of `0` MUST be rejected at universe creation time with a
+validation error. For legacy/migrated universes that somehow carry this value, it
+MUST be treated as `1`.
+
+### FR-34.04 — Time-of-Day Label Vocabulary
+
+The system MUST map the current `hour` to one of the following canonical labels using
+the boundaries in `tod_boundaries` (fractional proportion of `hours_per_day`).
+If `tod_boundaries` is null, the default boundaries below apply.
+
+| Label | Default Start (fraction) | Default Start (24h) |
+|-------|--------------------------|---------------------|
+| `midnight` | 0.000 | 00:00 |
+| `predawn` | 0.042 | 01:00 |
+| `dawn` | 0.208 | 05:00 |
+| `morning` | 0.292 | 07:00 |
+| `midday` | 0.500 | 12:00 |
+| `afternoon` | 0.583 | 14:00 |
+| `dusk` | 0.708 | 17:00 |
+| `evening` | 0.833 | 20:00 |
+| `night` | 0.917 | 22:00 |
+
+When `hours_per_day` ≠ 24, the fraction-based boundaries scale automatically.
+
+The `time_of_day_label` field is a plain string (not a closed enum) to allow universe
+authors to provide custom labels via `tod_boundaries` (e.g., `"lighttime"` /
+`"darktime"` for a binary day/night world).
+
+### FR-34.05 — Skip-Ahead Mechanics
+
+A **skip-ahead** is a player action that advances `WorldTime` by more than one tick.
+Valid triggers include: sleep/rest, explicit waiting, and location travel with a
+non-zero `Connection.travel_time`.
+
+- **FR-34.05a**: A skip-ahead of `N` ticks MUST advance `total_ticks` by exactly `N`.
+- **FR-34.05b**: For every tick advanced during a skip-ahead, the NPC autonomy
+  processor (S35 FR-35.05) MUST be invoked once, in ascending tick order. The
+  processor MAY batch multiple ticks for a single NPC for efficiency, provided the
+  observable NPC state at the end of the batch is equivalent to per-tick processing.
+- **FR-34.05c**: The maximum skip-ahead in one player action is `max_skip_ticks`
+  (see FR-34.03). Requests exceeding this limit MUST be silently capped.
+- **FR-34.05d**: A skip-ahead request MUST specify a target: either an absolute
+  `WorldTime` target (e.g., "next dawn") or a delta in ticks. The system converts
+  the target to a tick count before advancing.
+- **FR-34.05e**: A skip-ahead MUST pause when a `WorldEvent` (S35 FR-35.07) with
+  `triggers_at_tick ≤ target_tick` is encountered within the skip window. The event
+  MUST be applied at that tick before advancing further.
+
+### FR-34.06 — GameState Integration
+
+- **FR-34.06a**: `GameState` MUST include a `world_time: WorldTime` field.
+- **FR-34.06b**: On session creation, `world_time` MUST be initialized to the
+  universe's current canonical `WorldTime`. If the universe has no prior sessions,
+  `WorldTime` is initialized from `starting_hour` and `starting_day` config.
+- **FR-34.06c**: The canonical `WorldTime` for a universe is the `world_time` from
+  the last successfully completed session turn. A new session in an existing universe
+  inherits this canonical time.
+- **FR-34.06d**: `WorldTime` is included in the `GameState` snapshot persisted via
+  S33 `universe_snapshots`.
+
+### FR-34.07 — compute_world_time
+
+A pure function `compute_world_time(total_ticks: int, config: TimeConfig) -> WorldTime`
+MUST exist. It MUST be:
+
+- **Deterministic**: Identical inputs always produce identical output.
+- **Pure**: No I/O, no side effects, no database reads.
+- **Fast**: MUST complete in under 1 ms for any valid input.
+- **Portable**: Usable outside the running application (offline tooling, test fixtures,
+  S41 scenario seed validation).
+
+---
+
+## 5. Non-Functional Requirements
+
+### NFR-34.01 — Computation Latency
+`compute_world_time` MUST complete in under 1 ms. It is pure arithmetic; no I/O.
+
+### NFR-34.02 — Snapshot Size
+`WorldTime` serialized in `GameState` MUST NOT exceed 200 bytes.
+
+### NFR-34.03 — Backward Compatibility (v1 Migration)
+Sessions migrated from v1 have no `WorldTime`. On first access, MUST return a
+`WorldTime` initialized from universe config defaults (`total_ticks = 0`). MUST NOT
+derive `total_ticks` from `turn_count` — the semantics are different.
+
+---
+
+## 6. User Journeys
+
+### Journey 1: Normal Turn with Time Advancement
+
+**Trigger**: Player submits "I walk to the market."
+
+1. Pipeline processes the player's action.
+2. At turn-end, `total_ticks` advances by `ticks_per_turn`.
+3. `compute_world_time` recomputes all fields.
+4. Updated `WorldTime` written atomically with session state.
+5. Next turn's narrative generation receives the new `WorldTime`.
+6. Narrator may acknowledge: "The market bells ring as midday arrives."
+
+### Journey 2: Sleep Until Morning
+
+**Trigger**: Player inputs "I find a safe corner and sleep until morning."
+
+1. System determines target: next occurrence of `dawn` label.
+2. Computes `ticks_to_dawn`. Caps at `max_skip_ticks` if needed.
+3. For each tick in `[current_tick, current_tick + ticks_to_dawn)`:
+   - NPC autonomy processor (S35) runs.
+   - If a `WorldEvent` triggers mid-skip, pause and notify player.
+4. `WorldTime` advances to the `dawn` boundary.
+5. Accumulated `WorldDelta` events passed to narrative generation.
+6. Narrator describes rest, night's passage, and what has changed.
+
+### Journey 3: Universe with Custom Time Config
+
+**Trigger**: Universe author sets `hours_per_day = 16`, `ticks_per_turn = 2`.
+
+1. Each player action advances 2 in-world hours.
+2. A full day passes in 8 player turns.
+3. `time_of_day_label` boundaries scale proportionally to the 16-hour day.
+
+---
+
+## 7. Edge Cases & Failure Modes
+
+| # | Scenario | Expected Behavior |
+|---|----------|-------------------|
+| E1 | Universe has no prior `WorldTime` | Initialize from `starting_hour`/`starting_day` defaults |
+| E2 | Skip-ahead target is already in the past | Treat as 0-tick skip; no-op |
+| E3 | `hours_per_day = 1` (degenerate config) | Valid; labels cycle within 1 hour; proportional boundaries apply |
+| E4 | `ticks_per_turn = 0` | Rejected at creation. Legacy sessions treat as `1`. |
+| E5 | `minutes_per_tick = 90` | Carry over: 1 hour 30 minutes per tick; `hour` and `minute` computed correctly |
+| E6 | Two sessions advance time concurrently | Last-write-wins per S30 universe atomicity rules |
+| E7 | WorldEvent fires mid-skip | Pause at event tick; player notified; skip does NOT auto-resume |
+| E8 | v1 migrated session accessed before backfill | Return `total_ticks = 0` WorldTime; log warning; MUST NOT return null |
+
+---
+
+## 8. Acceptance Criteria (Gherkin)
+
+```gherkin
+Feature: Diegetic Time
+
+  Background:
+    Given a universe with default time config (1 tick/turn, 60 min/tick, 24h day)
+    And an active game session in that universe
+
+  Scenario: AC-34.01 — Time advances by one tick per normal turn
+    When the player submits a turn action
+    And the turn is processed successfully
+    Then world_time.total_ticks is incremented by 1
+    And world_time.hour is recomputed from total_ticks
+    And world_time.time_of_day_label reflects the new hour
+
+  Scenario: AC-34.02 — WorldTime is initialized from universe config on first session
+    Given a universe with starting_hour = 8 and starting_day = 0
+    And no prior session has been processed in this universe
+    When a new session is created
+    Then world_time.total_ticks = 0
+    And world_time.day_count = 0
+    And world_time.hour = 8
+    And world_time.time_of_day_label = "morning"
+
+  Scenario: AC-34.03 — New session inherits canonical universe time
+    Given a universe where the last completed session ended at world_time.total_ticks = 5
+    When a new session is started in the same universe
+    Then the new session's world_time.total_ticks = 5
+
+  Scenario: AC-34.04 — compute_world_time is deterministic
+    Given total_ticks = 36 and default time config
+    When compute_world_time is called twice with identical inputs
+    Then both calls return identical WorldTime objects
+
+  Scenario: AC-34.05 — Skip-ahead advances by the correct number of ticks
+    Given world_time.total_ticks = 10 and time_of_day_label = "evening"
+    When the player requests "sleep until morning" (target = next dawn)
+    Then world_time advances by the exact number of ticks to the next dawn boundary
+    And world_time.time_of_day_label = "dawn"
+
+  Scenario: AC-34.06 — Skip-ahead is capped at max_skip_ticks
+    Given a universe with max_skip_ticks = 48
+    When the player requests a skip-ahead of 100 ticks
+    Then only 48 ticks are advanced
+    And the session records that the skip was capped
+
+  Scenario: AC-34.07 — Skip-ahead invokes NPC autonomy per tick
+    Given an NPC with a routine step triggering at ticks 3 and 7
+    When the player skips ahead 10 ticks
+    Then the NPC routine step is processed at ticks 3 and 7 during skip processing
+
+  Scenario: AC-34.08 — Skip-ahead pauses at a WorldEvent within the skip window
+    Given a WorldEvent scheduled at tick 5 and current total_ticks = 2
+    When the player requests a skip-ahead of 10 ticks
+    Then the skip pauses at tick 5
+    And the WorldEvent is applied before the skip continues
+
+  Scenario: AC-34.09 — Custom hours_per_day scales time-of-day boundaries
+    Given a universe with hours_per_day = 16
+    When total_ticks results in an hour at the proportional midpoint of the day
+    Then time_of_day_label = "midday"
+
+  Scenario: AC-34.10 — Failed turn does not advance WorldTime
+    Given world_time.total_ticks = 10
+    When the turn pipeline raises an unrecoverable error
+    And the session state is not persisted
+    Then world_time.total_ticks remains 10
+```
+
+---
+
+## 9. Out of Scope
+
+- **Calendar systems, months, seasons**: Reserved for v3+.
+- **Real-time advancement**: No background timer advances time while offline.
+- **Narrating time passage**: Prose is the responsibility of the generation stage.
+- **`tod_boundaries` schema validation**: Governed by S39 (Universe Composition).
+- **UI/UX clock display**: A client concern.
+
+---
+
+## 10. Open Questions
+
+| OQ | Question | Status |
+|----|----------|--------|
+| OQ-34.01 | Diegetic-time-to-real-time mapping: configurable per universe or global? | **Resolved**: configurable per universe; system defaults in this spec. |
+| OQ-34.02 | Should `WorldTime` include sub-minute precision (seconds)? | Deferred. Reserve `second` field for v3+. |
+| OQ-34.03 | Should a WorldEvent mid-skip auto-resume after the event resolves? | Proposed: no auto-resume; require explicit player input. Final decision deferred to S40 author. |
+
+---
+
+## Appendix A — WorldTime Fields (Reference Implementation Shape)
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class WorldTime:
+    """Immutable in-world time value object.
+
+    All fields are derived from total_ticks via compute_world_time().
+    Do not construct directly — use compute_world_time().
+    """
+    total_ticks: int        # Monotonic. Never decreases.
+    day_count: int          # 0-indexed complete days elapsed.
+    hour: int               # [0, hours_per_day)
+    minute: int             # [0, 60)
+    time_of_day_label: str  # e.g., "dawn", "morning", "midnight"
+```
+
+---
+
+## Appendix B — Default TimeConfig Values
+
+```python
+from dataclasses import dataclass, field
+
+@dataclass
+class TimeConfig:
+    ticks_per_turn: int = 1
+    minutes_per_tick: int = 60
+    hours_per_day: int = 24
+    day_start_hour: int = 6
+    starting_hour: int = 8
+    starting_day: int = 0
+    max_skip_ticks: int = 48
+    tod_boundaries: dict[str, float] | None = None  # None = use built-in defaults
+```
+
+Default `tod_boundaries` expressed as fractional proportion of `hours_per_day`:
+
+| Label | Start fraction | 24h equivalent |
+|-------|---------------|----------------|
+| `midnight` | 0.000 | 00:00 |
+| `predawn` | 0.042 | 01:00 |
+| `dawn` | 0.208 | 05:00 |
+| `morning` | 0.292 | 07:00 |
+| `midday` | 0.500 | 12:00 |
+| `afternoon` | 0.583 | 14:00 |
+| `dusk` | 0.708 | 17:00 |
+| `evening` | 0.833 | 20:00 |
+| `night` | 0.917 | 22:00 |

--- a/specs/35-npc-autonomy-between-turns.md
+++ b/specs/35-npc-autonomy-between-turns.md
@@ -1,0 +1,499 @@
+# S35 — NPC Autonomy Between Turns
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v2.0
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 2 — Simulation
+> **Dependencies**: S34 (Diegetic Time), S29 (Universe Identity)
+> **Related**: v1 S06 (Character System), S36 (Consequence Propagation), S38 (NPC Memory)
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+In v1, NPCs exist only when the player is present. There is no concept of an NPC
+doing anything between player turns — the butcher does not close his shop at dusk,
+the king does not fall ill while the player is away, the thief guild does not
+reorganize after losing a conflict. Every encounter is freshly generated on demand.
+
+This is a correct v1 simplification. It means the world only exists when the player
+looks at it — a fundamentally flat simulation.
+
+v2 changes this with **NPC Autonomy Between Turns**: NPCs with defined routines and
+goals pursue them off-screen. A salience filter prevents this from becoming a
+performance problem or a multi-agent orchestration system — not every NPC is modeled
+every turn. The output of autonomy processing is a `WorldDelta`: a structured list of
+NPC state changes that the narrative generation stage can incorporate into the story,
+making the world feel genuinely alive.
+
+**This spec explicitly rejects multi-agent orchestration.** The charter's §10 scope
+fence ("no 10-agent decomposition") stands. There is no agent-router, no LangGraph,
+no per-NPC LLM loop. Autonomy is rule-based by default; a single optional batched
+LLM call per turn handles KEY-tier NPCs that have exceeded rule-based expressivity.
+
+---
+
+## 2. Design Philosophy
+
+### 2.1 Principles
+
+- **Salience filter, not full simulation**: Only NPCs that matter to the current player
+  context are modeled. BACKGROUND-tier NPCs are never autonomously processed — they
+  are regenerated on demand as in v1. SUPPORTING-tier NPCs are processed only when
+  in recently-visited locations. KEY-tier NPCs are always processed.
+- **Rule-based first, LLM optional**: The default autonomy mode is deterministic
+  rule evaluation against `RoutineStep` schedules. An LLM-assisted mode is
+  available for KEY-tier NPCs that need more than rules can express, but it is
+  opt-in per NPC, not the default.
+- **WorldDelta as the output contract**: The autonomy processor produces a `WorldDelta`
+  — a list of atomic NPC state changes. Everything downstream (narrative generation,
+  consequence propagation) consumes `WorldDelta`. The processor is not responsible
+  for narrating the changes; only for computing them.
+- **No orchestration primitives**: NPCs do not send messages to each other, hold
+  conversations, or delegate tasks via a routing layer. Autonomy is a property of
+  individual NPCs evaluated independently. Social effects (gossip, faction reactions)
+  belong to S38 (NPC Memory) and S36 (Consequence Propagation).
+- **Budget-bounded**: Processing has a configurable time budget per turn. NPCs that
+  exceed the budget are deferred, with lower-priority NPCs deprioritized first.
+
+### 2.2 What This Spec Is NOT
+
+- This spec does NOT define multi-agent NPC conversations or coordination.
+- This spec does NOT define how autonomy results are narrated (that is the generation
+  stage's responsibility, via `WorldDelta` context injection).
+- This spec does NOT define NPC memory of the player across sessions (see S38).
+- This spec does NOT define consequence propagation to non-NPC world entities (see S36).
+
+---
+
+## 3. User Stories
+
+> **US-35.1** — **As a** player, when I return to a location I visited yesterday
+> (in-world), I find it different in believable ways — the market is closed, the
+> guards have changed shift — without me having to trigger those changes explicitly.
+
+> **US-35.2** — **As a** player, I can learn that significant off-screen events
+> occurred while I was away (the duke was assassinated, the guild has new leadership),
+> so the world feels like it exists and changes without me.
+
+> **US-35.3** — **As a** player, NPCs behave consistently with the time of day:
+> the tavern keeper is behind the bar at evening, asleep at midnight.
+
+> **US-35.4** — **As a** developer, I can add a routine schedule to an NPC by
+> storing `RoutineStep` records on the NPC's Neo4j node and trust the autonomy
+> processor will execute them correctly given the current `WorldTime`.
+
+> **US-35.5** — **As a** developer, the autonomy processor is a contained,
+> injectable service — I can test it in isolation by providing a mock `WorldTime`
+> and a list of NPCs.
+
+> **US-35.6** — **As an** operator, I can observe the `WorldDelta` output for any
+> processed turn in the observability layer (Langfuse, structlog) to audit what
+> autonomous changes were applied.
+
+---
+
+## 4. Functional Requirements
+
+### FR-35.01 — RoutineStep Type
+
+A `RoutineStep` represents a single rule that an NPC follows when the world-time
+matches a condition.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `trigger` | RoutineTrigger | Yes | The condition that activates this step. |
+| `action` | AutonomyAction | Yes | The change to apply when the trigger fires. |
+| `priority` | Integer [1, 10] | No (default: 5) | Higher values are processed first within a tick. |
+| `repeating` | Boolean | No (default: true) | If true, fires every tick the trigger condition is met. If false, fires only once and becomes inactive. |
+| `condition` | RoutineCondition or null | No | Optional guard expression. Step fires only if condition is satisfied. See FR-35.02. |
+
+`RoutineStep` records are stored on the NPC's Neo4j node as a JSON array property
+named `schedule`. An NPC with an empty or absent `schedule` array is treated as
+having no autonomous behavior — it behaves as in v1.
+
+### FR-35.02 — RoutineTrigger Types
+
+A `RoutineTrigger` activates a `RoutineStep` when its condition is met. Supported
+trigger types:
+
+| Trigger Type | Fields | Description |
+|---|---|---|
+| `time_of_day` | `label: str` | Fires when `WorldTime.time_of_day_label` equals `label`. |
+| `tick_elapsed` | `delta: int` | Fires when `total_ticks - last_fired_tick >= delta`. Tracks when the step last fired. |
+| `world_event` | `event_type: str` | Fires when a `WorldEvent` of the given type has been recorded in the universe within the salience window. |
+| `player_visited` | `location_id: str, within_ticks: int` | Fires if the player visited `location_id` within the last `within_ticks`. |
+
+Only `time_of_day` and `tick_elapsed` are required for v2.0. `world_event` and
+`player_visited` triggers are OPTIONAL for v2.0 implementations and MUST be
+implemented in v2.1.
+
+### FR-35.03 — AutonomyAction Types
+
+An `AutonomyAction` specifies what changes when a `RoutineStep` fires. The union of
+all actions produced in a tick forms the `WorldDelta` (FR-35.04).
+
+| Action Type | Fields | Effect |
+|---|---|---|
+| `MoveAction` | `target_location_id: str` | Updates `NPC.location_id` to the target. The NPC is now in a different location. |
+| `StateChangeAction` | `new_state: NPCState` | Updates `NPC.state` (see v1 `NPCState` literal: `idle`, `active`, `busy`, `sleeping`, `traveling`). |
+| `DispositionShiftAction` | `npc_id: str, delta: int` | Adjusts the NPC's `disposition` score by `delta` (clamped to disposition range). |
+| `NarrativeEventAction` | `description: str, severity: EventSeverity` | Records a `WorldEvent` with the given description and severity. Consumed by narrative generation and S36. |
+
+All action types MUST be represented as discriminated union types. An `AutonomyAction`
+is always exactly one action type.
+
+### FR-35.04 — WorldDelta Type
+
+`WorldDelta` is the output of a single autonomy processing run.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tick` | int | The `total_ticks` value at which this delta was computed. |
+| `changes` | list[NPCStateChange] | Ordered list of applied NPC state changes. |
+| `events` | list[WorldEvent] | `NarrativeEventAction` results that were promoted to `WorldEvent` records. |
+
+`NPCStateChange` carries:
+- `npc_id: str` — the affected NPC
+- `action_type: str` — which action type was applied
+- `before: dict` — the NPC state snapshot before the change
+- `after: dict` — the NPC state snapshot after the change
+
+`WorldDelta` for a skip-ahead of N ticks is the union of all per-tick `WorldDelta`
+objects, in tick order.
+
+### FR-35.05 — AutonomyProcessor Contract
+
+The `AutonomyProcessor` is a service that computes `WorldDelta` given a session
+context. Its interface MUST satisfy:
+
+```
+process(
+    universe_id: str,
+    world_time: WorldTime,
+    npcs: list[NPC],
+) -> WorldDelta
+```
+
+- **FR-35.05a**: The processor MUST be injectable (not a singleton). Tests MUST be
+  able to provide a `MemoryAutonomyProcessor` with static NPC fixtures.
+- **FR-35.05b**: The processor MUST apply the salience filter (FR-35.06) before
+  processing any NPC. NPCs filtered out produce no `NPCStateChange` entries.
+- **FR-35.05c**: The processor MUST apply `RoutineStep`s in descending priority
+  order within a tick.
+- **FR-35.05d**: If two `RoutineStep`s on the same NPC conflict in the same tick
+  (e.g., both attempt a `StateChangeAction`), the higher-priority step wins. The
+  lower-priority step is recorded as a `deferred_change` in the `WorldDelta` for
+  observability.
+- **FR-35.05e**: The processor MUST respect the `budget_ms` parameter (see
+  FR-35.08). If the budget is exceeded, remaining unprocessed NPCs are recorded in
+  `WorldDelta.deferred_npcs` with the reason `budget_exceeded`.
+- **FR-35.05f**: The processor MUST be called BEFORE the narrative generation stage
+  in the turn pipeline. Its `WorldDelta` output is injected into the generation
+  context as `autonomous_changes`.
+
+### FR-35.06 — Salience Filter
+
+The salience filter determines which NPCs are eligible for autonomous processing in
+a given tick. NPCs that do not pass the filter are skipped (no processing, no cost).
+
+| NPC Tier | Processing Condition |
+|----------|---------------------|
+| `KEY` | Always processed if the NPC has a non-empty `schedule`. |
+| `SUPPORTING` | Processed if the NPC's current `location_id` matches any location the player has visited within the last `salience_window_turns` turns (default: 5). |
+| `BACKGROUND` | Never processed by the autonomy processor. Behavior regenerated on demand as in v1. |
+
+The `salience_window_turns` is configurable via `universes.config["autonomy"]["salience_window_turns"]`
+(default: 5, minimum: 1, maximum: 50).
+
+### FR-35.07 — WorldEvent Records
+
+A `NarrativeEventAction` result is promoted to a `WorldEvent` record stored in the
+universe's event log (Neo4j). `WorldEvent` fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `event_id` | ULID | Unique identifier. |
+| `universe_id` | ULID | Owning universe. |
+| `event_type` | str | Classifies the event (e.g., `"npc_death"`, `"political_change"`, `"environmental"`). |
+| `description` | str | Human-readable summary of what occurred. |
+| `severity` | EventSeverity | `minor`, `notable`, `major`, `critical`. |
+| `source_npc_id` | str or null | NPC that generated the event, if any. |
+| `location_id` | str or null | Location where the event occurred, if applicable. |
+| `triggered_at_tick` | int | The `total_ticks` at which the event occurred. |
+| `created_at` | datetime | Wall-clock time of record creation. |
+
+`WorldEvent` records are immutable once written. They serve as the historical record
+of autonomous activity and are consumed by S36 (consequence propagation) and S37
+(world memory).
+
+### FR-35.08 — Processing Budget
+
+The autonomy processor MUST accept a `budget_ms: int` parameter (default: 50).
+
+- **FR-35.08a**: If the processor has consumed `budget_ms` milliseconds of CPU time
+  and unprocessed NPCs remain, it MUST stop, record remaining NPCs in
+  `WorldDelta.deferred_npcs`, and return the partial `WorldDelta`.
+- **FR-35.08b**: Deferred NPCs are NOT retried in the same turn. They may be
+  processed in the next turn if they remain salient.
+- **FR-35.08c**: KEY-tier NPCs MUST always be processed within the budget window,
+  regardless of ordering. If including all KEY-tier NPCs would alone exceed the
+  budget, the budget is extended to accommodate them (KEY-tier NPCs are never
+  deferred due to budget).
+- **FR-35.08d**: Processing time is measured via `time.monotonic()` at processor
+  entry and at each NPC processing boundary.
+
+### FR-35.09 — LLM-Assisted Mode (Opt-In)
+
+For KEY-tier NPCs that have complex autonomous behavior beyond what `RoutineStep`
+rules can express, an **LLM-assisted mode** is available.
+
+- **FR-35.09a**: LLM-assisted mode is activated by setting `npc.autonomy_mode =
+  "llm_assisted"` on the NPC's Neo4j node. Default is `"rule_based"`.
+- **FR-35.09b**: In LLM-assisted mode, the processor includes the NPC in a single
+  **batched LLM call** per turn alongside all other `llm_assisted` KEY-tier NPCs.
+  The prompt describes each NPC's current state, schedule, and the `WorldTime`, and
+  asks for an `AutonomyAction` per NPC.
+- **FR-35.09c**: The LLM response MUST be parsed into `AutonomyAction` instances.
+  If parsing fails for an NPC, that NPC falls back to `rule_based` processing for
+  the current tick. The failure is logged.
+- **FR-35.09d**: The LLM call MUST be counted against the session's cost tracking
+  (S07, S28) and MUST use the standard LiteLLM client.
+- **FR-35.09e**: If the `llm_assisted` batch call fails entirely (network error,
+  rate limit), all `llm_assisted` NPCs fall back to `rule_based` for the current
+  tick. The fallback is logged as a warning.
+- **FR-35.09f**: The number of `llm_assisted` KEY-tier NPCs per turn is capped at
+  `universes.config["autonomy"]["max_llm_npcs_per_turn"]` (default: 5). NPCs
+  exceeding this cap fall back to `rule_based` for that tick.
+
+---
+
+## 5. Non-Functional Requirements
+
+### NFR-35.01 — Processing Latency
+Rule-based autonomy processing for up to 20 KEY + SUPPORTING NPCs MUST complete in
+under 50 ms (p95) on a standard API server. This budget is configurable via
+`budget_ms`.
+
+### NFR-35.02 — LLM Call Overhead
+The optional LLM-assisted batch call MUST NOT block the turn response. It SHOULD be
+structured so that if it exceeds `settings.turn_timeout_ms`, the call is abandoned
+and results fall back to rule-based.
+
+### NFR-35.03 — Observability
+All `WorldDelta` outputs MUST be logged at `DEBUG` level via structlog, keyed by
+`universe_id` and `total_ticks`. `NarrativeEventAction` promotions to `WorldEvent`
+MUST be logged at `INFO` level with `event_type` and `severity`.
+
+---
+
+## 6. User Journeys
+
+### Journey 1: Butcher Closes Shop at Dusk
+
+**Setup**: The `Butcher` NPC has a `RoutineStep`:
+- `trigger: time_of_day(label="dusk")`
+- `action: StateChangeAction(new_state="busy")` (preparing to close)
+- And: `action: MoveAction(target_location_id="butcher_back_room")`
+
+**Turn processing**:
+1. Player takes a turn. `WorldTime` advances to `dusk`.
+2. Autonomy processor runs. Salience filter: Butcher is KEY-tier → always processed.
+3. `time_of_day` trigger matches. Both actions fire in priority order.
+4. `WorldDelta` includes: `{npc: Butcher, state: idle→busy}`,
+   `{npc: Butcher, location: market→butcher_back_room}`.
+5. Narrative generation receives `WorldDelta` context.
+6. Narrator may note: "The butcher begins rolling down his shutters as the light fails."
+
+### Journey 2: King Dies While Player Explores Ruins
+
+**Setup**: The `King` NPC has a `RoutineStep`:
+- `trigger: tick_elapsed(delta=20)` (after 20 in-world hours)
+- `condition: NPC.state == "ill"` (only fires if the king is already ill)
+- `action: NarrativeEventAction(description="The king has died of his illness.", severity="critical")`
+- `repeating: false`
+
+**Turn processing** (20 ticks after king became ill):
+1. Player takes a turn in a distant dungeon.
+2. Autonomy processor runs. King is KEY-tier → processed.
+3. `tick_elapsed` trigger fires. Condition `state == "ill"` is true.
+4. `NarrativeEventAction` fires → `WorldEvent` record written to universe event log.
+5. `WorldDelta.events` contains the king's death event.
+6. Narrative generation MAY or MAY NOT surface this to the player this turn,
+   based on proximity and salience (S36 / generation stage decision).
+7. On next visit to the capital, the consequence is inescapable.
+
+### Journey 3: Skip-Ahead with NPC Autonomy
+
+**Turn**: Player sleeps until dawn (15-tick skip).
+
+1. `compute_world_time` calculates 15 ticks needed.
+2. Autonomy processor called 15 times (or in a batched 15-tick run).
+3. In ticks 3–10, a festival NPC routine fires: `StateChangeAction(active)`,
+   `NarrativeEventAction("Festival preparations fill the square.", minor)`.
+4. `WorldDelta` (aggregate of 15 ticks) delivered to narrative generation.
+5. Player wakes up to: "The square outside is festooned with banners you didn't
+   notice last night."
+
+---
+
+## 7. Edge Cases & Failure Modes
+
+| # | Scenario | Expected Behavior |
+|---|----------|-------------------|
+| E1 | NPC has `schedule = []` (empty) | No autonomy processing; NPC treated as v1 on-demand |
+| E2 | NPC tier is BACKGROUND with a non-empty `schedule` | Schedule is ignored; BACKGROUND tier is never processed autonomously |
+| E3 | Two RoutineSteps conflict on the same NPC in the same tick | Higher-priority step wins; lower-priority recorded as `deferred_change` in WorldDelta |
+| E4 | `MoveAction` targets a non-existent `location_id` | Action is rejected; NPC stays in current location; error logged; `deferred_change` recorded |
+| E5 | LLM-assisted batch call times out | All `llm_assisted` NPCs fall back to `rule_based` for this tick; warning logged |
+| E6 | LLM response has invalid JSON for one NPC | That NPC falls back to `rule_based`; other NPCs' LLM results are applied normally |
+| E7 | Budget exceeded before all salient NPCs processed | Partial WorldDelta returned; unprocessed NPCs listed in `deferred_npcs` |
+| E8 | `repeating: false` step fires during skip-ahead at tick 3 and again at tick 7 | Only fires once (at tick 3); `repeating: false` marks step inactive after first fire |
+| E9 | `player_visited` trigger (v2.1) used in a v2.0 deployment | Trigger is treated as `not_matched` (never fires); logged as unsupported trigger type |
+| E10 | Universe has no active sessions and a new one starts after 30 real days | `WorldTime` was last persisted at the end of the prior session; autonomy does NOT back-fill those 30 real days — only session turns advance time |
+
+---
+
+## 8. Acceptance Criteria (Gherkin)
+
+```gherkin
+Feature: NPC Autonomy Between Turns
+
+  Background:
+    Given a universe with a KEY-tier NPC named "Aldric the Butcher"
+    And Aldric has a schedule with one RoutineStep:
+      | trigger             | action                       |
+      | time_of_day("dusk") | StateChangeAction(new_state="sleeping") |
+    And an active game session with default time config
+
+  Scenario: AC-35.01 — KEY-tier NPC routine fires at correct time
+    Given the current world_time.time_of_day_label = "afternoon"
+    When the turn pipeline advances world_time to "dusk"
+    Then the autonomy processor fires Aldric's RoutineStep
+    And WorldDelta contains an NPCStateChange for Aldric: state = "sleeping"
+
+  Scenario: AC-35.02 — BACKGROUND-tier NPC with a schedule is not processed
+    Given a BACKGROUND-tier NPC "Bob the Passerby" with a non-empty schedule
+    When the autonomy processor runs
+    Then Bob's schedule is not evaluated
+    And WorldDelta contains no NPCStateChange for Bob
+
+  Scenario: AC-35.03 — SUPPORTING-tier NPC outside salience window is not processed
+    Given a SUPPORTING-tier NPC whose location was NOT visited in the last 5 turns
+    When the autonomy processor runs
+    Then the SUPPORTING NPC's schedule is not evaluated
+
+  Scenario: AC-35.04 — SUPPORTING-tier NPC within salience window is processed
+    Given a SUPPORTING-tier NPC whose location was visited 2 turns ago
+    And the NPC has a matching RoutineStep
+    When the autonomy processor runs
+    Then the RoutineStep fires
+    And WorldDelta contains an NPCStateChange for that NPC
+
+  Scenario: AC-35.05 — WorldDelta is injected into narrative generation context
+    Given the autonomy processor produced a non-empty WorldDelta
+    When the narrative generation stage runs
+    Then the generation prompt context includes "autonomous_changes" from the WorldDelta
+
+  Scenario: AC-35.06 — non-repeating RoutineStep fires only once
+    Given Aldric has a non-repeating RoutineStep with trigger time_of_day("dawn")
+    When the player takes a turn that advances time to "dawn"
+    Then the step fires once
+    When the player takes a subsequent turn that passes through "dawn" again
+    Then the step does not fire a second time
+
+  Scenario: AC-35.07 — NarrativeEventAction promotes to WorldEvent record
+    Given an NPC has a RoutineStep with a NarrativeEventAction
+    When the RoutineStep fires
+    Then a WorldEvent record is written to the universe's event log
+    And the WorldEvent has the correct event_type, description, severity, and triggered_at_tick
+
+  Scenario: AC-35.08 — Budget limit defers lower-priority NPCs
+    Given 30 SUPPORTING-tier NPCs all within the salience window
+    And the budget_ms is set very low (e.g., 1 ms) so only 5 fit
+    When the autonomy processor runs
+    Then at most 5 NPCs are processed within the budget
+    And WorldDelta.deferred_npcs lists the remaining 25 NPCs with reason "budget_exceeded"
+
+  Scenario: AC-35.09 — LLM-assisted NPC falls back to rule_based on parse failure
+    Given a KEY-tier NPC with autonomy_mode = "llm_assisted"
+    And the LLM response for that NPC cannot be parsed into an AutonomyAction
+    When the autonomy processor runs
+    Then the NPC's rule_based schedule is evaluated instead
+    And a warning is logged with the parse failure details
+
+  Scenario: AC-35.10 — AutonomyProcessor is injectable for testing
+    Given a MemoryAutonomyProcessor with a static NPC fixture list
+    When process() is called with a specific WorldTime
+    Then the processor returns a deterministic WorldDelta matching the fixture expectations
+    And no database or LLM calls are made
+```
+
+---
+
+## 9. Out of Scope
+
+- **Multi-agent NPC coordination**: NPCs do not communicate with each other via any
+  routing layer. Social effects are S38's responsibility.
+- **NPC memory of the player**: Cross-session NPC recollection is S38.
+- **Consequence propagation to locations, factions, items**: That is S36.
+- **Narrating autonomous changes**: The generation stage renders `WorldDelta`; this
+  spec only produces it.
+- **Player-facing autonomy controls**: Players cannot currently tune which NPCs are
+  autonomous or turn off autonomy. Reserved for v3+.
+- **Async/background processing**: Autonomy is always synchronous, in-turn. There is
+  no background job that runs autonomy while the player is not playing.
+
+---
+
+## 10. Open Questions
+
+| OQ | Question | Proposed Resolution |
+|----|----------|---------------------|
+| OQ-35.01 | NPC autonomy computation: batched LLM call with salience-filtered NPCs, or rule-based fallbacks? | **Resolved in this spec**: rule-based is primary (FR-35.02–FR-35.03); LLM-assisted is opt-in per NPC (FR-35.09). |
+| OQ-35.02 | Should `WorldDelta` be persisted as part of the turn record, or only logged? | Proposed: log only (Langfuse + structlog); do NOT write to `universe_snapshots` — it's derivable. Final decision deferred to S37 (World Memory) author who needs the history. |
+| OQ-35.03 | Should `deferred_npcs` be retried in the same pipeline pass (second sweep) or strictly next turn? | Proposed: strictly next turn. A second sweep risks budget overrun and complexity. |
+| OQ-35.04 | How does S36 (Consequence Propagation) consume `WorldEvent` records produced by autonomy? | S36 is the normative spec for that contract. S35 only specifies that events are written to the universe event log. |
+
+---
+
+## Appendix A — Salience Filter Decision Table
+
+| NPC Tier | Has Schedule? | Within Salience Window? | Autonomy_Mode | Processed? |
+|----------|--------------|------------------------|---------------|-----------|
+| KEY | Yes | n/a | rule_based | ✅ Yes |
+| KEY | Yes | n/a | llm_assisted | ✅ Yes (in LLM batch) |
+| KEY | No | n/a | any | ❌ No (no-op) |
+| SUPPORTING | Yes | Yes | rule_based | ✅ Yes |
+| SUPPORTING | Yes | No | rule_based | ❌ No (filtered) |
+| BACKGROUND | Yes | n/a | any | ❌ No (tier excluded) |
+| BACKGROUND | No | n/a | any | ❌ No (tier excluded) |
+
+---
+
+## Appendix B — AutonomyProcessor Data Flow
+
+```
+Turn pipeline (Enrich stage)
+         │
+         ▼
+  AutonomyProcessor.process(universe_id, world_time, npcs)
+         │
+    Salience Filter
+    (KEY always, SUPPORTING if visited, BACKGROUND never)
+         │
+    Rule Evaluation
+    (RoutineStep trigger → AutonomyAction)
+         │
+    Optional LLM batch
+    (llm_assisted KEY-tier only, single call, opt-in)
+         │
+         ▼
+       WorldDelta
+    {changes, events, deferred_npcs}
+         │
+         ├──► Neo4j write: NPC state updates + WorldEvent records
+         │
+         └──► Narrative Generation stage context: "autonomous_changes"
+```

--- a/specs/36-consequence-propagation.md
+++ b/specs/36-consequence-propagation.md
@@ -1,0 +1,418 @@
+# S36 — Consequence Propagation
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v2.0
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 2 — Simulation
+> **Dependencies**: S34 (Diegetic Time), S35 (NPC Autonomy), v1 S04 (World Simulation)
+> **Related**: S37 (World Memory), S38 (NPC Memory), v1 `WorldChange`, `WorldChangeType`
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+In v1, world changes are atomic and local. When the player does something, only the
+directly targeted entities change. The guard who dies in the market square stays dead,
+but the barkeep in the adjacent tavern has no idea anything happened. The faction the
+dead guard belonged to is unaffected until the player walks into their territory.
+
+This is the "world only exists when the player looks at it" limitation.
+
+v2 changes this with **Consequence Propagation**: when a significant event occurs —
+player action, NPC autonomous action (S35), or world event — its effects ripple
+outward through the location graph and social graph at bounded depth. Nearby entities
+react immediately; distant entities hear distorted rumors.
+
+This spec defines:
+- The `ConsequencePropagator` service contract
+- How effects are calculated at each graph hop
+- The distortion model (severity and description degradation)
+- Faction-aware propagation shortcuts through the social graph
+- The `ConsequenceRecord` output type consumed by narrative generation and S37
+
+---
+
+## 2. Design Philosophy
+
+### 2.1 Principles
+
+- **Bounded depth, not unlimited simulation**: Propagation MUST stop at a configured
+  maximum hop depth. Default max depth is 3 hops; configurable per universe.
+- **Distortion increases with distance**: At hop 2, the barkeep "heard there was a
+  fight." At hop 3, a distant village "got word of some trouble in the city."
+- **Graph-walk, not full re-simulation**: Propagation walks the existing Neo4j
+  `CONNECTS_TO` graph. It is an additive annotation process.
+- **Federation with S35**: NPC autonomous actions (`WorldDelta` from S35) are valid
+  propagation sources — not just player actions.
+- **Rule-based severity model**: The consequence severity calculation at each hop is
+  deterministic. LLM involvement is limited to optional hop-2 paraphrasing only.
+
+### 2.2 What This Spec Is NOT
+
+- S36 does not define how consequences are *rendered* in prose — see narrative generation.
+- S36 does not define NPC memory of the player across sessions — see S38.
+- S36 does not define the full world memory model — see S37.
+- S36 does not define faction mechanics beyond propagation social shortcuts.
+
+---
+
+## 3. User Stories
+
+> **US-36.1** — **As a** player, after I do something significant, I encounter
+> acknowledgment of that action from NPCs in nearby locations even if I haven't visited
+> them since, so the world feels causally connected.
+
+> **US-36.2** — **As a** player, NPCs closer to where I acted have more accurate
+> knowledge; those farther away have vaguer, possibly distorted information.
+
+> **US-36.3** — **As a** player, when I provoke a faction, other members of that
+> faction in different locations react even if they weren't witnesses.
+
+> **US-36.4** — **As a** developer, I can trace every `ConsequenceRecord` back to its
+> source event for auditing and debugging.
+
+> **US-36.5** — **As a** universe author, I can configure the maximum propagation depth
+> and severity threshold per universe.
+
+---
+
+## 4. Functional Requirements
+
+### FR-36.01 — Propagation Source Events
+
+A **propagation source** is any of the following:
+
+| Source Type | Origin | `source_type` value |
+|---|---|---|
+| Player action | v1 `WorldChange` list from `apply_world_changes` | `"player_action"` |
+| NPC autonomous action | S35 `WorldDelta.changes` | `"npc_autonomy"` |
+| World event promotion | S35 `WorldDelta.events` (`NarrativeEventAction`) | `"world_event"` |
+
+Only events with `EventSeverity` of `"notable"`, `"major"`, or `"critical"` are
+eligible as propagation sources. `"minor"` events do NOT propagate. This threshold
+is configurable via `universes.config["propagation"]["min_propagation_severity"]`
+(default: `"notable"`).
+
+### FR-36.02 — Propagation Graph Walk
+
+The propagator walks the Neo4j world graph outward from the **source location**.
+
+- **FR-36.02a**: Starting from `source_location_id`, the propagator queries all
+  locations reachable via `CONNECTS_TO` edges within `max_propagation_depth` hops.
+  (Default: 3; configurable via `universes.config["propagation"]["max_depth"]`.)
+- **FR-36.02b**: Queries MUST use the parameterized graph depth pattern already
+  established in v1 `_location_context_query`. No new Neo4j driver connection is
+  opened; the existing session is reused.
+- **FR-36.02c**: Only alive NPCs (`npc.alive = true`) at each reached location are
+  included (via `IS_AT` relationship).
+- **FR-36.02d**: For each NPC or location reached, the propagator computes a
+  `ConsequenceRecord` (FR-36.04) using the distortion model (FR-36.03).
+
+### FR-36.03 — Distortion Model
+
+Consequence severity and description degrade with hop distance.
+
+| Hop Distance | Severity Adjustment | Description Fidelity |
+|---|---|---|
+| 0 (source) | No change | Exact description |
+| 1 | Decrement 1 step | Full detail |
+| 2 | Decrement 2 steps | Partial detail, vague |
+| 3 | Decrement 3 steps | Rumor only |
+| > 3 | Not propagated | n/a |
+
+**Severity decrement table** (one step per hop):
+
+| Original | −1 (hop 1) | −2 (hop 2) | −3 (hop 3) |
+|---|---|---|---|
+| `critical` | `major` | `notable` | `minor` |
+| `major` | `notable` | `minor` | (filtered out) |
+| `notable` | `minor` | (filtered out) | (filtered out) |
+| `minor` | (filtered out) | n/a | n/a |
+
+Events decremented below `"minor"` are NOT propagated at that hop distance.
+
+**Description fidelity**:
+
+- Hop 1 (`full`): Description is passed through unchanged.
+- Hop 2 (`partial`): If LLM available, single batched paraphrase call. Otherwise,
+  template: `"Word has reached here that {original_description_summary}."`
+  (first 80 chars of original description).
+- Hop 3 (`rumor`): Template only: `"There are vague rumors of {event_type} near
+  {source_location_name}."` No LLM at hop 3 (cost control).
+
+### FR-36.04 — ConsequenceRecord Type
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `consequence_id` | ULID | Unique identifier. |
+| `universe_id` | ULID | Owning universe. |
+| `source_event_id` | str | ID of the originating `WorldEvent` or `WorldChange`. |
+| `source_type` | str | `"player_action"`, `"npc_autonomy"`, `"world_event"`. |
+| `source_location_id` | str | Location where the source event occurred. |
+| `affected_entity_id` | str | The NPC or location that received the consequence. |
+| `affected_entity_type` | str | `"npc"` or `"location"`. |
+| `hop_distance` | int [0–3] | Graph hops from source location. |
+| `original_severity` | str | Severity at source. |
+| `propagated_severity` | str | Severity at this hop after distortion. |
+| `description` | str | Consequence description at this fidelity level. |
+| `faction_id` | str or null | Faction ID if propagated via faction graph (FR-36.05). |
+| `triggered_at_tick` | int | `WorldTime.total_ticks` at propagation time. |
+| `created_at` | datetime | Wall-clock creation time. |
+
+`ConsequenceRecord` objects are persisted as Neo4j nodes with `universe_id` for
+cross-session querying. They are NOT stored in Postgres `world_events`.
+
+### FR-36.05 — Faction-Aware Propagation
+
+NPCs that share a `faction_id` with the directly affected NPC receive the consequence
+at hop-1 distortion level, regardless of their physical graph distance from the source.
+
+- **FR-36.05a**: Faction propagation applies only to NPC-targeted consequences
+  (`affected_entity_type = "npc"`).
+- **FR-36.05b**: Faction graph query:
+
+  ```cypher
+  MATCH (npc:NPC {faction_id: $faction_id, universe_id: $universe_id})
+  WHERE npc.id <> $source_npc_id AND npc.alive = true
+  ```
+
+- **FR-36.05c**: Faction records carry `hop_distance = 1` and `faction_id` set.
+- **FR-36.05d**: An NPC that is both within physical depth AND in the same faction
+  receives only ONE record. Physical record takes precedence if `hop_distance < 1`;
+  otherwise the faction record is used.
+- **FR-36.05e**: If `faction_id` is null on the affected NPC, no faction propagation.
+
+### FR-36.06 — PropagationResult Type
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `source_event_id` | str | The event that triggered propagation. |
+| `records` | list[ConsequenceRecord] | Records from graph-walk propagation. |
+| `faction_records` | list[ConsequenceRecord] | Records from faction-graph propagation. |
+| `total_records` | int | `len(records) + len(faction_records)`. |
+| `propagation_depth_reached` | int | Actual maximum hop depth reached this run. |
+| `skipped_minor` | int | Events filtered by `min_propagation_severity`. |
+| `budget_exceeded` | bool | True if `budget_ms` was reached before walk completed. |
+
+### FR-36.07 — ConsequencePropagator Contract
+
+```python
+async def propagate(
+    source_events: list[PropagationSource],
+    universe_id: str,
+    world_time: WorldTime,
+) -> PropagationResult: ...
+```
+
+- **FR-36.07a**: Injectable. A `MemoryConsequencePropagator` with static graph
+  fixtures MUST exist for unit testing without a live Neo4j instance.
+- **FR-36.07b**: At most ONE LLM call per `propagate()` invocation, batching all
+  hop-2 descriptions. Excess falls back to template.
+- **FR-36.07c**: Runs AFTER `AutonomyProcessor.process()` and BEFORE narrative
+  generation (Enrich stage).
+- **FR-36.07d**: `PropagationResult` is injected into the generation context as
+  `"propagated_consequences"`.
+- **FR-36.07e**: Must complete within `budget_ms` (default: 100 ms). On budget
+  exceeded, returns partial result with `budget_exceeded = True`.
+
+### FR-36.08 — Persistence
+
+- `ConsequenceRecord` nodes are written to Neo4j within the same transaction as the
+  triggering `WorldEvent`.
+- Records older than `universes.config["propagation"]["record_retention_ticks"]`
+  (default: 500 ticks) MAY be pruned by a background maintenance job.
+- S37 (World Memory) consumes `ConsequenceRecord` nodes as input to importance
+  scoring at memory write time.
+
+---
+
+## 5. Non-Functional Requirements
+
+### NFR-36.01 — Propagation Latency
+Graph-walk and `ConsequenceRecord` computation (rule-based) MUST complete in under
+100 ms (p95) for a universe with up to 100 locations and 200 NPCs at max depth 3.
+
+### NFR-36.02 — LLM Paraphrasing Budget
+Hop-2 paraphrasing MUST NOT issue more than 1 LLM call per `propagate()` run.
+
+### NFR-36.03 — Observability
+All `PropagationResult` objects MUST be logged at `DEBUG` level with structlog.
+Any `budget_exceeded = True` result MUST be logged at `WARNING` level.
+
+### NFR-36.04 — Test Coverage
+Unit tests MUST cover: severity decay, faction-override deduplication,
+budget-exceeded short-circuit, minor-event filter, empty graph.
+
+---
+
+## 6. User Journeys
+
+### Journey 1: Player Kills a Guard (Critical Event)
+
+**Setup**: Player at `market_square`. Guard belongs to `city_watch` faction.
+Adjacent: `tavern` (hop 1), `guild_hall` (hop 2), `city_gate` (hop 3).
+Other `city_watch` NPCs: `gate_captain` at `city_gate` (3 hops away).
+
+1. Source: `player_action`, severity `critical`, location `market_square`.
+2. Hop 1 (`tavern`): `barkeep`. Record: severity `major`, full description.
+3. Hop 2 (`guild_hall`): `guild_master`. Record: severity `notable`, partial
+   — "Word has reached here that a guard was killed in the market."
+4. Hop 3 (`city_gate`): `gate_guard`. Record: severity `minor`, rumor
+   — "There are vague rumors of player_action near market_square."
+5. Faction (`city_watch`): `gate_captain` gets a hop-1 faction record (severity
+   `major`, full description). Physical hop-3 record for gate_captain NOT created.
+6. `PropagationResult.total_records = 4`.
+
+### Journey 2: NPC Autonomous Event (King Dies)
+
+**Source**: S35 `NarrativeEventAction` produced `WorldEvent: "king_death"`,
+severity `critical`, location `throne_room`.
+
+1. `ConsequencePropagator.propagate()` receives `source_type: "world_event"`.
+2. Graph walk from `throne_room` proceeds identically to a player action.
+3. All `royal_guard` faction NPCs receive hop-1 faction records.
+4. Player in a distant dungeon (within graph depth 3) gets a hop-3 rumor record.
+
+---
+
+## 7. Edge Cases & Failure Modes
+
+| # | Scenario | Expected Behavior |
+|---|----------|-------------------|
+| E1 | Source event has severity `"minor"` | No records; `skipped_minor += 1` |
+| E2 | Source location has no connected locations | `records = []`; no error |
+| E3 | NPC is both physical hop-2 and same faction | Faction record (hop-1) wins; one record |
+| E4 | LLM paraphrasing call fails | Fall back to template; log warning; continues |
+| E5 | `max_depth = 0` configured | Treated as 1; hop-0 source record still created |
+| E6 | NPC dies between graph query and record write | Record written with state at query time; best-effort |
+| E7 | Budget exceeded mid-walk | `budget_exceeded = True`; partial result; WARNING logged |
+| E8 | Faction has 0 other alive members | No faction records; no error |
+
+---
+
+## 8. Acceptance Criteria (Gherkin)
+
+```gherkin
+Feature: Consequence Propagation
+
+  Background:
+    Given a universe with max propagation depth = 3
+    And a world graph: market_square → tavern (hop 1) → guild_hall (hop 2) → city_gate (hop 3)
+    And NPCs: barkeep at tavern, guild_master at guild_hall, gate_guard at city_gate
+    And a guard NPC at market_square belonging to faction "city_watch"
+    And a gate_captain NPC at city_gate belonging to faction "city_watch"
+
+  Scenario: AC-36.01 — Minor events do not propagate
+    Given a source event with severity "minor"
+    When propagate() is called
+    Then PropagationResult.total_records = 0
+    And PropagationResult.skipped_minor = 1
+
+  Scenario: AC-36.02 — Notable event propagates to correct depths only
+    Given a source event with severity "notable" at market_square
+    When propagate() is called
+    Then a ConsequenceRecord exists for barkeep with propagated_severity = "minor"
+    And no ConsequenceRecord exists for guild_master or gate_guard
+
+  Scenario: AC-36.03 — Critical event propagates with correct severity decay
+    Given a source event with severity "critical" at market_square
+    When propagate() is called
+    Then barkeep record has propagated_severity = "major"
+    And guild_master record has propagated_severity = "notable"
+    And gate_guard record has propagated_severity = "minor"
+
+  Scenario: AC-36.04 — Faction members receive hop-1 record regardless of distance
+    Given a critical source event targeting the guard at market_square
+    When propagate() is called
+    Then gate_captain has a ConsequenceRecord with hop_distance = 1 and faction_id = "city_watch"
+    And gate_captain does NOT also have a hop-3 ConsequenceRecord
+
+  Scenario: AC-36.05 — Hop-2 description falls back to template on LLM failure
+    Given the LLM paraphrasing service is unavailable
+    And a critical source event at market_square
+    When propagate() is called
+    Then guild_master ConsequenceRecord.description starts with "Word has reached here that"
+
+  Scenario: AC-36.06 — PropagationResult is injected into generation context
+    Given propagate() returns a non-empty PropagationResult
+    When the narrative generation stage runs
+    Then the generation context includes "propagated_consequences"
+
+  Scenario: AC-36.07 — Budget exceeded returns partial result without error
+    Given propagation budget_ms is set to 0 (forced timeout)
+    And a critical source event at market_square
+    When propagate() is called
+    Then PropagationResult.budget_exceeded = True
+    And no exception is raised
+
+  Scenario: AC-36.08 — ConsequenceRecords are persisted to Neo4j
+    Given a critical source event at market_square
+    When propagate() completes with a non-empty result
+    Then ConsequenceRecord nodes exist in Neo4j with the correct universe_id
+```
+
+---
+
+## 9. Out of Scope
+
+- Faction relationship mechanics (alliances, rivalries, reputation scores).
+- Cross-universe propagation — consequences do not cross universe boundaries.
+- Item propagation — stolen items noticed by distant owners.
+- Consequence record background pruning scheduling.
+- **Adaptive propagation depth** — depth is fixed per universe. Deferred to v3+.
+- Player-visible rumor mechanics — what the player *hears* from NPCs is a narrative
+  generation concern.
+
+---
+
+## 10. Open Questions
+
+| ID | Question | Status | Resolution |
+|---|----------|--------|------------|
+| OQ-36.01 | Propagation graph depth limit — fixed or adaptive? | ✅ Resolved | **Fixed** (default 3, configurable per universe). Adaptive depth deferred to v3+. |
+| OQ-36.02 | Should `ConsequenceRecord` be exposed to players via a "heard rumors" API? | ⏳ Open | Proposed: no direct API; records influence generation context only. Future spec to decide. |
+| OQ-36.03 | How does propagation interact with secret passages NPCs don't know about? | ⏳ Open | Proposed: `CONNECTS_TO` edges carry `traversable_by_npcs: bool`. S40 author to decide. |
+
+---
+
+## Appendix A — PropagationSource Type
+
+```python
+from dataclasses import dataclass
+from tta.world.time import WorldTime   # S34
+
+@dataclass(frozen=True)
+class PropagationSource:
+    source_event_id: str
+    source_type: str  # "player_action" | "npc_autonomy" | "world_event"
+    source_location_id: str
+    original_severity: str   # EventSeverity
+    description: str
+    faction_id: str | None = None
+    affected_entity_id: str | None = None
+    affected_entity_type: str | None = None  # "npc" | "location"
+```
+
+## Appendix B — Distortion Fidelity Decision Table
+
+| Hop | Fidelity Level | LLM Used? | Template Used? | Severity Filter |
+|-----|----------------|-----------|----------------|-----------------|
+| 0 | exact | No | No | Original severity |
+| 1 | full | No | No | −1 step |
+| 2 | partial | Yes (batched, optional) | Yes (fallback) | −2 steps |
+| 3 | rumor | No | Always | −3 steps |
+| >3 | (not propagated) | — | — | Filtered |
+
+## Appendix C — Pipeline Position
+
+```
+Turn Pipeline (v2 Enrich stage):
+  1. Understand stage (parse intent)
+  2. AutonomyProcessor.process()       →  WorldDelta              [S35]
+  3. ConsequencePropagator.propagate() →  PropagationResult       [S36] ← THIS SPEC
+  4. MemoryWriter.record()             →  MemoryRecord[]          [S37]
+  5. Context assembly                  →  generation context dict
+  6. Generate stage
+  7. Stream stage
+```

--- a/specs/36-consequence-propagation.md
+++ b/specs/36-consequence-propagation.md
@@ -100,7 +100,7 @@ The propagator walks the Neo4j world graph outward from the **source location**.
 
 - **FR-36.02a**: Starting from `source_location_id`, the propagator queries all
   locations reachable via `CONNECTS_TO` edges within `max_propagation_depth` hops.
-  (Default: 3; configurable via `universes.config["propagation"]["max_depth"]`.)
+  (Default: 3; configurable via `universes.config["propagation"]["max_propagation_depth"]`.)
 - **FR-36.02b**: Queries MUST use the parameterized graph depth pattern already
   established in v1 `_location_context_query`. No new Neo4j driver connection is
   opened; the existing session is reused.

--- a/specs/37-world-memory-model.md
+++ b/specs/37-world-memory-model.md
@@ -1,0 +1,532 @@
+# S37 — World Memory Model
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v2.0
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 2 — Simulation
+> **Dependencies**: v1 S03 (Narrative), v1 S08 (Turn Pipeline), v1 S12 (Persistence), v1 S13 (World Graph)
+> **Related**: S36 (Consequence Propagation), S38 (NPC Memory & Social), S62 (Story Export, v5+)
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+In v1, narrative memory is a flat `list[dict]` field (`GameState.narrative_history`)
+appended on every turn. There is no structure, no attribution, no importance scoring,
+no decay, and no compression. When the context window fills, older turns simply fall
+off the end. The player's story exists only as a growing string dump.
+
+v2 replaces this with a structured, attributed, time-aware **World Memory Model**.
+
+Memory is now a first-class entity with:
+- Per-entry importance scores that determine what survives compression
+- Tick-stamped timestamps from the diegetic clock (S34)
+- Attribution to actors, locations, and event sources
+- Three-tier working/active/compressed architecture tuned to context budgets
+- LLM-assisted compression using the `LLMRole.SUMMARIZATION` path
+
+This spec defines the `MemoryRecord` type, the `MemoryWriter` service contract,
+the three-tier memory model, importance scoring rules, and the compression algorithm.
+It is the foundation for story export (S62, v5+) and NPC memory (S38).
+
+---
+
+## 2. Design Philosophy
+
+### 2.1 Principles
+
+- **Memory as simulation state, not conversation log**: `MemoryRecord` entries are
+  canon world events, not raw LLM output. They are attributed, scored, and managed
+  independently of the text that mentions them.
+- **Context budget drives compression, not wall time**: Compression is triggered
+  by token count exceeding a configured threshold, not by age or calendar time.
+  A player who plays slowly never loses memory unfairly.
+- **Importance score determines what survives**: Low-importance records are compressed
+  first. High-importance records are preserved in full or summarized with higher
+  fidelity. Importance is scored at write time and decays over ticks.
+- **Working memory is never compressed**: The last `working_memory_size` turns are
+  always injected into the generation context in full, regardless of compression
+  state. This prevents "amnesia" between consecutive turns.
+- **LLM summarization is a compression tool, not a filter**: The summarization LLM
+  call reduces token footprint but MUST preserve named entities, locations, and
+  causal relationships present in the original records.
+
+### 2.2 Relationship to v1 `narrative_history`
+
+v1's `GameState.narrative_history: list[dict]` is deprecated in v2. During v2.0
+migration, existing sessions' `narrative_history` entries are backfilled as
+`MemoryRecord` entries with `source = "narrator"`, `importance_score = 0.3`
+(low, triggering early compression), and `world_time_tick = 0`.
+
+### 2.3 What This Spec Is NOT
+
+- S37 does not define per-NPC recollection of the player — see S38.
+- S37 does not define the story export format — see S62.
+- S37 does not define how memory affects the generation prompt structure — that is
+  the concern of the context assembly stage.
+- S37 does not replace Postgres `game_snapshots` — snapshots remain the recovery
+  mechanism; `MemoryRecord` is the semantic layer.
+
+---
+
+## 3. User Stories
+
+> **US-37.1** — **As a** player, the game remembers what I did several sessions ago
+> and NPCs can reference it, so the world feels persistent and meaningful.
+
+> **US-37.2** — **As a** player, important story moments (discovering the villain's
+> plan, making a major alliance) are never forgotten even after hundreds of turns,
+> while minor flavor events fade gracefully.
+
+> **US-37.3** — **As a** player, when memory is compressed, I don't notice jarring
+> gaps — the summarized version preserves the key facts and named entities.
+
+> **US-37.4** — **As a** developer, I can query all memory for a session ordered
+> by importance or time, so I can debug what the game "knows" at any point.
+
+> **US-37.5** — **As a** universe author, I can configure the working memory size
+> and compression threshold per universe to tune the game's memory budget.
+
+---
+
+## 4. Functional Requirements
+
+### FR-37.01 — MemoryRecord Type
+
+A single unit of world memory:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `memory_id` | ULID | Unique identifier. |
+| `universe_id` | ULID | Owning universe. |
+| `session_id` | UUID | Session that generated this record. |
+| `turn_number` | int | Turn number at creation. |
+| `world_time_tick` | int | `WorldTime.total_ticks` at creation (S34). |
+| `source` | str | Origin: `"player"`, `"narrator"`, `"npc"`, `"world"`. |
+| `attributed_to` | str or null | Entity ID (NPC, location) most associated with this event. |
+| `content` | str | The full narrative text of this memory. |
+| `summary` | str or null | LLM-generated summary if this is a compressed block. |
+| `importance_score` | float [0.0, 1.0] | Importance at write time. |
+| `current_importance` | float [0.0, 1.0] | Decayed importance at query time. |
+| `tier` | str | `"working"`, `"active"`, or `"compressed"`. |
+| `is_compressed` | bool | True if this record is a compression block. |
+| `compressed_from` | list[ULID] | IDs of records this block replaced. |
+| `tags` | list[str] | Content tags (e.g., `["combat", "quest", "faction:city_watch"]`). |
+| `consequence_ids` | list[ULID] | `ConsequenceRecord` IDs that contributed to this memory. |
+| `created_at` | datetime | Wall-clock time of record creation. |
+
+### FR-37.02 — Three-Tier Memory Architecture
+
+Memory is organized into three tiers at query time:
+
+| Tier | Definition | Compressed? | Always Included? |
+|------|-----------|-------------|------------------|
+| Working | Last `working_memory_size` turns (default: 5) | Never | Yes |
+| Active | Turns beyond working, up to `compression_threshold_tokens` | No | By importance |
+| Compressed | Records summarized into compression blocks | Yes | Summary only |
+
+- **FR-37.02a**: Working memory records are always injected into the generation
+  context in full, regardless of their importance score.
+- **FR-37.02b**: Active memory records are injected ordered by `current_importance`
+  descending, trimmed to fit the available context budget after working memory.
+- **FR-37.02c**: Compressed memory blocks are injected as their `summary` string
+  only, not their original `content`.
+- **FR-37.02d**: `working_memory_size` is configurable via
+  `universes.config["memory"]["working_memory_size"]` (default: 5 turns).
+
+### FR-37.03 — MemoryWriter Contract
+
+```python
+async def record(
+    session_id: UUID,
+    universe_id: str,
+    turn_number: int,
+    world_time: WorldTime,
+    content: str,
+    source: str,
+    attributed_to: str | None,
+    tags: list[str],
+    consequence_ids: list[str],
+) -> MemoryRecord: ...
+
+async def get_context(
+    session_id: UUID,
+    universe_id: str,
+    budget_tokens: int,
+) -> MemoryContext: ...
+
+async def compress_if_needed(
+    session_id: UUID,
+    universe_id: str,
+) -> CompressionResult: ...
+```
+
+- **FR-37.03a**: `record()` MUST compute and store `importance_score` at write time
+  using the scoring rules in FR-37.04.
+- **FR-37.03b**: `record()` MUST check whether compression is needed
+  (`compress_if_needed()`) after every write. Compression is async and non-blocking
+  — it does not delay the current turn's pipeline.
+- **FR-37.03c**: `get_context()` returns a `MemoryContext` object with three
+  partitions: `working`, `active`, `compressed`, all fitted to `budget_tokens`.
+- **FR-37.03d**: The `MemoryWriter` MUST be injectable. A `InMemoryMemoryWriter`
+  with no persistence MUST exist for unit testing.
+
+### FR-37.04 — Importance Scoring
+
+Importance is scored at write time on the scale [0.0, 1.0] using these rules:
+
+| Signal | Weight | Notes |
+|--------|--------|-------|
+| Source: `"player"` action | +0.3 | Player-driven events are inherently more salient |
+| Source: `"world"` event | +0.2 | World-level events are significant |
+| Source: `"narrator"` or `"npc"` | +0.0 | Baseline |
+| NPC tier in `attributed_to` is `KEY` (S35) | +0.3 | KEY NPCs are high-salience |
+| NPC tier `SUPPORTING` | +0.1 | |
+| `ConsequenceRecord` severity `"critical"` | +0.3 | |
+| `ConsequenceRecord` severity `"major"` | +0.2 | |
+| `ConsequenceRecord` severity `"notable"` | +0.1 | |
+| Tag `"quest"` present | +0.2 | Quest events are story-critical |
+| Tag `"death"` or `"combat"` | +0.1 | |
+
+Final score is clamped to [0.0, 1.0]. Scores are additive up to the cap.
+
+### FR-37.05 — Importance Decay
+
+Importance decays over diegetic time. The decay function is:
+
+```
+current_importance = importance_score * (0.5 ^ (ticks_elapsed / memory_half_life_ticks))
+```
+
+- `ticks_elapsed = current_world_time_tick - record.world_time_tick`
+- `memory_half_life_ticks` is configurable via
+  `universes.config["memory"]["memory_half_life_ticks"]` (default: 50 ticks).
+- Decay is computed at query time, not stored. `current_importance` is a derived
+  field calculated when `get_context()` is called.
+- Records in the working tier are NOT subject to decay for context injection purposes
+  (they are always included regardless of `current_importance`).
+- An `importance_score` of 1.0 (maximum) takes 10 half-lives (~500 ticks default)
+  to decay below 0.001. Such records are effectively permanent.
+
+### FR-37.06 — Compression Trigger
+
+Compression is triggered when the total token count of ALL active `MemoryRecord`
+content for a session exceeds `compression_threshold_tokens`.
+
+- `compression_threshold_tokens` is configurable via
+  `universes.config["memory"]["compression_threshold_tokens"]` (default: 4000).
+- Token count estimation uses the v1 `count_tokens()` function from
+  `tta.llm.context_budget` (character-count heuristic, safe over-estimate).
+- **FR-37.06a**: Compression selects the oldest active records with
+  `current_importance < 0.5` (configurable via `compression_importance_threshold`,
+  default: 0.5) for summarization.
+- **FR-37.06b**: Selected records are batched into a single LLM summarization call
+  using `LLMRole.SUMMARIZATION`. The prompt instructs the model to preserve named
+  entities, locations, and causal relationships.
+- **FR-37.06c**: The resulting summary text is stored as a new `MemoryRecord` with
+  `is_compressed = True`, `tier = "compressed"`, and `compressed_from = [list of
+  original memory_ids]`. The original records are NOT deleted — they are marked
+  `tier = "archived"` and excluded from context injection.
+- **FR-37.06d**: If LLM summarization fails, compression is skipped for this turn.
+  A `WARNING` is logged. The uncompressed records remain in the active tier.
+  Compression will be retried on the next turn.
+- **FR-37.06e**: Working-tier records (last `working_memory_size` turns) are NEVER
+  eligible for compression.
+
+### FR-37.07 — MemoryContext Type
+
+The output of `get_context()`, consumed by the context assembly stage:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `working` | list[MemoryRecord] | Last N turns, always in full. |
+| `active` | list[MemoryRecord] | Older records, sorted by `current_importance` desc. |
+| `compressed` | list[MemoryRecord] | Compression blocks; only `summary` is used. |
+| `total_tokens` | int | Estimated token count of this context. |
+| `dropped_count` | int | Active records dropped to fit budget. |
+
+### FR-37.08 — Integration with S36 (Consequence Propagation)
+
+When `ConsequencePropagator.propagate()` produces `ConsequenceRecord` entries, the
+corresponding `MemoryRecord` for that turn receives:
+- `consequence_ids` populated with the `consequence_id` values from the result.
+- An importance boost per FR-37.04 based on the highest severity propagated
+  consequence.
+
+This linkage enables S38 (NPC Memory) to query MemoryRecords by consequence.
+
+### FR-37.09 — Persistence
+
+`MemoryRecord` objects are stored in Neo4j as `Memory` nodes with `universe_id`
+and `session_id` properties, connected to their `Universe` node via a
+`HAS_MEMORY` relationship.
+
+A `MemoryRecord` is NEVER mutated after creation. Compression creates new records;
+original records are re-labeled to `tier = "archived"`.
+
+---
+
+## 5. Non-Functional Requirements
+
+### NFR-37.01 — Write Latency
+`record()` MUST complete in under 20 ms (p95), excluding the async compression call.
+
+### NFR-37.02 — Context Assembly Latency
+`get_context()` MUST complete in under 50 ms (p95) for a session with up to 500
+active `MemoryRecord` nodes.
+
+### NFR-37.03 — Compression Non-Blocking
+`compress_if_needed()` is async and runs outside the turn pipeline critical path.
+It MUST NOT delay generation by more than 5 ms (it should be fire-and-forget).
+
+### NFR-37.04 — Observability
+Every `record()` call MUST emit a structlog event with `memory_id`, `importance_score`,
+and `session_id`. Every compression run MUST emit `records_compressed`,
+`tokens_before`, `tokens_after`, and `session_id`.
+
+### NFR-37.05 — Test Coverage
+An `InMemoryMemoryWriter` and unit tests MUST cover: importance scoring for all
+signal combinations, decay calculation at multiple tick offsets, compression
+trigger boundary (just under and just over threshold), LLM failure fallback
+(no compression), and three-tier context assembly with budget trimming.
+
+---
+
+## 6. User Journeys
+
+### Journey 1: Player Discovers the Villain's Plan (High Importance)
+
+**Turn N**: Player in `villain_lair`. Player action triggers a `"world"` event.
+A `ConsequenceRecord` with severity `critical` is generated (S36).
+
+1. `MemoryWriter.record()` is called with `source = "world"`, `tags = ["quest"]`,
+   `consequence_ids = [villain_plan_consequence_id]`.
+2. Importance scoring: `+0.2` (world source) + `+0.2` (quest tag) + `+0.3`
+   (critical consequence) = `0.7` importance_score.
+3. Record stored in Neo4j. Tier: `active` (not yet in working window's overflow).
+4. After 200 ticks (4 half-lives at default 50): `current_importance = 0.7 × (0.5^4)
+   = 0.7 × 0.0625 = 0.044`. Still above `0.001` — not effectively zero.
+5. After 500 ticks (10 half-lives): `current_importance ≈ 0.001`. Near-zero,
+   eligible for compression in a future compression run.
+
+### Journey 2: Compression Run (50 Turns of Low-Importance Events)
+
+After 50 turns of `"narrator"` source records (importance `0.0`–`0.3`), total
+active memory crosses `compression_threshold_tokens = 4000`.
+
+1. `compress_if_needed()` fires asynchronously after turn 50's `record()` call.
+2. Records with `current_importance < 0.5` selected (40 of 50 records).
+3. Batched into single `LLMRole.SUMMARIZATION` call.
+4. Summary returned: "Over the past 40 turns, the player explored the merchant
+   district, resolved a minor dispute between innkeeper Carla and the baker,
+   and purchased supplies for the journey north."
+5. New `MemoryRecord` created: `is_compressed = True`, `tier = "compressed"`,
+   `compressed_from = [40 ids]`, `importance_score = 0.5`.
+6. 40 original records marked `tier = "archived"` (excluded from context injection).
+7. `compress_if_needed()` logs: `records_compressed = 40`, `tokens_before = 4400`,
+   `tokens_after = 850`.
+
+### Journey 3: Working Memory Guarantee
+
+Player is on turn 200 in a long session. Active memory is heavily compressed.
+
+1. `get_context(budget_tokens = 2000)` is called.
+2. Working tier (last 5 turns) consumes ~500 tokens — always included first.
+3. Remaining 1500 tokens split between active records (sorted by
+   `current_importance` desc) and compressed block summaries.
+4. Player never experiences amnesia about what happened in the last 5 turns.
+
+---
+
+## 7. Edge Cases & Failure Modes
+
+| # | Scenario | Expected Behavior |
+|---|----------|-------------------|
+| E1 | `record()` called with empty `content` | Raise `ValueError`; do not persist |
+| E2 | LLM summarization fails during compression | Skip compression; log WARNING; retry next turn |
+| E3 | `compress_if_needed()` called but threshold not reached | No-op; no LLM call made |
+| E4 | `get_context()` with budget smaller than working memory alone | Include working memory only; `dropped_count` reflects dropped active + compressed |
+| E5 | All records are in working tier (session < `working_memory_size` turns) | No active or compressed records; context is purely working tier |
+| E6 | `world_time_tick` is 0 (migrated v1 session) | No decay applied (0 ticks elapsed); importance_score used as-is |
+| E7 | Compression block's `compressed_from` references a deleted record | Log WARNING; continue; block is still valid |
+| E8 | Two concurrent turns attempt compression simultaneously | Second call short-circuits if first is in progress (Redis lock or idempotency key) |
+
+---
+
+## 8. Acceptance Criteria (Gherkin)
+
+```gherkin
+Feature: World Memory Model
+
+  Background:
+    Given a session with universe memory config:
+      | working_memory_size          | 5    |
+      | compression_threshold_tokens | 4000 |
+      | compression_importance_threshold | 0.5 |
+      | memory_half_life_ticks       | 50   |
+
+  Scenario: AC-37.01 — MemoryRecord is created with correct importance score
+    Given a turn with source "world", tag "quest", and a critical ConsequenceRecord
+    When MemoryWriter.record() is called
+    Then a MemoryRecord is persisted with importance_score = 0.7
+    And the record has tier = "active"
+
+  Scenario: AC-37.02 — Working memory records are always injected
+    Given a session with 20 turns of compressed memory
+    And a budget_tokens of 100 (smaller than active memory)
+    When get_context() is called
+    Then working tier records (last 5 turns) are included
+    And dropped_count reflects records excluded from active/compressed
+
+  Scenario: AC-37.03 — Compression is triggered when threshold exceeded
+    Given a session where active memory token count exceeds 4000
+    When MemoryWriter.record() completes
+    Then compress_if_needed() fires asynchronously
+    And records with current_importance < 0.5 are summarized
+    And a new MemoryRecord with is_compressed = True is created
+    And original records are marked tier = "archived"
+
+  Scenario: AC-37.04 — LLM summarization failure leaves memory unchanged
+    Given a session where compression is triggered
+    And the LLM summarization call fails
+    When compress_if_needed() completes
+    Then no MemoryRecord is archived
+    And a WARNING is logged
+    And the next turn's record() call retries compression
+
+  Scenario: AC-37.05 — Importance decay reduces active record priority over time
+    Given a MemoryRecord with importance_score = 0.4 created at tick 0
+    And current_world_time_tick = 50 (one half-life elapsed)
+    When get_context() is called
+    Then the record's current_importance = 0.2
+
+  Scenario: AC-37.06 — Working-tier records are never compressed
+    Given 5 records in the working tier
+    And active memory token count exceeds compression_threshold_tokens
+    When compress_if_needed() runs
+    Then working-tier records are not included in compression candidates
+
+  Scenario: AC-37.07 — ConsequenceRecord linkage boosts importance
+    Given a source event with a critical ConsequenceRecord
+    When MemoryWriter.record() is called with consequence_ids populated
+    Then the resulting MemoryRecord.importance_score includes the +0.3 critical boost
+
+  Scenario: AC-37.08 — Migrated v1 records have low default importance
+    Given a MemoryRecord migrated from v1 narrative_history
+    Then importance_score = 0.3
+    And world_time_tick = 0
+    And no decay is applied (ticks_elapsed = 0)
+```
+
+---
+
+## 9. Out of Scope
+
+- Per-NPC recollection of the player — see S38.
+- Story export format — see S62.
+- How `MemoryContext` is serialized into the generation prompt — context assembly
+  stage concern.
+- Long-term semantic search over memories — deferred to v3+ (likely S62 dependency).
+- Multi-session shared world memory across different players' sessions in the same
+  universe — deferred to a future Universe Shared State spec.
+
+---
+
+## 10. Open Questions
+
+| ID | Question | Status | Resolution |
+|---|----------|--------|------------|
+| OQ-37.01 | Memory compression threshold — token count or semantic boundary? | ✅ Resolved | **Token count** (primary trigger, configurable). Semantic boundaries (chapter/arc breaks) deferred to v2.1 as optional secondary hints. |
+| OQ-37.02 | Should `MemoryRecord` be persisted in Postgres (for `game_snapshots` recovery) or Neo4j only? | ⏳ Open | Proposed: Neo4j only. Postgres `game_snapshots` remain the recovery path; `MemoryRecord` is the semantic layer. `compress_if_needed()` fires post-snapshot. S33 author to confirm schema. |
+| OQ-37.03 | Is `tier` a stored field or always derived at query time? | ✅ Resolved | **Stored field** (`"working"`, `"active"`, `"compressed"`, `"archived"`). Tier is assigned at write time and updated during compression. This avoids recomputing for every `get_context()` call. |
+| OQ-35.02 | Should `WorldDelta` be persisted as part of the turn record? | ⏳ Open (inherited from S35) | Proposed: `WorldDelta.changes` are consumed by S36 and S37; the delta itself is ephemeral and need not be stored separately. S37 implementation author to confirm. |
+
+---
+
+## Appendix A — MemoryRecord Dataclass Shape
+
+```python
+from dataclasses import dataclass, field
+from datetime import datetime
+
+@dataclass
+class MemoryRecord:
+    memory_id: str          # ULID
+    universe_id: str        # ULID
+    session_id: str         # UUID
+    turn_number: int
+    world_time_tick: int    # WorldTime.total_ticks (S34)
+    source: str             # "player" | "narrator" | "npc" | "world"
+    attributed_to: str | None
+    content: str
+    summary: str | None
+    importance_score: float
+    tier: str               # "working" | "active" | "compressed" | "archived"
+    is_compressed: bool
+    compressed_from: list[str] = field(default_factory=list)
+    tags: list[str] = field(default_factory=list)
+    consequence_ids: list[str] = field(default_factory=list)
+    created_at: datetime = field(default_factory=lambda: datetime.now())
+
+    def current_importance(self, current_tick: int, half_life_ticks: int) -> float:
+        ticks_elapsed = max(0, current_tick - self.world_time_tick)
+        if ticks_elapsed == 0 or half_life_ticks <= 0:
+            return self.importance_score
+        return self.importance_score * (0.5 ** (ticks_elapsed / half_life_ticks))
+```
+
+## Appendix B — Importance Scoring Reference
+
+| Signal | Score Delta | Cap |
+|--------|-------------|-----|
+| source = `"player"` | +0.3 | 1.0 |
+| source = `"world"` | +0.2 | 1.0 |
+| source = `"narrator"` or `"npc"` | +0.0 | — |
+| attributed_to NPC tier = `KEY` | +0.3 | 1.0 |
+| attributed_to NPC tier = `SUPPORTING` | +0.1 | 1.0 |
+| ConsequenceRecord severity `"critical"` | +0.3 | 1.0 |
+| ConsequenceRecord severity `"major"` | +0.2 | 1.0 |
+| ConsequenceRecord severity `"notable"` | +0.1 | 1.0 |
+| tag `"quest"` | +0.2 | 1.0 |
+| tag `"death"` or `"combat"` | +0.1 | 1.0 |
+| *(any combination)* | sum, clamped to [0.0, 1.0] | 1.0 |
+
+## Appendix C — Three-Tier Memory Architecture Diagram
+
+```
+Session memory at get_context() time:
+
+  ┌──────────────────────────────────────────────────────┐
+  │  WORKING TIER  (last 5 turns — always injected)      │
+  │  turn 196, 197, 198, 199, 200                        │
+  └──────────────────────────────────────────────────────┘
+
+  ┌──────────────────────────────────────────────────────┐
+  │  ACTIVE TIER  (sorted by current_importance desc)    │
+  │  Full content — trimmed to context budget            │
+  │  turn 100, 150, 175 (high-importance survivors)      │
+  └──────────────────────────────────────────────────────┘
+
+  ┌──────────────────────────────────────────────────────┐
+  │  COMPRESSED TIER  (summary text only)                │
+  │  block A: turns 1–99 summary                         │
+  │  block B: turns 101–149 summary                      │
+  └──────────────────────────────────────────────────────┘
+
+  [ARCHIVED records: excluded from context, kept for audit / S62 export]
+```
+
+## Appendix D — Pipeline Position
+
+```
+Turn Pipeline (v2 Enrich stage):
+  1. Understand stage (parse intent)
+  2. AutonomyProcessor.process()       →  WorldDelta              [S35]
+  3. ConsequencePropagator.propagate() →  PropagationResult       [S36]
+  4. MemoryWriter.record()             →  MemoryRecord[]          [S37] ← THIS SPEC
+     └─ compress_if_needed() (async, non-blocking)
+  5. Context assembly: get_context()   →  MemoryContext
+  6. Generate stage
+  7. Stream stage
+```

--- a/specs/38-npc-memory-and-social-model.md
+++ b/specs/38-npc-memory-and-social-model.md
@@ -1,0 +1,578 @@
+# S38 — NPC Memory & Social Model
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v2.0
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 2 — Simulation
+> **Dependencies**: v1 S06 (Characters & Relationships), S33 (Universe Persistence), S35 (NPC Autonomy), S37 (World Memory Model)
+> **Related**: S36 (Consequence Propagation), S62 (Story Export, v5+)
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+v1 tracks NPC relationships as a five-axis numeric vector (`RelationshipDimensions`:
+trust, affinity, respect, fear, familiarity). This vector captures *how* an NPC
+feels toward the player, but not *why* or *what specifically happened*. There is
+no episodic memory — NPCs cannot recall the event where trust was lost, cannot
+gossip about it to other NPCs, and forget everything when the session ends.
+
+S38 adds two complementary layers on top of v1's relationship model:
+
+1. **Episodic Memory**: each NPC maintains a timestamped log of significant
+   interactions with the player — the events that shaped the relationship vector.
+   KEY and SUPPORTING NPCs retain episodic memory across sessions (universe-scoped).
+
+2. **Social Graph & Gossip**: NPCs are connected by a social relationship graph
+   (distinct from the world geography graph used by S36). NPCs with sufficient
+   familiarity gossip knowledge about the player to their social neighbors,
+   propagating reputation across the cast without player involvement.
+
+This spec defines `NPCEpisodicMemory`, `NPCSocialEdge`, `GossipEvent`,
+`SocialMemoryWriter`, and the gossip propagation rules.
+
+---
+
+## 2. Design Philosophy
+
+### 2.1 S38 vs S36 — Two Propagation Systems
+
+S36 (Consequence Propagation) and S38 (NPC Social) are complementary but distinct:
+
+| Dimension | S36 — Consequence Propagation | S38 — NPC Social Gossip |
+|-----------|-------------------------------|-------------------------|
+| Graph | World geography (`CONNECTS_TO`) | Social relationships (`KNOWS`) |
+| Unit | `ConsequenceRecord` | `GossipEvent` |
+| Trigger | World events exceeding severity threshold | NPC familiarity + opportunity |
+| Content | Factual event description (distorted by hop) | Player-reputation fragment |
+| Scope | Reaches all entities near an event | Travels NPC-to-NPC selectively |
+| Memory | Written to world memory (S37) | Written to NPC episodic memory (S38) |
+
+A `ConsequenceRecord` (S36) traveling from an explosion may cause an NPC to hear
+a rumor. That rumor becomes a `GossipEvent` in S38 when the NPC passes it on.
+
+### 2.2 S38 vs S37 — Two Memory Systems
+
+S37 (World Memory Model) is the canonical record of what happened in the world.
+S38 (NPC Memory) is how individual NPCs *interpret and remember* those events:
+
+| Dimension | S37 — World Memory | S38 — NPC Episodic Memory |
+|-----------|-------------------|--------------------------|
+| Scope | Session / universe | Per-NPC |
+| Content | Objective event description | NPC-filtered interpretation |
+| Persistence | Universe-scoped in Neo4j | Universe-scoped for KEY/SUPPORTING |
+| Attribution | `attributed_to` entity ID | Stored under NPC ID |
+| Compression | LLM-summarized blocks | Not compressed (relationship-critical) |
+
+An `NPCEpisodicMemory` record SHOULD reference its source `MemoryRecord` by ID.
+It is NOT a copy — it is an interpretation with emotional valence and an NPC-specific
+framing (`"Elara remembers the player betrayed her at the docks"`). 
+
+### 2.3 Cross-Session Memory for KEY NPCs
+
+KEY NPCs survive session boundaries. Their `RelationshipDimensions` and episodic
+memories are stored in the universe's persistent Neo4j graph, attached to the NPC
+node. When a new session begins in the same universe, KEY NPC relationships are
+restored from the graph. BACKGROUND NPCs have no cross-session memory.
+
+---
+
+## 3. User Stories
+
+> **US-38.1** — **As a** player, NPCs I wronged in a previous session are still cold
+> toward me when I return, because they remember what happened.
+
+> **US-38.2** — **As a** player, an NPC I've never met is already wary of me because
+> they heard about my actions from a mutual acquaintance.
+
+> **US-38.3** — **As a** player, when I ask an NPC about a past event, they can
+> specifically reference it ("That time you broke your promise at the market…")
+> rather than just expressing vague distrust.
+
+> **US-38.4** — **As a** universe author, I can configure how aggressively NPCs
+> gossip and how quickly reputation travels through the social graph.
+
+> **US-38.5** — **As a** developer, I can query all episodic memories for an NPC,
+> sorted by importance, to debug why an NPC has a particular relationship score.
+
+---
+
+## 4. Functional Requirements
+
+### FR-38.01 — NPCEpisodicMemory Type
+
+A single episodic memory record for a specific NPC:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `episode_id` | ULID | Unique identifier. |
+| `npc_id` | str | The NPC who holds this memory. |
+| `universe_id` | ULID | Owning universe. |
+| `session_id` | UUID | Session in which this memory was formed. |
+| `turn_number` | int | Turn number at creation. |
+| `world_time_tick` | int | `WorldTime.total_ticks` at creation (S34). |
+| `source_memory_id` | ULID or null | The `MemoryRecord` (S37) that originated this episode. |
+| `consequence_id` | ULID or null | `ConsequenceRecord` (S36) if this was triggered by propagation. |
+| `player_id` | str | Player entity this memory concerns. |
+| `content` | str | NPC-framed narrative of the event. |
+| `emotional_valence` | float [-1.0, 1.0] | Negative = negative experience; positive = positive. |
+| `relationship_delta` | RelationshipChange or null | Dimension changes applied when this memory was formed. |
+| `importance_score` | float [0.0, 1.0] | Importance at write time (same scoring rules as S37.FR-37.04). |
+| `is_gossip` | bool | True if this memory was received via gossip rather than direct experience. |
+| `gossip_source_npc_id` | str or null | The NPC who gossiped this memory to this NPC. |
+| `created_at` | datetime | Wall-clock time of record creation. |
+
+### FR-38.02 — NPCSocialEdge Type
+
+A directed social relationship in the NPC graph:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `edge_id` | ULID | Unique identifier. |
+| `source_npc_id` | str | The NPC holding this relationship view. |
+| `target_id` | str | NPC ID or player ID (relationship target). |
+| `universe_id` | ULID | Owning universe (relationships are universe-scoped). |
+| `dimensions` | RelationshipDimensions | The five-axis vector (trust, affinity, respect, fear, familiarity). |
+| `gossip_weight` | float [0.0, 1.0] | How likely this NPC is to gossip about `target_id` to others. |
+| `updated_at` | datetime | Last modification time. |
+
+- **FR-38.02a**: `NPCSocialEdge` extends (not replaces) v1's `NPCRelationship`. The
+  `dimensions` field maps directly to v1's `RelationshipDimensions`.
+- **FR-38.02b**: `gossip_weight` defaults to `familiarity / 100.0`.
+  Universe authors may override via NPC template.
+
+### FR-38.03 — GossipEvent Type
+
+A single unit of gossip traveling through the social graph:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `gossip_id` | ULID | Unique identifier. |
+| `universe_id` | ULID | Owning universe. |
+| `originating_episode_id` | ULID | The `NPCEpisodicMemory` that originated this gossip. |
+| `sender_npc_id` | str | NPC sending this gossip. |
+| `receiver_npc_id` | str | NPC receiving this gossip. |
+| `content` | str | Gossip text (may be distorted from original). |
+| `hop_count` | int | Number of NPC-to-NPC hops from the direct witness. |
+| `reliability` | float [0.0, 1.0] | `1.0` at hop-0 (direct), decrements 0.2 per hop. |
+| `session_id` | UUID | Session in which gossip was generated. |
+| `world_time_tick` | int | Tick at which gossip was generated. |
+| `created_at` | datetime | Wall-clock time. |
+
+### FR-38.04 — SocialMemoryWriter Contract
+
+```python
+async def record_episode(
+    npc_id: str,
+    universe_id: str,
+    session_id: UUID,
+    turn_number: int,
+    world_time: WorldTime,
+    content: str,
+    emotional_valence: float,
+    relationship_delta: RelationshipChange | None,
+    source_memory_id: str | None,
+    consequence_id: str | None,
+    is_gossip: bool,
+    gossip_source_npc_id: str | None,
+) -> NPCEpisodicMemory: ...
+
+async def propagate_gossip(
+    episode_id: str,
+    universe_id: str,
+    session_id: UUID,
+    world_time: WorldTime,
+    max_hops: int,
+) -> list[GossipEvent]: ...
+
+async def get_npc_context(
+    npc_id: str,
+    universe_id: str,
+    player_id: str,
+    budget_tokens: int,
+) -> NPCSocialContext: ...
+
+async def get_relationship(
+    npc_id: str,
+    target_id: str,
+    universe_id: str,
+) -> NPCSocialEdge | None: ...
+
+async def update_relationship(
+    npc_id: str,
+    target_id: str,
+    universe_id: str,
+    change: RelationshipChange,
+) -> NPCSocialEdge: ...
+```
+
+- **FR-38.04a**: `SocialMemoryWriter` MUST be injectable.
+  An `InMemorySocialMemoryWriter` MUST exist for unit testing.
+- **FR-38.04b**: `get_npc_context()` returns a `NPCSocialContext` containing:
+  the current `NPCSocialEdge` between this NPC and the player, a trimmed list
+  of `NPCEpisodicMemory` records sorted by `importance_score` descending, and
+  any `GossipEvent` records received by this NPC about the player.
+- **FR-38.04c**: `propagate_gossip()` is fire-and-forget (async, non-blocking).
+  It MUST NOT delay the current turn's generation pipeline.
+
+### FR-38.05 — Gossip Propagation Rules
+
+After `record_episode()` creates a direct experience (`is_gossip = False`):
+
+1. The `SocialMemoryWriter` queries the NPC's social neighbors: all NPCs connected
+   via `NPCSocialEdge` with `familiarity >= gossip_familiarity_threshold`
+   (default: 30, configurable via `universes.config["social"]["gossip_familiarity_threshold"]`).
+2. For each neighbor, a `GossipEvent` is created with `hop_count = 1`,
+   `reliability = 0.8`, and content distorted by a template rule (NOT an LLM call).
+3. The receiving NPC gains a new `NPCEpisodicMemory` via `record_episode()` with
+   `is_gossip = True`, `gossip_source_npc_id` set, and `importance_score` scaled
+   by `reliability`.
+4. Gossip propagates recursively up to `max_gossip_hops` (default: 2,
+   configurable via `universes.config["social"]["max_gossip_hops"]`).
+5. **Reliability floor**: gossip with `reliability < 0.2` is NOT propagated further.
+6. **No LLM calls in gossip propagation**: all distortion is template-based.
+   LLM summarization of gossip chains is deferred to a future spec.
+
+### FR-38.06 — Cross-Session Persistence
+
+| NPC Tier | Persistence Scope | Who Persists |
+|----------|------------------|--------------|
+| KEY | Universe-scoped | All `NPCEpisodicMemory` + `NPCSocialEdge` persisted to Neo4j universe node |
+| SUPPORTING | Universe-scoped | `NPCSocialEdge` persisted; episodic memory persisted for episodes with `importance_score >= 0.5` |
+| BACKGROUND | Session-scoped | No cross-session persistence |
+
+- **FR-38.06a**: At session start, KEY and SUPPORTING NPC relationships are loaded
+  from the universe's persistent graph.
+- **FR-38.06b**: At session end (or game state transition to `completed` or
+  `abandoned`), KEY and SUPPORTING NPC data is flushed to Neo4j.
+
+### FR-38.07 — Integration with S35 (NPC Autonomy)
+
+When `AutonomyProcessor.process()` (S35) generates `NarrativeEventAction` for an NPC
+(e.g., an NPC moves or changes disposition), the `SocialMemoryWriter` records an
+episodic memory for affected social neighbors if the action involves the player
+or changes a relationship dimension.
+
+### FR-38.08 — Integration with S36 (Consequence Propagation)
+
+When a `ConsequenceRecord` is received by an NPC via `ConsequencePropagator.propagate()`
+(S36), and the `ConsequenceRecord` references the player:
+
+1. `record_episode()` is called with `consequence_id` populated.
+2. `emotional_valence` is derived from the consequence severity:
+   - `critical` → ±0.8 (sign depends on event type)
+   - `major` → ±0.6
+   - `notable` → ±0.3
+   - `minor` → ±0.1
+3. `relationship_delta` is computed from the consequence type and applied.
+
+### FR-38.09 — NPCSocialContext Type
+
+The output of `get_npc_context()`, injected into dialogue generation context:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `npc_id` | str | The NPC. |
+| `player_id` | str | The player. |
+| `relationship` | NPCSocialEdge or null | Current relationship edge. |
+| `episodes` | list[NPCEpisodicMemory] | Trimmed, sorted by importance desc. |
+| `gossip_received` | list[GossipEvent] | Gossip events this NPC received about player. |
+| `total_tokens` | int | Estimated token count of this context. |
+| `dropped_count` | int | Episodes dropped to fit budget. |
+
+---
+
+## 5. Non-Functional Requirements
+
+### NFR-38.01 — record_episode() Latency
+`record_episode()` MUST complete in under 20 ms (p95), excluding async gossip propagation.
+
+### NFR-38.02 — get_npc_context() Latency
+`get_npc_context()` MUST complete in under 50 ms (p95) for an NPC with up to 200
+episodic memory records.
+
+### NFR-38.03 — Gossip Non-Blocking
+`propagate_gossip()` is async, fire-and-forget. It MUST NOT delay the turn pipeline
+by more than 5 ms.
+
+### NFR-38.04 — No LLM in Gossip Path
+Gossip propagation (FR-38.05) MUST NOT make LLM calls. Template-only distortion.
+This ensures gossip scales without LLM cost per hop.
+
+### NFR-38.05 — Observability
+Every `record_episode()` MUST emit a structlog event with `episode_id`, `npc_id`,
+`importance_score`, `is_gossip`, and `hop_count` (if gossip).
+Every `propagate_gossip()` run MUST emit `gossip_id`, `sender`, `receiver`,
+`hop_count`, and `reliability`.
+
+### NFR-38.06 — Test Coverage
+Unit tests MUST cover: importance scoring, gossip propagation to depth 2,
+reliability floor stopping propagation, cross-session KEY NPC relationship restore,
+BACKGROUND NPC no-persistence, S36 integration (consequence → episode), and
+budget trimming in `get_npc_context()`.
+
+---
+
+## 6. User Journeys
+
+### Journey 1: Player Betrays KEY NPC (Cross-Session Consequence)
+
+**Turn N**: Player chooses to betray Commander Vesh (KEY NPC, familiarity=60,
+trust=40). A `ConsequenceRecord` with severity `major` referencing the player is
+generated (S36).
+
+1. `record_episode()` called for Vesh: `emotional_valence = -0.6`,
+   `relationship_delta = RelationshipChange(trust=-20, affinity=-15, respect=-10)`.
+2. Episode stored in Neo4j under Vesh's universe node.
+3. Gossip propagation fires: Vesh's familiarity-30+ neighbors (3 NPCs) receive
+   `GossipEvent` (hop_count=1, reliability=0.8): "Vesh was betrayed by {player_name}".
+4. Those 3 NPCs gain episodic memories (`is_gossip=True`), relationship deltas applied.
+5. **Next session**: player loads the universe. Vesh's `RelationshipDimensions`
+   restored from Neo4j: trust=-20 from base. Vesh greets player coldly.
+   `get_npc_context()` returns Vesh's episodes — the betrayal event is visible to
+   the generation model, enabling specific dialogue.
+
+### Journey 2: Player's Reputation Travels (Gossip Propagation)
+
+**Turn 15**: Player rescues innkeeper Carla (SUPPORTING, familiarity=45) from bandits.
+Positive `ConsequenceRecord` (notable). `record_episode()` creates a positive
+episode for Carla: `emotional_valence = +0.3`, trust+10.
+
+1. Gossip propagation: Carla's neighbors include the blacksmith (familiarity=55)
+   and the merchant (familiarity=30 — exactly at threshold).
+2. Both receive `GossipEvent` (hop_count=1, reliability=0.8): "Carla says {player_name}
+   saved her from bandits."
+3. Blacksmith gossips further to the guard captain (familiarity=40):
+   hop_count=2, reliability=0.6, content distorted to "{player_name} drove off
+   some trouble near the inn."
+4. At hop_count=3, reliability would be 0.4 — still above 0.2 floor, but
+   `max_gossip_hops = 2` stops propagation here.
+5. When player meets the guard captain, `get_npc_context()` includes the hop-2
+   gossip event — captain's tone is slightly warmer (relationship delta scaled
+   by reliability: trust+5 × 0.6 = trust+3).
+
+### Journey 3: Budget-Trimmed NPC Context
+
+KEY NPC with 150 episodic memories. `get_npc_context(budget_tokens=1000)` called.
+
+1. `NPCSocialEdge` summary: ~100 tokens.
+2. Top-15 episodes by `importance_score` desc: ~700 tokens.
+3. Top-5 gossip events: ~200 tokens.
+4. Total: ~1000 tokens. `dropped_count = 135` episodes excluded.
+5. Generation model receives a focused, budget-compliant NPC context.
+
+---
+
+## 7. Edge Cases & Failure Modes
+
+| # | Scenario | Expected Behavior |
+|---|----------|-------------------|
+| E1 | `record_episode()` called for a BACKGROUND NPC | Stored in session memory only (not Neo4j persistent); no cross-session restore |
+| E2 | Gossip cycle: A gossips to B, B gossips to A | Idempotency: `originating_episode_id` check prevents recording the same gossip twice |
+| E3 | NPC's social neighbors all below familiarity threshold | No gossip events generated; log DEBUG |
+| E4 | Cross-session restore fails (Neo4j unavailable) | Use baseline `RelationshipDimensions` (all zeros); log WARNING; session continues |
+| E5 | `emotional_valence` supplied outside [-1.0, 1.0] | Clamp silently to range |
+| E6 | `get_npc_context()` called for NPC with no episodes | Return empty `NPCSocialContext` with null relationship |
+| E7 | Gossip loops through 3+ NPCs with same episode | `seen_episode_ids` set in propagation call prevents re-processing |
+| E8 | SUPPORTING NPC episode importance < 0.5 at session flush | Not persisted cross-session; log DEBUG |
+
+---
+
+## 8. Acceptance Criteria (Gherkin)
+
+```gherkin
+Feature: NPC Memory & Social Model
+
+  Background:
+    Given a universe with social config:
+      | gossip_familiarity_threshold | 30 |
+      | max_gossip_hops              | 2  |
+    And a KEY NPC "Vesh" with familiarity=60, trust=40
+    And a SUPPORTING NPC "Carla" with familiarity=45, trust=20
+    And a BACKGROUND NPC "Passerby" with familiarity=5
+
+  Scenario: AC-38.01 — Episodic memory is created with correct importance score
+    Given a direct player interaction with Vesh causing a major consequence
+    When SocialMemoryWriter.record_episode() is called
+    Then a NPCEpisodicMemory is created with is_gossip = False
+    And importance_score reflects the major consequence boost
+
+  Scenario: AC-38.02 — Gossip propagates to familiarity-threshold neighbors
+    Given Vesh has a direct episode from the player interaction
+    When propagate_gossip() fires
+    Then GossipEvents are created for Vesh's neighbors with familiarity >= 30
+    And each receiving NPC gains a NPCEpisodicMemory with is_gossip = True
+
+  Scenario: AC-38.03 — Gossip reliability decrements per hop
+    Given a hop-1 GossipEvent with reliability = 0.8
+    When that NPC propagates to a hop-2 neighbor
+    Then the resulting GossipEvent has reliability = 0.6
+
+  Scenario: AC-38.04 — Gossip stops at max_gossip_hops
+    Given a GossipEvent at hop_count = 2
+    When propagate_gossip() is called for the receiving NPC
+    Then no further GossipEvents are created
+
+  Scenario: AC-38.05 — Gossip stops at reliability floor
+    Given a GossipEvent with reliability below 0.2
+    When propagate_gossip() checks this event
+    Then no further GossipEvents are created
+
+  Scenario: AC-38.06 — KEY NPC episodes persist across sessions
+    Given Vesh has a NPCEpisodicMemory from session 1
+    When a new session 2 begins in the same universe
+    Then Vesh's RelationshipDimensions and episodic memories are restored
+
+  Scenario: AC-38.07 — BACKGROUND NPC has no cross-session memory
+    Given Passerby has an episode from session 1
+    When a new session 2 begins in the same universe
+    Then Passerby has no restored episodes
+    And Passerby's RelationshipDimensions start at zero
+
+  Scenario: AC-38.08 — S36 consequence triggers episode with emotional_valence
+    Given a critical ConsequenceRecord referencing the player arrives for Vesh
+    When SocialMemoryWriter processes the consequence
+    Then a NPCEpisodicMemory is created with emotional_valence = ±0.8
+    And the relationship delta is applied to Vesh's NPCSocialEdge
+```
+
+---
+
+## 9. Out of Scope
+
+- NPC-to-NPC relationships (other than gossip conduit): tracked in `NPCSocialEdge`
+  but emotional valence between NPCs (not involving the player) is deferred to v3+.
+- Multiplayer: one NPC remembering multiple players — deferred to v4+ (OQ-38.01).
+- LLM-assisted gossip distortion — deferred to a future spec.
+- Gossip about events NOT involving the player — deferred to v3+.
+- NPC-to-player direct memory sharing (NPCs tell the player what they heard) — this
+  is a generation/dialogue concern, not a memory model concern.
+
+---
+
+## 10. Open Questions
+
+| ID | Question | Status | Resolution |
+|---|----------|--------|------------|
+| OQ-38.01 | NPC memory in multiplayer (v4+): one NPC, multiple players — how does that work? | ⏳ Open | Deferred to v4+ as out of scope for v2.0. The `player_id` field in `NPCEpisodicMemory` explicitly supports one player per episode; multi-player extension will require per-player episode partitioning. |
+| OQ-38.02 | Should gossip distortion be template-only (FR-38.05) or LLM-assisted? | ✅ Resolved | **Template-only** for v2.0 (no LLM cost per hop). LLM-assisted gossip distortion deferred to a future enhancement. |
+| OQ-38.03 | Should `NPCSocialEdge` store NPC↔NPC relationships, or only NPC↔player? | ⏳ Open | Proposed: NPC↔NPC edges stored but only `familiarity` dimension populated in v2.0 (needed for gossip routing). Full five-axis NPC↔NPC relationships deferred to v3+. |
+
+---
+
+## Appendix A — Type Shapes
+
+```python
+from dataclasses import dataclass, field
+from datetime import datetime
+from tta.models.world import RelationshipDimensions, RelationshipChange
+
+@dataclass
+class NPCEpisodicMemory:
+    episode_id: str             # ULID
+    npc_id: str
+    universe_id: str
+    session_id: str             # UUID
+    turn_number: int
+    world_time_tick: int
+    source_memory_id: str | None
+    consequence_id: str | None
+    player_id: str
+    content: str
+    emotional_valence: float    # [-1.0, 1.0]
+    relationship_delta: RelationshipChange | None
+    importance_score: float     # [0.0, 1.0]
+    is_gossip: bool
+    gossip_source_npc_id: str | None
+    created_at: datetime = field(default_factory=lambda: datetime.now())
+
+@dataclass
+class NPCSocialEdge:
+    edge_id: str                # ULID
+    source_npc_id: str
+    target_id: str              # NPC ID or player ID
+    universe_id: str
+    dimensions: RelationshipDimensions = field(
+        default_factory=RelationshipDimensions
+    )
+    gossip_weight: float = 0.0  # familiarity / 100.0 by default
+    updated_at: datetime = field(default_factory=lambda: datetime.now())
+
+@dataclass
+class GossipEvent:
+    gossip_id: str              # ULID
+    universe_id: str
+    originating_episode_id: str
+    sender_npc_id: str
+    receiver_npc_id: str
+    content: str
+    hop_count: int
+    reliability: float          # [0.0, 1.0]; decrements 0.2/hop
+    session_id: str
+    world_time_tick: int
+    created_at: datetime = field(default_factory=lambda: datetime.now())
+```
+
+## Appendix B — Gossip Propagation Flowchart
+
+```
+record_episode(is_gossip=False)
+  │
+  └─► propagate_gossip() [async, fire-and-forget]
+        │
+        ├─► Query social neighbors where familiarity >= threshold
+        │
+        ├─► For each neighbor:
+        │     ├─► Create GossipEvent(hop_count=1, reliability=0.8)
+        │     ├─► Distort content via template
+        │     └─► record_episode(is_gossip=True, gossip_source=self)
+        │           │
+        │           └─► [recursive] propagate_gossip() if hop_count < max_hops
+        │                 │   AND reliability >= 0.2
+        │                 │   AND episode NOT already seen
+        │                 └─► ... (up to max_hops depth)
+        │
+        └─► Log all created GossipEvents
+```
+
+## Appendix C — Persistence by Tier
+
+```
+Session end / game state → completed|abandoned:
+
+  KEY NPC:
+    └─► ALL NPCEpisodicMemory → Neo4j (NPC node, universe-scoped)
+    └─► NPCSocialEdge (player↔npc, npc↔npc familiarity) → Neo4j
+
+  SUPPORTING NPC:
+    └─► NPCEpisodicMemory where importance_score >= 0.5 → Neo4j
+    └─► NPCSocialEdge (player↔npc) → Neo4j
+
+  BACKGROUND NPC:
+    └─► No persistence. In-session only.
+
+Session start / universe load:
+
+  KEY + SUPPORTING NPCs:
+    └─► NPCSocialEdge restored from Neo4j (→ RelationshipDimensions)
+    └─► Top-50 episodes by importance_score restored for KEY NPCs
+    └─► Top-20 episodes by importance_score restored for SUPPORTING NPCs
+```
+
+## Appendix D — Pipeline Position
+
+```
+Turn Pipeline (v2 Enrich stage):
+  1. Understand stage (parse intent)
+  2. AutonomyProcessor.process()          →  WorldDelta              [S35]
+  3. ConsequencePropagator.propagate()    →  PropagationResult       [S36]
+  4. MemoryWriter.record()                →  MemoryRecord[]          [S37]
+     └─► compress_if_needed() (async)
+  5. SocialMemoryWriter.record_episode()  →  NPCEpisodicMemory[]     [S38] ← THIS SPEC
+     └─► propagate_gossip() (async)
+  6. Context assembly: get_context()      →  MemoryContext
+                      get_npc_context()   →  NPCSocialContext[]
+  7. Generate stage
+  8. Stream stage
+```

--- a/specs/39-universe-composition-model.md
+++ b/specs/39-universe-composition-model.md
@@ -1,0 +1,552 @@
+# S39 — Universe Composition Model
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v2.0
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 2 — Simulation
+> **Dependencies**: S29 (Universe as First-Class Entity)
+> **Related**: S33 (Universe Persistence), S34 (Diegetic Time), S40 (Genesis v2), S41 (Scenario Seed Library, v2.1+)
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+In v1, a "universe" is a session's implicit backdrop with no explicit content
+identity — no themes, no genre, no stylistic fingerprint. Two sessions using the
+same template are indistinguishable at the engine level; there is no schema
+governing what content a universe is *supposed to contain*.
+
+S29 introduced the `Universe` entity and reserved a `config` field (opaque JSON)
+for future use. S33 provides the persistence mechanism. **S39 fills the `config`
+field with a first-class content vocabulary.**
+
+The Universe Composition Model defines:
+- The JSON schema for `universes.config` (the four composition layers: themes,
+  tropes, archetypes, genre-twists)
+- The `UniverseComposition` type that the engine parses from `config`
+- Seedability: deterministic universe generation given (seed, composition)
+- Reserved config namespaces for S36, S37, S38, and S40 subsystems
+- Validation rules enforced at creation and config update time
+
+S39 is the primitive that makes parallel universes **distinctly identifiable**,
+supports the Scenario Seed Library (S41, v2.1+), and is the foundation for the
+Resonance Correlation Engine (S56, v4+).
+
+---
+
+## 2. Design Philosophy
+
+### 2.1 S29 / S33 / S39 Are Orthogonal
+
+Per the v2 design note in S29 §1:
+- **S29** — *Identity*: a universe has an ID and boundary.
+- **S33** — *Persistence*: a versioned envelope for storing universe state.
+- **S39** — *Composition*: the content vocabulary that fills a universe.
+
+S39's schema MAY evolve without requiring S33 schema migrations, because S29
+stores `config` as an opaque JSON blob. S39 versions its own composition schema
+using a `composition_version` key inside the blob.
+
+### 2.2 Four Composition Layers
+
+A universe composition is defined by four combinable layers:
+
+| Layer | Description | Max Entries (default) |
+|-------|-------------|----------------------|
+| **Themes** | High-level tonal/thematic qualities | 5 |
+| **Tropes** | Narrative patterns and plot primitives | 10 |
+| **Archetypes** | Character role types the world supports | 8 |
+| **Genre-twists** | Modifiers that bend the primary genre | 3 |
+
+Layers are additive and composable. An empty layer is valid (defaults apply).
+
+### 2.3 Determinism
+
+Given the same `seed` + same composition config JSON, the universe MUST generate
+the same world state deterministically. This enables:
+- Playtester reproducibility (run the same scenario twice, compare results)
+- Debugging (reproduce a specific world for inspection)
+- Scenario Seed Library distribution (S41 bundles are seed + config pairs)
+
+The `seed` is a 64-bit unsigned integer stored in `config["seed"]`. It is set
+at universe creation (genesis, S40) and MUST NOT change after first session open.
+
+### 2.4 Opaque Subsystem Namespaces
+
+Config keys under reserved namespaces are consumed by specific subsystems:
+
+| Namespace | Consumed By |
+|-----------|-------------|
+| `config["memory"]` | S37 (World Memory Model) |
+| `config["propagation"]` | S36 (Consequence Propagation) |
+| `config["social"]` | S38 (NPC Social) |
+| `config["time"]` | S34 (Diegetic Time) |
+| `config["genesis"]` | S40 (Genesis v2) |
+| `config["composition"]` | S39 (this spec) |
+
+---
+
+## 3. User Stories
+
+> **US-39.1** — **As a** universe author, I can define a universe as a gothic horror
+> story with themes of decay and redemption, the "corrupted_mentor" archetype,
+> and a noir genre-twist — all in a single composable config.
+
+> **US-39.2** — **As a** playtester, I can reproduce the exact universe I played
+> yesterday by sharing the seed + config, guaranteeing the same generated world.
+
+> **US-39.3** — **As a** developer, the engine validates a universe config at creation
+> time, failing loudly if I specify an unknown theme or a trope weight outside
+> the valid range.
+
+> **US-39.4** — **As a** scenario author (S41), I can bundle a curated set of
+> themes, tropes, archetypes, and genre-twists into a named scenario seed that
+> other authors and players can use as a starting point.
+
+> **US-39.5** — **As a** universe author, I can configure diegetic time, memory
+> compression, and NPC gossip thresholds in the same config blob, keeping all
+> universe-level settings in one place.
+
+---
+
+## 4. Functional Requirements
+
+### FR-39.01 — UniverseComposition Type
+
+The parsed, validated representation of a universe's `config["composition"]` block:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `composition_version` | str | `"1.0"` | Schema version for forward-compat migration. |
+| `seed` | int (uint64) | random | Deterministic generation seed. Set at creation; immutable. |
+| `primary_genre` | str | `"fantasy"` | The baseline genre of the universe. |
+| `themes` | list[ThemeSpec] | `[]` | Thematic qualities. Up to 5. |
+| `tropes` | list[TropeSpec] | `[]` | Narrative patterns. Up to 10. |
+| `archetypes` | list[ArchetypeSpec] | `[]` | Character role types. Up to 8. |
+| `genre_twists` | list[GenreTwist] | `[]` | Genre modifiers. Up to 3. |
+| `prose` | ProseConfig | default | Prose voice and style. |
+| `tone` | ToneProfile | derived | Aggregated tone (derived from themes + genre_twists). |
+
+### FR-39.02 — ThemeSpec Type
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | str | Theme identifier (e.g., `"redemption"`, `"cosmic_horror"`). |
+| `weight` | float [0.0, 1.0] | Narrative weight; higher = more pervasive. Default: `0.5`. |
+| `description` | str or null | Optional human-readable label. |
+
+### FR-39.03 — TropeSpec Type
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | str | Trope identifier (e.g., `"chosen_one"`, `"betrayal_within"`). |
+| `weight` | float [0.0, 1.0] | How often this trope manifests. Default: `0.5`. |
+| `required` | bool | If true, this trope MUST manifest at least once in the narrative. |
+| `description` | str or null | Optional human-readable label. |
+
+### FR-39.04 — ArchetypeSpec Type
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | str | Archetype identifier (e.g., `"trickster_guide"`, `"threshold_guardian"`). |
+| `npc_tier` | str | The NPC tier that SHOULD embody this archetype: `"key"`, `"supporting"`. |
+| `description` | str or null | Optional human-readable label. |
+
+### FR-39.05 — GenreTwist Type
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | str | Twist identifier (e.g., `"noir_fantasy"`, `"cozy_dark"`, `"mundane_cosmic"`). |
+| `strength` | float [0.0, 1.0] | How strongly the twist colours the universe. Default: `0.5`. |
+| `description` | str or null | Optional human-readable label. |
+
+### FR-39.06 — ProseConfig Type
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `voice` | str | `"default"` | Prose voice identifier (e.g., `"hardboiled"`, `"lyrical"`, `"terse"`). |
+| `pacing` | str | `"balanced"` | Pacing hint: `"slow"`, `"balanced"`, `"fast"`. |
+| `description_density` | str | `"medium"` | Scene description density: `"sparse"`, `"medium"`, `"rich"`. |
+| `second_person` | bool | `true` | Whether to narrate in second-person ("You enter…"). |
+
+### FR-39.07 — ToneProfile Type
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `primary` | str | Dominant tone (e.g., `"dark"`, `"hopeful"`, `"comedic"`). |
+| `secondary` | str or null | Secondary tone modifier. |
+| `warmth` | float [0.0, 1.0] | 0.0 = cold/grim, 1.0 = warm/hopeful. Derived from themes. |
+| `intensity` | float [0.0, 1.0] | 0.0 = gentle, 1.0 = intense. Derived from trope weights. |
+
+- **FR-39.07a**: `ToneProfile` is derived from the rest of `UniverseComposition`.
+  It is computed at load time, not stored. Universe authors MAY override `primary`
+  and `secondary` directly; `warmth` and `intensity` are always computed.
+
+### FR-39.08 — Config Namespace Schema
+
+The full `universes.config` object has this top-level structure:
+
+```json
+{
+  "composition": { ... },
+  "seed": 12345678901234567,
+  "memory": { "working_memory_size": 5, "compression_threshold_tokens": 4000, ... },
+  "propagation": { "max_propagation_depth": 3, "min_propagation_severity": "notable", ... },
+  "social": { "gossip_familiarity_threshold": 30, "max_gossip_hops": 2 },
+  "time": { "ticks_per_turn": 1, "seconds_per_tick": 3600, ... },
+  "genesis": { "narrator_phase": "void", ... }
+}
+```
+
+- **FR-39.08a**: The `seed` key lives at the top level of `config` (not inside
+  `composition`), so it is accessible without parsing the composition block.
+- **FR-39.08b**: All subsystem namespace keys (`memory`, `propagation`, `social`,
+  `time`, `genesis`) are optional. Each subsystem uses its own defaults if the
+  key is absent.
+- **FR-39.08c**: Unknown top-level keys MUST be preserved and ignored
+  (forward-compat rule inherited from S29 FR-29.08a).
+
+### FR-39.09 — CompositionValidator
+
+A `CompositionValidator` is called:
+1. At universe creation (S40 genesis flow)
+2. When `config` is updated via the admin API (S26)
+
+Validation rules:
+- `composition_version` MUST be a recognized version string.
+- `themes` MUST have ≤ 5 entries (configurable via
+  `universes.config["composition"]["max_themes"]`, default 5).
+- `tropes` MUST have ≤ 10 entries (default max).
+- `archetypes` MUST have ≤ 8 entries (default max).
+- `genre_twists` MUST have ≤ 3 entries (default max).
+- All `weight`/`strength` fields MUST be in [0.0, 1.0].
+- `npc_tier` in ArchetypeSpec MUST be `"key"` or `"supporting"`.
+- `pacing` MUST be one of `["slow", "balanced", "fast"]`.
+- `description_density` MUST be one of `["sparse", "medium", "rich"]`.
+- Theme/trope/archetype/genre-twist `name` values MUST be lowercase_underscore
+  identifiers (regex: `^[a-z][a-z0-9_]*$`). Unknown names are allowed (open
+  vocabulary) — S41 will define a canonical library.
+
+Validation failure raises `CompositionValidationError` (a subclass of
+`TemplateValidationError` from the v1 template registry).
+
+### FR-39.10 — Composition Context Injection
+
+At context assembly time (before generation), the `UniverseComposition` is
+serialized to a concise prompt fragment injected as `"universe_composition"`
+in the generation context. The fragment MUST include:
+- Primary genre
+- Active themes (name + weight ≥ 0.4)
+- Required tropes (`required = true`)
+- Prose voice and pacing
+- Primary tone
+
+The full composition is NOT injected verbatim — only the above subset.
+Universe authors may set `prose.description_density = "rich"` to get more
+detail injected (trope list, archetype list).
+
+### FR-39.11 — Seed Immutability
+
+The `seed` value in `universes.config` is set once at universe creation.
+Any subsequent admin `PATCH /admin/universes/{id}` that attempts to change
+the `seed` MUST be rejected with HTTP 409 and error category `state_conflict`.
+
+### FR-39.12 — Empty Config Is Valid
+
+An empty `config = {}` is always valid (S29 AC-29.11 requirement). When
+`config["composition"]` is absent, a default `UniverseComposition` with
+no themes, tropes, archetypes, or genre-twists is used. The `seed` is
+automatically populated at first session open if absent.
+
+---
+
+## 5. Non-Functional Requirements
+
+### NFR-39.01 — Validation Latency
+`CompositionValidator.validate()` MUST complete in under 5 ms.
+
+### NFR-39.02 — Parse Latency
+Parsing `UniverseComposition` from `config` MUST complete in under 2 ms.
+
+### NFR-39.03 — Observability
+Every `CompositionValidator.validate()` call MUST emit a structlog event with
+`universe_id`, `composition_version`, and `validation_result` (`ok` or `error`).
+
+### NFR-39.04 — Test Coverage
+Unit tests MUST cover: valid full composition, empty composition (defaults),
+all validation error paths (each rule), seed immutability rejection,
+ToneProfile derivation, and context injection fragment correctness.
+
+---
+
+## 6. User Journeys
+
+### Journey 1: Author Creates a Gothic Horror Universe
+
+Universe author POSTs to `POST /admin/universes` with:
+```json
+{
+  "name": "The Hollow Court",
+  "config": {
+    "composition": {
+      "composition_version": "1.0",
+      "primary_genre": "gothic_horror",
+      "themes": [
+        {"name": "decay", "weight": 0.8},
+        {"name": "redemption", "weight": 0.4}
+      ],
+      "tropes": [
+        {"name": "corrupted_bloodline", "weight": 0.7, "required": true},
+        {"name": "unreliable_narrator", "weight": 0.5}
+      ],
+      "archetypes": [
+        {"name": "corrupted_mentor", "npc_tier": "key"},
+        {"name": "threshold_guardian", "npc_tier": "supporting"}
+      ],
+      "genre_twists": [
+        {"name": "cozy_dark", "strength": 0.3}
+      ],
+      "prose": {
+        "voice": "lyrical",
+        "pacing": "slow",
+        "description_density": "rich"
+      }
+    },
+    "memory": {"compression_threshold_tokens": 6000}
+  }
+}
+```
+
+1. `CompositionValidator.validate()` runs — all rules pass.
+2. A random `seed` is generated and stored in `config["seed"]`.
+3. `ToneProfile` is derived: `primary = "dark"`, `warmth = 0.25`, `intensity = 0.7`.
+4. Universe persisted to Postgres. Config blob stored intact.
+
+### Journey 2: Playtester Reproduces a Session
+
+1. Playtester notes `seed = 9182736450` from their session's universe.
+2. Admin creates a new universe with the same config blob + `seed = 9182736450`.
+3. First session opened on this universe generates identical world state.
+4. Playtester can compare narratives across two sessions with identical inputs.
+
+### Journey 3: Context Assembly Injects Composition Fragment
+
+At generation time, the context assembler calls `get_composition_context()`:
+
+```
+Genre: gothic_horror
+Themes: decay (strong), redemption (mild)
+Required tropes: corrupted_bloodline
+Prose voice: lyrical | pacing: slow | description: rich
+Tone: dark (warm=0.25, intensity=0.7)
+```
+
+This fragment is prepended to the generation system prompt, biasing the LLM
+toward appropriate style and content.
+
+---
+
+## 7. Edge Cases & Failure Modes
+
+| # | Scenario | Expected Behavior |
+|---|----------|-------------------|
+| E1 | `config["composition"]` is absent | Use default `UniverseComposition`; auto-generate seed at first session open |
+| E2 | Theme count exceeds max (>5) | `CompositionValidationError` at creation/update |
+| E3 | Unknown theme name | Allowed; logged DEBUG; open vocabulary |
+| E4 | Admin attempts to change `seed` | HTTP 409 `state_conflict` |
+| E5 | `pacing = "warp-speed"` (invalid) | `CompositionValidationError` |
+| E6 | `weight = 1.5` (out of range) | `CompositionValidationError` |
+| E7 | `config` is a JSON array (not object) | Rejected at S29 level (FR-29.08a requires object); `CompositionValidationError` |
+| E8 | Empty `themes = []`, empty `tropes = []` | Valid; default composition with no thematic bias |
+
+---
+
+## 8. Acceptance Criteria (Gherkin)
+
+```gherkin
+Feature: Universe Composition Model
+
+  Scenario: AC-39.01 — Full composition is validated and stored
+    Given a valid universe creation payload with themes, tropes, archetypes, genre_twists
+    When POST /admin/universes is called
+    Then the universe is created with a seed populated in config
+    And CompositionValidator emits a validation_result = "ok" log event
+
+  Scenario: AC-39.02 — Empty config uses default composition
+    Given a universe creation with config = {}
+    When the first session is opened
+    Then a seed is generated and stored in config["seed"]
+    And composition defaults apply (no themes, no tropes, primary_genre = "fantasy")
+
+  Scenario: AC-39.03 — Too many themes fails validation
+    Given a composition with 6 theme entries
+    When CompositionValidator.validate() is called
+    Then a CompositionValidationError is raised
+    And the error message references the max_themes limit
+
+  Scenario: AC-39.04 — Weight out of range fails validation
+    Given a theme with weight = 1.5
+    When CompositionValidator.validate() is called
+    Then a CompositionValidationError is raised
+
+  Scenario: AC-39.05 — Seed is immutable after creation
+    Given universe U1 with seed = 9182736450
+    When admin attempts PATCH /admin/universes/U1 with config["seed"] = 99
+    Then the response is HTTP 409
+    And the error category is "state_conflict"
+
+  Scenario: AC-39.06 — ToneProfile is derived from themes
+    Given a composition with themes ["cosmic_horror" weight=0.9, "existential_dread" weight=0.8]
+    When UniverseComposition is parsed
+    Then ToneProfile.warmth is low (< 0.3)
+    And ToneProfile.intensity is high (> 0.7)
+
+  Scenario: AC-39.07 — Composition context fragment injected at generation time
+    Given a universe with primary_genre = "gothic_horror" and prose.voice = "lyrical"
+    When get_composition_context() is called
+    Then the fragment includes "gothic_horror" and "lyrical"
+
+  Scenario: AC-39.08 — Subsystem config namespaces are preserved
+    Given a universe with config["memory"]["compression_threshold_tokens"] = 6000
+    When the universe config is retrieved
+    Then config["memory"]["compression_threshold_tokens"] equals 6000
+```
+
+---
+
+## 9. Out of Scope
+
+- Canonical theme/trope/archetype library — that is S41 (Scenario Seed Library, v2.1+).
+- User-generated seeds and community sharing — deferred to S63 (v5+).
+- Theme weighting affecting NPC trait generation — generation prompt concern.
+- Resonance correlation between universes based on shared themes — S56 (v4+).
+- Composition diff/merge tooling — admin tooling concern, future spec.
+
+---
+
+## 10. Open Questions
+
+| ID | Question | Status | Resolution |
+|---|----------|--------|------------|
+| OQ-39.01 | Universe deterministic given (seed, config)? | ✅ Resolved | **Yes, deterministic.** `seed` is stored immutably at creation and governs all stochastic world generation. Enables playtester reproducibility and scenario seed sharing (S41). |
+| OQ-39.02 | Where does `seed` live — inside `composition` or at `config` top-level? | ✅ Resolved | **Top-level** (`config["seed"]`), not inside `composition`. This makes seed accessible without parsing the composition block, and aligns with S29's intent. |
+| OQ-39.03 | Theme/trope name validation — closed enum (must be in S41 library) or open vocabulary? | ✅ Resolved | **Open vocabulary** in v2.0. Unknown names are logged and allowed; S41 defines the canonical library. Closed-enum enforcement deferred to v2.1 when S41 exists. |
+| OQ-29.01 | Does `config: {}` have semantic meaning ("use platform defaults"), or must S39 always pre-populate content? | ✅ Resolved (from S29) | Empty config is always valid. Defaults apply. Seed is auto-populated at first session open if absent. |
+
+---
+
+## Appendix A — UniverseComposition Dataclass Shape
+
+```python
+from dataclasses import dataclass, field
+from typing import Literal
+
+@dataclass
+class ThemeSpec:
+    name: str
+    weight: float = 0.5         # [0.0, 1.0]
+    description: str | None = None
+
+@dataclass
+class TropeSpec:
+    name: str
+    weight: float = 0.5         # [0.0, 1.0]
+    required: bool = False
+    description: str | None = None
+
+@dataclass
+class ArchetypeSpec:
+    name: str
+    npc_tier: Literal["key", "supporting"] = "supporting"
+    description: str | None = None
+
+@dataclass
+class GenreTwist:
+    name: str
+    strength: float = 0.5       # [0.0, 1.0]
+    description: str | None = None
+
+@dataclass
+class ProseConfig:
+    voice: str = "default"
+    pacing: Literal["slow", "balanced", "fast"] = "balanced"
+    description_density: Literal["sparse", "medium", "rich"] = "medium"
+    second_person: bool = True
+
+@dataclass
+class ToneProfile:
+    primary: str = "neutral"
+    secondary: str | None = None
+    warmth: float = 0.5         # derived
+    intensity: float = 0.5      # derived
+
+@dataclass
+class UniverseComposition:
+    composition_version: str = "1.0"
+    primary_genre: str = "fantasy"
+    themes: list[ThemeSpec] = field(default_factory=list)
+    tropes: list[TropeSpec] = field(default_factory=list)
+    archetypes: list[ArchetypeSpec] = field(default_factory=list)
+    genre_twists: list[GenreTwist] = field(default_factory=list)
+    prose: ProseConfig = field(default_factory=ProseConfig)
+    tone: ToneProfile = field(default_factory=ToneProfile)
+
+    @classmethod
+    def from_config(cls, config: dict) -> "UniverseComposition":
+        comp = config.get("composition", {})
+        # parse + validate; return instance or raise CompositionValidationError
+        ...
+
+    def get_context_fragment(self) -> str:
+        """Returns the concise prompt fragment for context injection."""
+        ...
+```
+
+## Appendix B — Config Namespace Reference
+
+```
+universes.config (top-level keys):
+
+  seed                   uint64   Deterministic generation seed. Immutable.       [S39]
+  composition            object   UniverseComposition schema.                      [S39]
+  memory                 object   World Memory Model config.                       [S37]
+    working_memory_size    int      Default: 5
+    compression_threshold_tokens  int  Default: 4000
+    compression_importance_threshold  float  Default: 0.5
+    memory_half_life_ticks  int    Default: 50
+  propagation            object   Consequence Propagation config.                  [S36]
+    max_propagation_depth  int      Default: 3
+    min_propagation_severity  str  Default: "notable"
+  social                 object   NPC Social config.                               [S38]
+    gossip_familiarity_threshold  int  Default: 30
+    max_gossip_hops        int      Default: 2
+  time                   object   Diegetic Time config.                            [S34]
+    ticks_per_turn         int      Default: 1
+    seconds_per_tick       int      Default: 3600
+  genesis                object   Genesis v2 config.                               [S40]
+    narrator_phase         str      Default: "void"
+```
+
+## Appendix C — Relationship to S41 (Scenario Seed Library)
+
+S41 (v2.1) will define a library of named scenario seeds. Each seed is a
+tuple of `(name, config_blob)` where `config_blob` contains a pre-filled
+`composition` block (themes, tropes, archetypes, genre-twists) and subsystem
+config overrides. S41 seeds are directly usable as `universes.config` values.
+
+Example S41 seed (non-normative):
+```json
+{
+  "seed": "dirty_frodo",
+  "config": {
+    "seed": 1234567890,
+    "composition": {
+      "primary_genre": "epic_fantasy",
+      "themes": [{"name": "corruption_of_power", "weight": 0.9}],
+      "genre_twists": [{"name": "noir_detective", "strength": 0.6}],
+      "prose": {"voice": "hardboiled", "pacing": "balanced"}
+    }
+  }
+}
+```

--- a/specs/39-universe-composition-model.md
+++ b/specs/39-universe-composition-model.md
@@ -82,6 +82,7 @@ Config keys under reserved namespaces are consumed by specific subsystems:
 | `config["propagation"]` | S36 (Consequence Propagation) |
 | `config["social"]` | S38 (NPC Social) |
 | `config["time"]` | S34 (Diegetic Time) |
+| `config["autonomy"]` | S35 (NPC Autonomy) |
 | `config["genesis"]` | S40 (Genesis v2) |
 | `config["composition"]` | S39 (this spec) |
 
@@ -114,12 +115,13 @@ Config keys under reserved namespaces are consumed by specific subsystems:
 
 ### FR-39.01 — UniverseComposition Type
 
-The parsed, validated representation of a universe's `config["composition"]` block:
+The parsed, validated representation of a universe's `config["composition"]` block.
+The deterministic universe seed is defined separately at top-level `config["seed"]`
+and is not part of `UniverseComposition`.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `composition_version` | str | `"1.0"` | Schema version for forward-compat migration. |
-| `seed` | int (uint64) | random | Deterministic generation seed. Set at creation; immutable. |
 | `primary_genre` | str | `"fantasy"` | The baseline genre of the universe. |
 | `themes` | list[ThemeSpec] | `[]` | Thematic qualities. Up to 5. |
 | `tropes` | list[TropeSpec] | `[]` | Narrative patterns. Up to 10. |
@@ -194,7 +196,7 @@ The full `universes.config` object has this top-level structure:
   "memory": { "working_memory_size": 5, "compression_threshold_tokens": 4000, ... },
   "propagation": { "max_propagation_depth": 3, "min_propagation_severity": "notable", ... },
   "social": { "gossip_familiarity_threshold": 30, "max_gossip_hops": 2 },
-  "time": { "ticks_per_turn": 1, "seconds_per_tick": 3600, ... },
+  "time": { "ticks_per_turn": 1, "minutes_per_tick": 60, ... },
   "genesis": { "narrator_phase": "void", ... }
 }
 ```

--- a/specs/README.md
+++ b/specs/README.md
@@ -119,7 +119,7 @@ for the full roadmap rationale, dependency graph, and open questions per spec.
 | [S35](35-npc-autonomy-between-turns.md) | NPC Autonomy Between Turns | Off-screen NPC goals, routines, salience filter (no LangGraph) |
 | [S36](36-consequence-propagation.md) | Consequence Propagation | Effect ripple via graph-walk, bounded depth, rumor distortion |
 | [S37](37-world-memory-model.md) | World Memory Model | Canon events, decay, compression, structured attributed memory |
-| S38 | NPC Memory Model | Per-NPC episodic memory; relationship-graph arcs; v4+ multiplayer hook |
+| [S38](38-npc-memory-and-social-model.md) | NPC Memory & Social Model | Per-NPC episodic memory; relationship-graph arcs; gossip propagation; v4+ multiplayer hook |
 | S39 | Universe Composition Model | Themes, tropes, archetypes, genre-twists; composable, seedable, deterministic from (seed, config) |
 | S40 | Genesis v2 | 7-phase world-creation; consumes S39 composition vocabulary |
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -120,7 +120,7 @@ for the full roadmap rationale, dependency graph, and open questions per spec.
 | [S36](36-consequence-propagation.md) | Consequence Propagation | Effect ripple via graph-walk, bounded depth, rumor distortion |
 | [S37](37-world-memory-model.md) | World Memory Model | Canon events, decay, compression, structured attributed memory |
 | [S38](38-npc-memory-and-social-model.md) | NPC Memory & Social Model | Per-NPC episodic memory; relationship-graph arcs; gossip propagation; v4+ multiplayer hook |
-| S39 | Universe Composition Model | Themes, tropes, archetypes, genre-twists; composable, seedable, deterministic from (seed, config) |
+| [S39](39-universe-composition-model.md) | Universe Composition Model | Themes, tropes, archetypes, genre-twists; composable, seedable, deterministic from (seed, config) |
 | S40 | Genesis v2 | 7-phase world-creation; consumes S39 composition vocabulary |
 
 ### v2.1 — "Prove It's Fun" (S41–S45)

--- a/specs/README.md
+++ b/specs/README.md
@@ -111,10 +111,10 @@ for the full roadmap rationale, dependency graph, and open questions per spec.
 | # | Name | Description |
 |---|------|-------------|
 | S29 | [Universe as First-Class Entity](29-universe-as-first-class-entity.md) | Universe identity, config, persistent state — not a session appendage |
-| S30 | Session↔Universe Binding | Explicit 1:1 binding contract; schema permits n:1 for v4+ |
-| S31 | Actor Identity Portability | Actor IDs universe-agnostic; unblocks cross-universe travel |
+| [S30](30-session-universe-binding.md) | Session↔Universe Binding | Explicit 1:1 binding contract; schema permits n:1 for v4+ |
+| [S31](31-actor-identity-portability.md) | Actor Identity Portability | Actor IDs universe-agnostic; unblocks cross-universe travel |
 | S32 | Transport Abstraction | `NarrativeTransport` interface; SSE as first impl, WebSocket-ready |
-| S33 | Universe Persistence Schema | Versioned forward-compat state envelope; enables universe reload |
+| [S33](33-universe-persistence-schema.md) | Universe Persistence Schema | Versioned forward-compat state envelope; enables universe reload |
 | S34 | Diegetic Time | In-world clock; day/night cycles, scene transitions, skip-ahead |
 | S35 | NPC Autonomy Between Turns | Off-screen NPC goals, routines, salience filter (no LangGraph) |
 | S36 | Consequence Propagation | Effect ripple via graph-walk, bounded depth, rumor distortion |

--- a/specs/README.md
+++ b/specs/README.md
@@ -99,6 +99,79 @@ S00 (Charter)
  └── S18-S22 (Future) ← Stubs, boundary constraints only
 ```
 
+## Reserved Spec IDs — v2+ (Post-v1 Roadmap)
+
+IDs S29–S63 are reserved for post-v1 releases. They are not yet full specs; they
+will be drafted via individual brainstorm sessions following the SDD workflow.
+See [`docs/superpowers/specs/2026-04-21-v2-v3-roadmap-design.md`](../docs/superpowers/specs/2026-04-21-v2-v3-roadmap-design.md)
+for the full roadmap rationale, dependency graph, and open questions per spec.
+
+### v2.0 — "Believable Simulation" (S29–S40)
+
+| # | Name | Description |
+|---|------|-------------|
+| S29 | [Universe as First-Class Entity](29-universe-as-first-class-entity.md) | Universe identity, config, persistent state — not a session appendage |
+| S30 | Session↔Universe Binding | Explicit 1:1 binding contract; schema permits n:1 for v4+ |
+| S31 | Actor Identity Portability | Actor IDs universe-agnostic; unblocks cross-universe travel |
+| S32 | Transport Abstraction | `NarrativeTransport` interface; SSE as first impl, WebSocket-ready |
+| S33 | Universe Persistence Schema | Versioned forward-compat state envelope; enables universe reload |
+| S34 | Diegetic Time | In-world clock; day/night cycles, scene transitions, skip-ahead |
+| S35 | NPC Autonomy Between Turns | Off-screen NPC goals, routines, salience filter (no LangGraph) |
+| S36 | Consequence Propagation | Effect ripple via graph-walk, bounded depth, rumor distortion |
+| S37 | World Memory Model | Canon events, decay, compression, structured attributed memory |
+| S38 | NPC Memory Model | Per-NPC episodic memory; relationship-graph arcs; v4+ multiplayer hook |
+| S39 | Universe Composition Model | Themes, tropes, archetypes, genre-twists; composable, seedable, deterministic from (seed, config) |
+| S40 | Genesis v2 | 7-phase world-creation; consumes S39 composition vocabulary |
+
+### v2.1 — "Prove It's Fun" (S41–S45)
+
+| # | Name | Description |
+|---|------|-------------|
+| S41 | Scenario Seed Library | Curated/community scenario seeds; YAML/JSON format; discovery registry |
+| S42 | LLM Playtester Agent Harness | LLM-persona agents; semi-randomized taste profiles; end-to-end session runs; transcript + commentary |
+| S43 | Human Playtester Program | Recruitment, consent, NDA; structured feedback protocol |
+| S44 | Narrative Quality Evaluation | Scoring rubric; 0–1 normalisation; LLM + human signal weighting |
+| S45 | Evaluation Pipeline | Orchestration of parallel LLM-playtester runs; human-playtester intake; result aggregation; CI thresholds |
+
+### v3 — "Ship It" (S46–S49)
+
+| # | Name | Description |
+|---|------|-------------|
+| S46 | Cloud Deployment v2 | Fly.io / Cloud Run; live-DB CI; TLS; secrets rotation |
+| S47 | Live Neo4j in CI | Ephemeral Neo4j per test run; replaces mocked integration tests; fixture setup/teardown |
+| S48 | Async Job Runner | Job queue + worker for GDPR deletion, retention sweeps, backfills; worker permitted alongside FastAPI process |
+| S49 | Horizontal Scaling | Session affinity policy; Redis cluster; load-balancer config |
+
+### v4+ — "Multiverse Unlock" (S50–S59)
+
+| # | Name | Description |
+|---|------|-------------|
+| S50 | Concurrent Universe Loading | Two or more universes resident in memory simultaneously; resource-budget rules, eviction policy, isolation guarantees |
+| S51 | Cross-Universe Travel Protocol | Actor movement from Universe A to Universe B; trigger conditions, state-transfer rules, arrival onboarding |
+| S52 | Nexus as Special Universe | Nexus modeled as a universe whose composition permits inhabitants from any other universe; no engine-level hub special case |
+| S53 | Nexus Access Rules | Narrative triggers and gating for reaching the Nexus; the *story* of why players find it, separate from its mechanics (S52) |
+| S54 | Inter-Universe Event Substrate | Communication bus between loaded universes; pure primitive, no semantics; delivery guarantees and ordering rules |
+| S55 | Bleedthrough Propagation Rules | Semantics of subtle inter-universe influence on S54; weather anomalies, rumors, echoes; probabilistic distortion rules |
+| S56 | Resonance Correlation Engine | Thematic echoes: a choice in Universe A biases narrative weight in Universe B along shared S39 themes; correlation rules, strength decay |
+| S57 | Multi-Actor Universe Model | Multiple actors coexist in one universe; promotes v1 S21; shared world-state semantics, per-actor narrative perspective |
+| S58 | Turn Conflict Resolution | Simultaneous/contradictory actor actions; ordering rules, priority, narrative reconciliation |
+| S59 | Multiplayer Transport | WebSocket implementation of S32 `NarrativeTransport` interface; session-level sync, presence, reconnection |
+
+### v5+ — "Long Vision" (S60–S63, promotes v1 stubs)
+
+| # | Promotes | Description |
+|---|----------|-------------|
+| S60 | v1 S19 Crisis Safety | **Gate** for S61. Crisis detection, escalation, clinician-notify |
+| S61 | v1 S18 Therapeutic Framework | CBT + Mindfulness MVP; therapeutic annotation layer |
+| S62 | v1 S20 Story Sharing | PDF/ePub/web export; consent model; public story library |
+| S63 | v1 S22 Community | User-generated world templates; moderation; attribution |
+
+> **Note**: v1 stubs S18–S22 remain frozen at `specs/future/` until the relevant
+> v5+ spec is drafted. S21 is **not** promoted via this table; it is superseded by
+> S57–S59 (v4+) which provide a more complete multiplayer foundation.
+
+---
+
 ## Conventions
 
 - Specs are **behavior-focused**, not implementation-prescriptive

--- a/specs/README.md
+++ b/specs/README.md
@@ -113,7 +113,7 @@ for the full roadmap rationale, dependency graph, and open questions per spec.
 | S29 | [Universe as First-Class Entity](29-universe-as-first-class-entity.md) | Universe identity, config, persistent state — not a session appendage |
 | [S30](30-session-universe-binding.md) | Session↔Universe Binding | Explicit 1:1 binding contract; schema permits n:1 for v4+ |
 | [S31](31-actor-identity-portability.md) | Actor Identity Portability | Actor IDs universe-agnostic; unblocks cross-universe travel |
-| S32 | Transport Abstraction | `NarrativeTransport` interface; SSE as first impl, WebSocket-ready |
+| [S32](32-transport-abstraction.md) | Transport Abstraction | `NarrativeTransport` interface; SSE as first impl, WebSocket-ready |
 | [S33](33-universe-persistence-schema.md) | Universe Persistence Schema | Versioned forward-compat state envelope; enables universe reload |
 | S34 | Diegetic Time | In-world clock; day/night cycles, scene transitions, skip-ahead |
 | S35 | NPC Autonomy Between Turns | Off-screen NPC goals, routines, salience filter (no LangGraph) |

--- a/specs/README.md
+++ b/specs/README.md
@@ -101,7 +101,8 @@ S00 (Charter)
 
 ## Reserved Spec IDs — v2+ (Post-v1 Roadmap)
 
-IDs S29–S63 are reserved for post-v1 releases. They are not yet full specs; they
+IDs S29–S63 are allocated to post-v1 releases. Specs S29–S39 are now published
+as full specs in this repository. IDs S40–S63 remain reserved roadmap slots and
 will be drafted via individual brainstorm sessions following the SDD workflow.
 See [`docs/superpowers/specs/2026-04-21-v2-v3-roadmap-design.md`](../docs/superpowers/specs/2026-04-21-v2-v3-roadmap-design.md)
 for the full roadmap rationale, dependency graph, and open questions per spec.

--- a/specs/README.md
+++ b/specs/README.md
@@ -117,8 +117,8 @@ for the full roadmap rationale, dependency graph, and open questions per spec.
 | [S33](33-universe-persistence-schema.md) | Universe Persistence Schema | Versioned forward-compat state envelope; enables universe reload |
 | [S34](34-diegetic-time.md) | Diegetic Time | In-world clock; day/night cycles, scene transitions, skip-ahead |
 | [S35](35-npc-autonomy-between-turns.md) | NPC Autonomy Between Turns | Off-screen NPC goals, routines, salience filter (no LangGraph) |
-| S36 | Consequence Propagation | Effect ripple via graph-walk, bounded depth, rumor distortion |
-| S37 | World Memory Model | Canon events, decay, compression, structured attributed memory |
+| [S36](36-consequence-propagation.md) | Consequence Propagation | Effect ripple via graph-walk, bounded depth, rumor distortion |
+| [S37](37-world-memory-model.md) | World Memory Model | Canon events, decay, compression, structured attributed memory |
 | S38 | NPC Memory Model | Per-NPC episodic memory; relationship-graph arcs; v4+ multiplayer hook |
 | S39 | Universe Composition Model | Themes, tropes, archetypes, genre-twists; composable, seedable, deterministic from (seed, config) |
 | S40 | Genesis v2 | 7-phase world-creation; consumes S39 composition vocabulary |

--- a/specs/README.md
+++ b/specs/README.md
@@ -115,8 +115,8 @@ for the full roadmap rationale, dependency graph, and open questions per spec.
 | [S31](31-actor-identity-portability.md) | Actor Identity Portability | Actor IDs universe-agnostic; unblocks cross-universe travel |
 | [S32](32-transport-abstraction.md) | Transport Abstraction | `NarrativeTransport` interface; SSE as first impl, WebSocket-ready |
 | [S33](33-universe-persistence-schema.md) | Universe Persistence Schema | Versioned forward-compat state envelope; enables universe reload |
-| S34 | Diegetic Time | In-world clock; day/night cycles, scene transitions, skip-ahead |
-| S35 | NPC Autonomy Between Turns | Off-screen NPC goals, routines, salience filter (no LangGraph) |
+| [S34](34-diegetic-time.md) | Diegetic Time | In-world clock; day/night cycles, scene transitions, skip-ahead |
+| [S35](35-npc-autonomy-between-turns.md) | NPC Autonomy Between Turns | Off-screen NPC goals, routines, salience filter (no LangGraph) |
 | S36 | Consequence Propagation | Effect ripple via graph-walk, bounded depth, rumor distortion |
 | S37 | World Memory Model | Canon events, decay, compression, structured attributed memory |
 | S38 | NPC Memory Model | Per-NPC episodic memory; relationship-graph arcs; v4+ multiplayer hook |


### PR DESCRIPTION
## Summary

Adds 11 foundation specs (S29–S39) for the v2.0 "Believable Simulation" release: universe-as-first-class-entity, session↔universe binding, actor identity, transport abstraction, persistence schema, and the five simulation sub-systems (diegetic time, NPC autonomy, consequence propagation, world memory, NPC memory & social).

Contains 7 commits authored previously, split from a larger local branch for per-topic reviewability.

## Scope

- S29: Universe as First-Class Entity
- S30: Session↔Universe Binding
- S31: Actor Identity Portability
- S32: NarrativeTransport abstraction (v2 transport layer)
- S33: Universe Persistence Schema
- S34: Diegetic Time
- S35: NPC Autonomy Between Turns (salience-filtered; not multi-agent)
- S36: Consequence Propagation
- S37: World Memory Model
- S38: NPC Memory & Social Model
- S39: Universe Composition Model

## Decision Record

See [docs/superpowers/specs/2026-04-21-v2-v3-roadmap-design.md](docs/superpowers/specs/2026-04-21-v2-v3-roadmap-design.md) for the roadmap rationale, dependency graph, and open questions that motivated this decomposition.

## Test plan

- [ ] `make validate-all` passes (spec + plan validators)
- [ ] Spec index regenerates without warnings beyond the pre-existing baseline
- [ ] Dependency graph cross-refs in each spec point at extant specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)