### PR TITLE
docs(specs): add v2.1 evaluation suite S41-S45

### DIFF
--- a/specs/41-scenario-seed-library.md
+++ b/specs/41-scenario-seed-library.md
@@ -367,7 +367,7 @@ slip, unreliable narrator. Prose: second-person present tense, literary.
 **cafe-with-strange-symbols**: A café the player has been coming to for years.
 Today the symbols in the menu are wrong. Or were they always like that?
 Themes: hidden world, sacred ordinary. Tropes: occult signs, knowledge that
-cannot be unknowed. Prose: intimate, first impressions, literary.
+cannot be unknown. Prose: intimate, first impressions, literary.
 
 **library-forbidden-book**: A public library. A book that shouldn't be there.
 The call number is wrong. The catalog doesn't show it. But the player can

--- a/specs/41-scenario-seed-library.md
+++ b/specs/41-scenario-seed-library.md
@@ -1,0 +1,382 @@
+# S41 — Scenario Seed Library
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v2.1
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 2 — Content
+> **Dependencies**: S39 (Universe Composition Model)
+> **Related**: S40 (Genesis v2), S42 (LLM Playtester), S63 (Community, v5+)
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+S39 defines the composition schema for a universe — themes, tropes,
+archetypes, genre-twists, prose, tone. S41 fills that schema with actual
+content: a library of named, curated seeds that authors and players can
+use as starting points.
+
+A **scenario seed** is a complete, valid `UniverseComposition` value bundled
+with metadata (name, description, tags, intended audience) and stored as a
+YAML file under `data/seeds/`. The Genesis orchestrator (S40) can load a seed
+by ID and apply it as the universe's composition config instead of asking the
+player to build the world from scratch.
+
+S41 defines:
+- The YAML format for scenario seeds
+- The canonical initial library (4 seeds from the old-TTA design heritage)
+- The discovery registry and lookup contract
+- Validation rules (extend S39's `CompositionValidator`)
+- The authoring guide for adding new seeds
+
+**User-generated seeds** are explicitly out of scope — that is S63 (Community).
+
+---
+
+## 2. Design Philosophy
+
+### 2.1 Seeds Are Versioned Composition Values
+
+A seed is not a world — it is a starting point. Two universes created from
+the same seed with different random seeds will diverge from the first prompt.
+Seeds guarantee *atmosphere*, not content.
+
+### 2.2 YAML for Human Authoring
+
+Seeds are edited by humans (content authors, narrative designers) who are not
+necessarily engineers. YAML is readable, diff-friendly, and aligns with the
+project's existing config conventions.
+
+### 2.3 Open Registry, Closed Format
+
+Any YAML file dropped into `data/seeds/` is discovered automatically. The
+registry does not need manual registration. But the format is strict:
+every seed is validated against the `SeedManifest` schema at load time.
+Unknown composition names pass (S39 OQ-39.03 resolved), but schema
+violations (wrong types, over-count limits) reject the file.
+
+---
+
+## 3. User Stories
+
+> **US-41.1** — **As a** player who doesn't want to build a world from scratch,
+> I can choose a named scenario ("The Strange Café") and begin immediately.
+
+> **US-41.2** — **As a** universe author, I can reference a seed by ID in my
+> universe config and know it will be validated and resolved at load time.
+
+> **US-41.3** — **As a** narrative designer, I can add a new seed by dropping a
+> YAML file into `data/seeds/` and running the validator — no code change needed.
+
+> **US-41.4** — **As a** LLM playtester (S42), I can select a seed by tag
+> (genre, difficulty, tone) to run diverse scenario coverage.
+
+---
+
+## 4. Data Contract — Seed Manifest
+
+### 4.1 Top-Level Fields
+
+```yaml
+# data/seeds/<seed-id>.yaml
+schema_version: "1.0"        # required; must be "1.0" in v2.1
+id: bus-stop-shimmer          # required; unique slug; [a-z0-9-]+
+name: "Bus Stop Shimmer"      # required; human display name
+version: "1.0.0"             # required; semver; incremented on material changes
+description: |               # required; 2-6 sentences
+  A lonely bus stop on an ordinary evening. Time slips. The mundane
+  becomes strange. A classic real-to-strange slip entry point.
+tags:                         # required; 1-10 tags from the canonical tag list
+  - strange-mundane
+  - urban
+  - slow-burn
+  - beginner-friendly
+intended_audience:            # optional; narrative hint, not enforced
+  - first-time players
+  - narrative explorers
+composition:                  # required; a full UniverseComposition value (S39)
+  primary_genre: urban_fantasy
+  themes:
+    - name: liminal_space
+      weight: 0.9
+    - name: mundane_mystery
+      weight: 0.7
+  tropes:
+    - name: time_slip
+      intensity: moderate
+    - name: unreliable_narrator
+      intensity: subtle
+  archetypes:
+    - name: the_witness
+      role: protagonist
+    - name: the_recurring_stranger
+      role: guide
+  genre_twists: []
+  prose:
+    voice: second_person
+    tense: present
+    register: literary
+    paragraph_length: short
+  tone:
+    primary: melancholic
+    secondary: wonder
+    override: false
+genesis_hints:                # optional; hints passed to the Genesis orchestrator
+  slip_type: mundane          # sets config["genesis"]["slip_type"]
+  starting_location: "A bus stop at dusk, Route 12."
+  opening_mood: "Everything is ordinary. That is the problem."
+```
+
+### 4.2 Field Constraints
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `schema_version` | string | ✅ | Must be `"1.0"` in v2.1 |
+| `id` | string | ✅ | `[a-z0-9-]+`; unique across all seeds in library; max 64 chars |
+| `name` | string | ✅ | 3–80 chars; human-readable display name |
+| `version` | string | ✅ | Semver: `MAJOR.MINOR.PATCH` |
+| `description` | string | ✅ | 10–600 chars |
+| `tags` | list[string] | ✅ | 1–10 tags; each tag `[a-z0-9-]+`; max 32 chars |
+| `composition` | UniverseComposition | ✅ | Full S39 composition; validated by `CompositionValidator` |
+| `genesis_hints` | object | ❌ | Forwarded to genesis orchestrator (S40); unknown keys logged, not rejected |
+| `intended_audience` | list[string] | ❌ | Informational only |
+
+### 4.3 Canonical Tag List
+
+Tags from the list below are *recognized* (indexed for filtering). Unknown
+tags are accepted but not indexed.
+
+**Genre**: `fantasy`, `sci-fi`, `horror`, `mystery`, `romance`, `historical`,
+`urban-fantasy`, `weird-fiction`, `fairy-tale`, `myth`
+
+**Mood**: `dark`, `hopeful`, `melancholic`, `comedic`, `tense`, `wonder`,
+`cozy`, `bleak`, `surreal`
+
+**Entry Type**: `strange-mundane`, `portal`, `discovery`, `chase`, `ritual`,
+`collapse`, `awakening`
+
+**Difficulty**: `beginner-friendly`, `narrative-dense`, `mechanics-heavy`
+
+**Setting**: `urban`, `rural`, `cosmic`, `subterranean`, `maritime`, `forest`
+
+---
+
+## 5. Canonical Initial Library
+
+Four seeds ship with the v2.1 release. These are the TTA founding scenarios
+from the old-TTA design heritage.
+
+| Seed ID | Name | Heritage | Primary Genre | Tags |
+|---------|------|----------|---------------|------|
+| `bus-stop-shimmer` | Bus Stop Shimmer | old-TTA GDD | urban_fantasy | strange-mundane, urban, slow-burn, beginner-friendly |
+| `cafe-with-strange-symbols` | The Café with Strange Symbols | old-TTA GDD | weird_fiction | strange-mundane, urban, mystery, wonder |
+| `library-forbidden-book` | The Library with a Forbidden Book | old-TTA GDD | dark_fantasy | strange-mundane, discovery, narrative-dense |
+| `dirty-frodo` | Dirty Frodo | old-TTA GDD | hardboiled_fantasy | portal, urban-fantasy, dark, mechanics-heavy |
+
+### Dirty Frodo Notes
+
+"Dirty Frodo" combines Tolkien-scale epic fantasy (themes, archetypes)
+with hardboiled detective tropes and urban noir prose. The name is an
+internal shorthand from the old-TTA GDD and is NOT surfaced to players
+(the display name is "City of Thorns"). This seed demonstrates that
+S39's composition vocabulary can express multi-genre combinations.
+
+---
+
+## 6. Functional Requirements
+
+### FR-41.01 — File Layout
+
+Seeds MUST live at `data/seeds/<id>.yaml`. The directory MUST be scanned
+recursively; subdirectories are permitted for organization but do not affect IDs.
+
+### FR-41.02 — Load and Validate at Startup
+
+The `SeedRegistry` MUST load and validate all seeds at application startup
+(FastAPI lifespan). Any seed that fails validation MUST log an ERROR and be
+excluded from the registry. Startup MUST NOT fail due to an invalid seed;
+only a WARNING is emitted (degraded-but-functional). If zero seeds load,
+a CRITICAL log is emitted.
+
+### FR-41.03 — Lookup by ID
+
+`SeedRegistry.get(seed_id: str) -> SeedManifest | None`
+
+Returns the seed or `None` if not found. No exception raised for missing seed.
+Callers MUST handle `None`.
+
+### FR-41.04 — List with Filter
+
+`SeedRegistry.list(tags: list[str] | None = None,
+                    genre: str | None = None) -> list[SeedManifest]`
+
+Returns all loaded seeds, optionally filtered by tag intersection and/or
+`primary_genre`. Empty filter returns all. Order: alphabetical by `id`.
+
+### FR-41.05 — Composition Application
+
+When a universe is created with a `seed_id` in its genesis config, the
+Genesis orchestrator (S40) MUST call `SeedRegistry.get(seed_id)` and
+apply `seed.composition` to the universe's `config["composition"]` block.
+The `config["seed"]` (S39) is still auto-generated independently — the
+scenario seed is NOT the universe's randomness seed.
+
+### FR-41.06 — Immutable After Load
+
+Seed manifests are read-only after the registry loads. Hot-reload of seeds
+during runtime is out of scope. A restart is required to pick up new seeds.
+
+### FR-41.07 — ID Collision Detection
+
+If two seed files share the same `id`, the registry MUST reject both and
+log an ERROR naming both file paths. Neither seed is available until the
+collision is resolved.
+
+### FR-41.08 — Versioning
+
+When a seed file's `version` is bumped, existing universes that loaded a
+prior version MUST NOT be affected. The seed version is stored in the
+universe config at composition-apply time: `config["composition"]["seed_id"]`
+and `config["composition"]["seed_version"]`. Future re-reads use the stored
+snapshot, not the current library file.
+
+---
+
+## 7. SeedRegistry Contract
+
+```python
+@dataclass(frozen=True)
+class SeedManifest:
+    schema_version: str
+    id: str
+    name: str
+    version: str
+    description: str
+    tags: list[str]
+    composition: UniverseComposition  # S39
+    genesis_hints: dict[str, Any]
+    intended_audience: list[str]
+
+
+class SeedRegistry:
+    """Loaded at FastAPI lifespan start. Immutable after load."""
+
+    def get(self, seed_id: str) -> SeedManifest | None: ...
+    def list(
+        self,
+        tags: list[str] | None = None,
+        genre: str | None = None,
+    ) -> list[SeedManifest]: ...
+    def loaded_count(self) -> int: ...
+```
+
+---
+
+## 8. Validation Rules
+
+`SeedValidator` extends `CompositionValidator` (S39) with seed-specific checks:
+
+| Rule | Error class | Message |
+|------|-------------|---------|
+| `id` does not match `[a-z0-9-]+` | `SeedSchemaError` | "Seed ID must be lowercase alphanumeric with hyphens" |
+| `id` longer than 64 chars | `SeedSchemaError` | "Seed ID exceeds 64-character limit" |
+| `schema_version` != `"1.0"` | `SeedSchemaError` | "Unsupported schema_version: {value}" |
+| `tags` empty | `SeedSchemaError` | "Seed must have at least one tag" |
+| `tags` count > 10 | `SeedSchemaError` | "Seed exceeds 10-tag limit" |
+| Composition invalid (S39 rules) | `CompositionValidationError` (re-raised) | S39 message |
+| Duplicate `id` in registry | `SeedCollisionError` | "Duplicate seed id: {id} in {file1} and {file2}" |
+
+---
+
+## 9. Acceptance Criteria (Gherkin)
+
+```gherkin
+Feature: Scenario Seed Library
+
+  Scenario: AC-41.01 — All canonical seeds load without error
+    Given the data/seeds/ directory contains the 4 canonical seed files
+    When the application starts
+    Then SeedRegistry.loaded_count() == 4
+    And no ERROR logs are emitted during seed loading
+
+  Scenario: AC-41.02 — Lookup by ID returns correct seed
+    Given the registry is loaded
+    When SeedRegistry.get("bus-stop-shimmer") is called
+    Then the returned SeedManifest has id = "bus-stop-shimmer"
+    And composition.primary_genre = "urban_fantasy"
+
+  Scenario: AC-41.03 — Filter by tag returns only matching seeds
+    Given the registry is loaded with 4 seeds
+    When SeedRegistry.list(tags=["strange-mundane"]) is called
+    Then 3 seeds are returned (bus-stop-shimmer, cafe-with-strange-symbols, library-forbidden-book)
+    And dirty-frodo is not in the result
+
+  Scenario: AC-41.04 — Invalid seed file is excluded from registry
+    Given a seed file with a missing required field (composition)
+    When the application starts
+    Then the invalid seed is excluded from the registry
+    And an ERROR log is emitted naming the invalid file
+    And all other valid seeds are still available
+
+  Scenario: AC-41.05 — Duplicate seed ID rejects both
+    Given two seed files share the same id
+    When the application starts
+    Then both seeds are excluded
+    And an ERROR log names both file paths
+
+  Scenario: AC-41.06 — Seed applied to universe composition at Genesis
+    Given a universe config with genesis.seed_id = "bus-stop-shimmer"
+    When Genesis Phase 2 begins
+    Then config["composition"] is populated from the bus-stop-shimmer seed
+    And config["composition"]["seed_id"] = "bus-stop-shimmer"
+    And config["composition"]["seed_version"] = "1.0.0"
+```
+
+---
+
+## 10. Out of Scope
+
+- User-generated seeds — S63 (Community, v5+).
+- Runtime seed editing or hot-reload.
+- Seed recommendation / personalization.
+- Seed marketplace, ratings, or social features.
+- Procedurally generated seeds — seeds are curated, not generated.
+
+---
+
+## 11. Open Questions
+
+| ID | Question | Status | Resolution |
+|---|----------|--------|------------|
+| OQ-41.01 | Scenario format — YAML, JSON, TOML? | ✅ Resolved | **YAML.** Human-editable, diff-friendly, consistent with project config conventions. Parsed by `pyyaml` at startup. |
+| OQ-41.02 | Discovery — filesystem scan or registry file? | ✅ Resolved | **Filesystem scan** of `data/seeds/` at startup. No manual registry file needed. Recursive scan supports subdirectories for organization. |
+| OQ-41.03 | Are seed IDs stable identifiers across versions? | ✅ Resolved | Yes. Seed IDs are stable; `version` field tracks revisions. Config snapshot at apply-time (FR-41.08) protects existing universes from library updates. |
+
+---
+
+## Appendix A — Canonical Seed Sketches
+
+*(Non-normative. Full YAML files live in `data/seeds/`. These are author notes.)*
+
+**bus-stop-shimmer**: Urban mundane. Evening. A city bus stop. The schedule
+says the bus is due. It is always due. The player is waiting. They have
+always been waiting. Themes: liminal space, mundane mystery. Tropes: time
+slip, unreliable narrator. Prose: second-person present tense, literary.
+
+**cafe-with-strange-symbols**: A café the player has been coming to for years.
+Today the symbols in the menu are wrong. Or were they always like that?
+Themes: hidden world, sacred ordinary. Tropes: occult signs, knowledge that
+cannot be unknowed. Prose: intimate, first impressions, literary.
+
+**library-forbidden-book**: A public library. A book that shouldn't be there.
+The call number is wrong. The catalog doesn't show it. But the player can
+hold it. Themes: forbidden knowledge, institutional uncanny. Tropes: cursed
+object, the archivist who knows. Prose: deliberate, slightly formal, gothic.
+
+**dirty-frodo** (display: "City of Thorns"): A city built on the ruins of an
+ancient kingdom. Thieves, brokers of information, a corrupt ruling council.
+The player is a fixer. Themes: moral ambiguity, fallen glory, loyalty.
+Tropes: reluctant hero, corrupt institution, the one job that goes wrong.
+Genre-twists: hardboiled-overlay (detective noir voice over epic-fantasy stakes).
+Prose: hardboiled, short sentences, cynical register.

--- a/specs/42-llm-playtester-agent-harness.md
+++ b/specs/42-llm-playtester-agent-harness.md
@@ -1,0 +1,273 @@
+# S42 — LLM Playtester Agent Harness
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v2.1
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 4 — Operations
+> **Dependencies**: S41 (Scenario Seed Library), v1 S07 (LLM Integration), v1 S16 (Testing Strategy)
+> **Related**: S43 (Human Playtester Program), S44 (Narrative Quality Evaluation), S45 (Evaluation Pipeline)
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+Manual testing of a text adventure at scale is not practical. S42 defines an
+automated playtesting harness that uses LLM agents with semi-randomized
+taste profiles to play sessions end-to-end, producing transcripts and
+agent-side commentary that feed the evaluation pipeline (S44, S45).
+
+An **LLM Playtester** is a software agent that:
+1. Selects a scenario seed (S41) or receives one from S45
+2. Creates a new game session via the TTA API
+3. Plays through Genesis (S40) and at least 5 gameplay turns
+4. Records the full conversation transcript
+5. Appends agent-side commentary: what it intended, what surprised it,
+   whether it felt the narrative was coherent
+
+The S42 harness satisfies the *necessary* half of v2.1 validation: it is
+automated, scalable, and cheap to run. It does NOT replace human playtesters
+(S43), which catch emotional resonance and pacing gaps that LLM agents miss.
+
+---
+
+## 2. Design Philosophy
+
+### 2.1 Taste Profiles, Not Scripted Responses
+
+LLM playtesters do not follow a script. They have a **taste profile** that
+biases their responses: an impulsive player chooses boldly; a cautious player
+hesitates; a verbose player writes paragraphs; a terse player writes one word.
+The semi-randomized profiles ensure diverse test coverage without scripted paths.
+
+### 2.2 Agent Commentary is a First-Class Output
+
+A transcript alone does not tell the evaluator whether the session was good.
+Each agent turn appends a brief internal commentary: "I expected to be stopped
+here. The narrative let me through without acknowledging my earlier choice."
+This commentary is the input to narrative coherence evaluation (S44).
+
+### 2.3 Reproducibility via Seed
+
+Every playtester run is associated with a `run_seed` (random integer). Given
+the same `run_seed`, `scenario_seed_id`, and model, the run is reproducible.
+This supports regression detection in S45.
+
+---
+
+## 3. User Stories
+
+> **US-42.1** — **As a** CI engineer, I can run `make playtest` and get a
+> transcript + evaluation score for a full Genesis-through-gameplay session.
+
+> **US-42.2** — **As a** narrative designer, I can run 10 playtester personas
+> against the same seed and compare transcripts to see how the narrative
+> adapts to different play styles.
+
+> **US-42.3** — **As a** quality engineer, I can replay a specific failing run
+> by supplying the same `run_seed` and model to reproduce the exact interaction.
+
+---
+
+## 4. Persona & Taste Profile
+
+### 4.1 TasteProfile Fields
+
+```python
+@dataclass
+class TasteProfile:
+    # Response style
+    verbosity: float        # 0.0 (terse) – 1.0 (verbose). Default: random in [0.1, 0.9]
+    boldness: float         # 0.0 (cautious) – 1.0 (impulsive). Affects choice direction.
+    curiosity: float        # 0.0 (passive) – 1.0 (probing). Affects follow-up questions.
+
+    # Narrative preferences
+    genre_affinity: str     # Primary genre preference (uses S39 vocabulary). E.g. 'horror', 'comedy'.
+    tone_affinity: str      # Preferred narrative tone. E.g. 'dark', 'hopeful'.
+    trope_affinity: list[str]  # 0-3 tropes the agent gravitates toward.
+
+    # Engagement model
+    attention_span: float   # 0.0 (disengages fast) – 1.0 (plays full session).
+    meta_awareness: float   # 0.0 (fully in-world) – 1.0 (notes game mechanics).
+```
+
+### 4.2 Built-in Persona Templates
+
+Five named personas ship with S42. The S45 pipeline selects from these;
+each run uses a persona template with minor jitter applied to all float fields
+(±0.15, clamped to [0.0, 1.0]).
+
+| Persona ID | Name | Profile Summary |
+|------------|------|-----------------|
+| `curious-explorer` | The Curious Explorer | High curiosity (0.9), moderate verbosity (0.6), low boldness (0.3). Asks follow-up questions. Stays in-world. |
+| `impulsive-actor` | The Impulsive Actor | High boldness (0.9), low verbosity (0.2), low curiosity (0.2). Picks fast, moves on. |
+| `terse-minimalist` | The Terse Minimalist | Very low verbosity (0.1), moderate boldness (0.5). Single-word or one-line responses. Tests terse-player handling (v1 AC-2.8). |
+| `verbose-narrator` | The Verbose Narrator | Very high verbosity (0.9), high curiosity (0.8). Writes paragraphs. Tests long-input handling. |
+| `disengaged-skeptic` | The Disengaged Skeptic | Low attention span (0.3), high meta-awareness (0.9). Likely to abandon mid-session. Tests reconnect and timeout behaviors. |
+
+### 4.3 Persona Selection
+
+When the S45 pipeline does not specify a persona, the harness selects one
+randomly. Each run records the persona ID and jitter seed so the run is
+reproducible.
+
+---
+
+## 5. Functional Requirements
+
+### FR-42.01 — Session Lifecycle
+
+A playtester run follows this sequence:
+
+1. `PlaytesterAgent.setup(scenario_seed_id, persona_id, run_seed)` — initialise
+   the random state, load the scenario seed (S41), resolve the TasteProfile.
+2. `PlaytesterAgent.run()` — open a session via `POST /api/v1/games`, play
+   through all 7 Genesis phases (S40), then play `min_turns` gameplay turns
+   (default: 5; configurable via `PLAYTEST_MIN_TURNS` env var).
+3. `PlaytesterAgent.finish()` — close the session, emit `PlaytestReport`.
+
+### FR-42.02 — Turn Generation
+
+For each agent turn, the agent MUST:
+1. Read the most recent narrative fragment from the API response.
+2. Construct an agent prompt combining the narrative + TasteProfile instructions.
+3. Call the LLM (via LiteLLM, S07) to generate the player response.
+4. Append commentary: 1-3 sentences on what the agent intended and what it noticed.
+5. Submit the response to `POST /api/v1/games/{id}/turns`.
+
+### FR-42.03 — Commentary Content
+
+Agent commentary MUST be structured as a JSON object alongside each turn:
+
+```json
+{
+  "turn_index": 3,
+  "agent_intent": "I wanted to ask about the figure at the window.",
+  "surprise_level": 0.6,
+  "surprise_note": "The narrator ignored my question about the window.",
+  "coherence_rating": 0.7,
+  "coherence_note": "Response was vivid but did not acknowledge my earlier choice."
+}
+```
+
+### FR-42.04 — Timeout and Abandon
+
+If the API returns no response within `PLAYTEST_TURN_TIMEOUT` seconds
+(default: 60), the agent logs a timeout and skips the turn. After 3
+consecutive timeouts, the agent marks the run as `abandoned` and stops.
+
+### FR-42.05 — PlaytestReport Output
+
+Every run produces a `PlaytestReport` as a JSON file:
+
+```json
+{
+  "run_id": "uuid",
+  "run_seed": 42,
+  "scenario_seed_id": "bus-stop-shimmer",
+  "persona_id": "curious-explorer",
+  "persona_jitter_seed": 17,
+  "model": "gpt-4o-mini",
+  "status": "complete",
+  "genesis_phases_completed": 7,
+  "gameplay_turns_completed": 5,
+  "turns": [
+    {"turn_index": 0, "phase": "void", "player_input": "...",
+     "narrative": "...", "commentary": { ... }}
+  ],
+  "overall_agent_rating": 0.75,
+  "overall_agent_notes": "Narrative was coherent. Slip event was effective."
+}
+```
+
+### FR-42.06 — Reproducibility
+
+Given the same `run_seed`, `scenario_seed_id`, `persona_id`, `persona_jitter_seed`,
+and `model`, a playtester run MUST produce the same player responses.
+Reproducibility applies to the *agent's responses only* — the TTA narrative
+varies based on the universe seed (S39), which is separate.
+
+### FR-42.07 — Parallel Execution
+
+Multiple playtester agents MAY run in parallel. Each agent has its own API
+session; no shared state between agents. The S45 pipeline controls concurrency.
+
+---
+
+## 6. PlaytesterAgent Contract
+
+```python
+class PlaytesterAgent:
+    def __init__(
+        self,
+        api_base_url: str,
+        llm_model: str = "gpt-4o-mini",
+    ) -> None: ...
+
+    def setup(
+        self,
+        scenario_seed_id: str,
+        persona_id: str,
+        run_seed: int,
+    ) -> None: ...
+
+    async def run(self) -> PlaytestReport: ...
+    async def finish(self) -> PlaytestReport: ...
+```
+
+---
+
+## 7. Acceptance Criteria (Gherkin)
+
+```gherkin
+Feature: LLM Playtester Agent Harness
+
+  Scenario: AC-42.01 — Agent completes a full session
+    Given a PlaytesterAgent with scenario_seed_id = "bus-stop-shimmer"
+    And persona_id = "curious-explorer"
+    And the TTA API is running
+    When agent.run() completes
+    Then PlaytestReport.status = "complete"
+    And PlaytestReport.genesis_phases_completed = 7
+    And PlaytestReport.gameplay_turns_completed >= 5
+
+  Scenario: AC-42.02 — Every turn has commentary
+    Given a completed PlaytestReport
+    Then every turn in report.turns has a non-null commentary field
+    And every commentary has agent_intent, surprise_level, coherence_rating
+
+  Scenario: AC-42.03 — Run is reproducible given same seeds
+    Given two runs with identical run_seed, persona_id, persona_jitter_seed, model
+    Then the player_input field of each turn is identical across both runs
+
+  Scenario: AC-42.04 — Terse persona exercises AC-2.8 path
+    Given persona_id = "terse-minimalist"
+    When the agent runs through Phase 4
+    Then at least one turn has player_input length < 20 characters
+    And the PlaytestReport is still status = "complete"
+
+  Scenario: AC-42.05 — API timeout leads to abandoned status after 3 consecutive
+    Given the TTA API times out on every turn
+    When the agent has recorded 3 consecutive timeouts
+    Then PlaytestReport.status = "abandoned"
+    And no further turns are attempted
+```
+
+---
+
+## 8. Out of Scope
+
+- Human playtest sessions — S43.
+- Narrative quality scoring — S44.
+- Pipeline orchestration — S45.
+- Browser/UI automation — LLM playtesters use the API directly.
+
+---
+
+## 9. Open Questions
+
+| ID | Question | Status | Resolution |
+|---|----------|--------|------------|
+| OQ-42.01 | LLM persona count and taste-profile dimensions | ✅ Resolved | **5 built-in personas**, 8-field TasteProfile. Persona count is sufficient for v2.1; S45 selects from them. Additional personas can be added by dropping new persona YAML into `data/personas/`. |
+| OQ-42.02 | Which LLM model should the playtester use? | ✅ Resolved | **`gpt-4o-mini` by default** (fast, cheap, sufficient for behavioral variety). Configurable via `PLAYTEST_LLM_MODEL` env var. Same LiteLLM client as TTA (S07). |
+| OQ-42.03 | Should commentary be LLM-generated or rule-based? | ✅ Resolved | **LLM-generated** (same model as the agent's turn response, via a second call). This adds cost but produces richer evaluation input. Rule-based commentary (e.g., just turn length) is insufficient for S44. |

--- a/specs/43-human-playtester-program.md
+++ b/specs/43-human-playtester-program.md
@@ -1,0 +1,250 @@
+# S43 — Human Playtester Program
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v2.1
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 4 — Operations
+> **Dependencies**: S41 (Scenario Seed Library)
+> **Related**: S42 (LLM Playtester), S44 (Narrative Quality Evaluation), S17 (Privacy)
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+LLM playtesters (S42) catch structural and coherence failures. They do not
+feel. They do not get bored. They do not experience a moment of wonder, or
+notice that the pacing dragged through Act IV, or feel uncomfortable about
+the way a consequence was framed.
+
+S43 defines the human playtester program: a small-scale (10–30 participants)
+structured feedback process where real humans play curated scenarios and
+report their experience through a standardized intake form. S43 satisfies the
+*sufficient* half of v2.1 validation that the v1 project charter explicitly
+called out: automated testing is necessary but not sufficient.
+
+S43 covers:
+- Recruitment criteria and process
+- Consent, compensation, and privacy policy
+- Session structure (what playtesters do, how long)
+- Feedback intake form format
+- Triage pipeline: how feedback becomes regression tickets
+- Roles and responsibilities
+
+---
+
+## 2. Scope and Scale
+
+**v2.1 target**: 10–30 playtesters. This is deliberately small. The goal is
+signal quality, not statistical volume. A 100-person study is out of scope
+for v2.1; that belongs to a future marketing/product research phase.
+
+**Session structure**: Each participant plays one curated scenario (S41) to
+completion (Genesis + at least 5 gameplay turns). One session per participant
+per scenario. A participant may play multiple scenarios across multiple sessions.
+
+**Compensation**: Nominal gift card (value TBD by ops team; ~$15–25 USD
+equivalent). Participation is voluntary and participants may stop at any time.
+
+---
+
+## 3. Roles
+
+| Role | Responsibilities |
+|------|-----------------|
+| **Program Coordinator** | Recruits playtesters, schedules sessions, distributes access tokens, handles consent forms |
+| **Playtester** | Plays a scenario; completes the feedback form |
+| **Triage Reviewer** | Reviews submitted feedback; creates regression tickets; marks low-signal entries |
+| **Narrative Designer** | Reviews regression tickets flagged as narrative issues; proposes fixes |
+
+---
+
+## 4. Recruitment
+
+### 4.1 Criteria
+
+Participants MUST:
+- Be 18 years of age or older
+- Be able to read and write in English
+- Have at least occasional familiarity with interactive fiction, text games,
+  or narrative games (examples provided; no prior TTA experience required)
+
+Participants MUST NOT:
+- Be current employees or contractors of the TTA project
+- Have contributed code, specs, or design to TTA in the prior 6 months
+
+### 4.2 Recruitment Channels
+
+v2.1 channels (in priority order):
+1. Direct invite: known friends and community members of the team
+2. Interactive fiction community forums (e.g., IF Forum, IFDB community)
+3. General social post targeting narrative game enthusiasts
+
+Participants are NOT recruited from general public labor platforms (e.g.,
+Mechanical Turk) for v2.1. Engagement quality is prioritized over throughput.
+
+### 4.3 Access Provisioning
+
+Each participant receives a single-use access token scoped to their assigned
+scenario seed. Tokens expire 7 days after issuance. Token management is a
+manual ops task for v2.1 (no automated provisioning).
+
+---
+
+## 5. Consent and Privacy
+
+### 5.1 Consent Form
+
+Before accessing TTA, each participant MUST complete a digital consent form that:
+- Describes TTA and the purpose of the playtester program
+- States that their session transcript will be stored and reviewed by the TTA team
+- States that feedback will be used to improve the system
+- Confirms compensation amount and terms
+- Includes an opt-out clause (participant may withdraw at any time; stored
+  data is deleted within 14 days of withdrawal request)
+
+Consent form MUST comply with v1 S17 (Privacy) consent requirements.
+
+### 5.2 Data Retention
+
+Playtester session transcripts are retained for a maximum of 90 days after
+the v2.1 evaluation window closes. After 90 days they are deleted.
+Feedback form responses (anonymized) may be retained indefinitely for
+longitudinal tracking.
+
+### 5.3 Anonymization
+
+Feedback form responses are anonymized before sharing with the narrative
+design team: participant names and contact details are stripped. Session
+transcripts are tagged by session ID only.
+
+---
+
+## 6. Session Structure
+
+A standard playtester session:
+
+| Step | Duration | Description |
+|------|----------|-------------|
+| 1. Onboarding | 5 min | Read a one-page orientation guide (no spoilers about TTA mechanics) |
+| 2. Play | 20–40 min | Play the assigned scenario through Genesis + 5+ gameplay turns |
+| 3. Feedback form | 10–15 min | Complete the structured feedback intake form |
+| **Total** | **35–60 min** | |
+
+Participants are free to exceed 5 turns if they wish to continue. The form
+is submitted before they close the browser. Sessions are not timed.
+
+---
+
+## 7. Feedback Intake Form
+
+The feedback intake form is a structured digital form (Google Forms or equivalent).
+It produces a JSON record for each submission.
+
+### 7.1 Quantitative Fields
+
+| Field ID | Question | Scale |
+|----------|----------|-------|
+| `q_coherence` | "The story made sense from moment to moment" | 1–5 |
+| `q_wonder` | "At least once, I felt surprised or delighted by the narrative" | 1–5 |
+| `q_character` | "My character felt like mine — shaped by my choices" | 1–5 |
+| `q_pacing` | "The story moved at a pace that felt right" | 1–5 |
+| `q_genesis_comfort` | "Getting started felt natural, not overwhelming" | 1–5 |
+| `q_consequence` | "My choices seemed to matter to the story" | 1–5 |
+| `q_overall` | "Overall, I enjoyed this experience" | 1–5 |
+| `q_recommend` | "I would recommend this to a friend" | Yes / No / Maybe |
+
+### 7.2 Qualitative Fields
+
+| Field ID | Question | Type |
+|----------|----------|------|
+| `q_best_moment` | "Describe one moment that worked really well." | Free text (≤ 500 chars) |
+| `q_worst_moment` | "Describe one moment that didn't work for you." | Free text (≤ 500 chars) |
+| `q_confusion` | "Was there anything confusing or unclear?" | Free text (≤ 500 chars) |
+| `q_freeform` | "Any other thoughts?" | Free text (≤ 500 chars) |
+
+### 7.3 Metadata Fields (Auto-populated)
+
+| Field | Source |
+|-------|--------|
+| `session_id` | Provided by access token |
+| `scenario_seed_id` | Derived from session |
+| `turns_played` | API-reported turn count |
+| `genesis_completed` | Boolean from session state |
+| `submission_timestamp` | Form submit time |
+
+---
+
+## 8. Triage Pipeline
+
+After the evaluation window closes, a Triage Reviewer processes all submissions:
+
+1. **Score baseline**: Compute median and distribution for each quantitative
+   field. Any field with median < 3.0 is flagged as a **regression candidate**.
+2. **Qualitative review**: Read all `q_worst_moment` and `q_confusion` entries.
+   Group by theme (pacing, Genesis confusion, consequence gap, prose tone).
+3. **Regression ticket creation**: For each flagged issue, create a GitHub issue
+   with label `playtester-regression` and the scenario seed ID.
+   Ticket includes: raw quotes (anonymized), quantitative score context,
+   suggested spec section (e.g., "S40 Phase 3", "S44 coherence metric").
+4. **Low-signal marking**: Submissions with `q_overall == 1` AND all fields == 1
+   with no qualitative content are flagged as low-signal and excluded from
+   aggregate scoring.
+
+### 8.1 Escalation Threshold
+
+If median `q_overall` < 3.0 across the cohort, or median `q_coherence` < 3.0,
+the evaluation pipeline (S45) MUST mark the release as **NOT VALIDATED** and
+block the v2.1 milestone tag.
+
+---
+
+## 9. Acceptance Criteria
+
+```gherkin
+Feature: Human Playtester Program
+
+  Scenario: AC-43.01 — Consent collected before session access
+    Given a participant has a valid access token
+    When they attempt to access TTA without completing the consent form
+    Then they are redirected to the consent form
+    And session access is not granted until consent is recorded
+
+  Scenario: AC-43.02 — Feedback form produces structured JSON record
+    Given a participant completes the feedback form
+    When the form is submitted
+    Then a JSON record with all required fields is stored
+    And session_id, scenario_seed_id, and submission_timestamp are auto-populated
+
+  Scenario: AC-43.03 — Participant withdrawal triggers data deletion
+    Given a participant requests withdrawal
+    When the request is processed
+    Then their session transcript is deleted within 14 days
+    And their feedback record is anonymized (name and contact stripped)
+
+  Scenario: AC-43.04 — Low median triggers NOT VALIDATED signal
+    Given the cohort median for q_overall is 2.5
+    When the triage reviewer runs the aggregate scoring
+    Then the evaluation pipeline receives a NOT_VALIDATED signal
+    And a regression ticket is created with all below-threshold scores
+```
+
+---
+
+## 10. Out of Scope
+
+- Automated participant recruitment or scheduling (manual ops for v2.1).
+- Longitudinal tracking of the same participants across releases (v3+).
+- A/B testing of narrative variants with participant cohorts.
+- Therapeutic impact evaluation — S18 (future stub).
+- NDA requirement for participants (not warranted at v2.1 scale).
+
+---
+
+## 11. Open Questions
+
+| ID | Question | Status | Resolution |
+|---|----------|--------|------------|
+| OQ-43.01 | Recruitment channels and compensation level | ✅ Resolved | Channels: direct invite → IF forums → general social. Compensation: ~$15–25 gift card (exact amount set by ops). No Mechanical Turk for v2.1. |
+| OQ-43.02 | NDA / consent form legal review | ⚠️ Open | Consent form template provided in this spec; legal review required before first participant is recruited. |
+| OQ-43.03 | Feedback form platform | ✅ Resolved | Google Forms or equivalent. Must produce structured JSON-exportable records. Exact platform is an ops decision. |

--- a/specs/44-narrative-quality-evaluation.md
+++ b/specs/44-narrative-quality-evaluation.md
@@ -1,0 +1,248 @@
+# S44 — Narrative Quality Evaluation
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v2.1
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 4 — Operations
+> **Dependencies**: S42 (LLM Playtester Agent Harness), S43 (Human Playtester Program)
+> **Related**: S45 (Evaluation Pipeline)
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+S44 defines how a TTA narrative session is **scored**: the quality categories,
+what each means, how each is computed, and what thresholds indicate pass/fail.
+
+Two sources feed S44:
+- **Automated signal** (S42): LLM playtester commentary, turn metadata, API
+  response times, error counts
+- **Human signal** (S43): participant feedback form scores and qualitative text
+
+S44 outputs a `NarrativeQualityReport` for each evaluated session. The S45
+pipeline aggregates these across a run batch and computes release-level
+verdicts.
+
+---
+
+## 2. Quality Categories
+
+Six categories. Each is scored 0.0–1.0. The scoring rubric for each is in
+Appendix A.
+
+| ID | Category | Definition | Primary Source |
+|----|----------|------------|----------------|
+| QC-01 | **Coherence** | The narrative is internally consistent: references to earlier events are accurate; character names and traits are stable; world details do not contradict themselves. | Automated (S42 commentary + rule checks) |
+| QC-02 | **Tension** | The narrative maintains narrative drive: choices feel consequential; scenes escalate or resolve with purpose; the player is pulled forward. | Mixed (S42 commentary + S43 `q_consequence`) |
+| QC-03 | **Wonder** | At least one moment in the session produced surprise, delight, or emotional resonance beyond mechanical expectation. | Human primary (S43 `q_wonder`); LLM secondary (S42 commentary `surprise_level`) |
+| QC-04 | **Character Depth** | The player's character feels specific and shaped by their choices. Traits from Genesis appear in gameplay narrative. | Automated (S40 first-turn seed check) + Human (S43 `q_character`) |
+| QC-05 | **Genre Fidelity** | The narrative is consistent with the scenario seed's declared primary genre, themes, and tone. Hardboiled fantasy stays hardboiled; horror maintains dread. | Automated (LLM genre-fidelity scorer) |
+| QC-06 | **Consequence Weight** | Choices made by the player produce observable changes in the world state. S36 consequence records exist and are referenced in later narrative. | Automated (S36 ConsequenceRecord presence) + Human (S43 `q_consequence`) |
+
+---
+
+## 3. Scoring Methods
+
+### 3.1 Coherence (QC-01) — Automated
+
+Computed from S42 playtester commentary:
+- Average `coherence_rating` across all commentary objects in the transcript
+- Penalized by: any narrative contradiction detected (character name mismatch,
+  location referenced before established, trait used inconsistently)
+- Contradiction detection: rule-based checks against genesis_state fields
+
+Formula: `coherence = mean(commentary.coherence_rating) * (1 - contradiction_count * 0.15)`
+
+Clamped to [0.0, 1.0].
+
+### 3.2 Tension (QC-02) — Mixed
+
+- Automated component (0.6 weight): mean `surprise_level` from S42 commentary
+  (higher surprise with no confusion = tension). Penalized by `api_turn_p95_ms > 5000`
+  (slow turns break immersion).
+- Human component (0.4 weight): `q_consequence` score from S43, normalized to [0.0, 1.0]
+  (score / 5).
+
+Formula: `tension = 0.6 * auto_tension + 0.4 * human_tension`
+
+### 3.3 Wonder (QC-03) — Human Primary
+
+- Human component (0.7 weight): `q_wonder` from S43, normalized to [0.0, 1.0].
+- Automated component (0.3 weight): mean `surprise_level` from S42 commentary.
+
+Wonder has no automated fallback if S43 data is absent: if no human data
+exists, QC-03 is marked `not_evaluated` and excluded from release score.
+
+### 3.4 Character Depth (QC-04) — Mixed
+
+- Automated (0.5 weight): Did the first gameplay turn contain the character
+  name AND a trait phrase from genesis_state? Boolean → 0.0 or 1.0.
+- Human (0.5 weight): `q_character` from S43, normalized.
+
+### 3.5 Genre Fidelity (QC-05) — Automated
+
+An LLM call (separate from the playtester) receives:
+1. The scenario seed's declared `primary_genre`, `themes`, and `tone`
+2. A random sample of 5 narrative fragments from the session
+
+The evaluator LLM scores genre fidelity on a 1–5 scale and returns a brief
+rationale. Score is normalized to [0.0, 1.0]. If the LLM call fails, QC-05
+is retried once; if still failing, it is marked `not_evaluated`.
+
+### 3.6 Consequence Weight (QC-06) — Mixed
+
+- Automated (0.6 weight): count of `ConsequenceRecord` entries (S36) in the
+  session / expected_count. `expected_count = max(1, turns_played // 3)` (one
+  consequence every 3 turns is the baseline expectation).
+  Clamped to [0.0, 1.0].
+- Human (0.4 weight): `q_consequence` from S43, normalized.
+
+---
+
+## 4. NarrativeQualityReport
+
+```python
+@dataclass
+class CategoryScore:
+    category_id: str           # "QC-01" through "QC-06"
+    score: float | None        # 0.0–1.0 or None if not_evaluated
+    status: str                # "scored", "not_evaluated", "failed"
+    sources: list[str]         # ["automated", "human"] — which sources contributed
+    notes: str                 # brief rationale
+
+
+@dataclass
+class NarrativeQualityReport:
+    report_id: str
+    session_id: str
+    run_id: str | None         # S42 run_id if automated; None if human-only
+    scenario_seed_id: str
+    evaluated_at: datetime
+    categories: list[CategoryScore]
+    composite_score: float     # weighted mean of evaluated categories
+    verdict: str               # "pass", "fail", "inconclusive"
+    fail_reasons: list[str]    # human-readable reasons for fail verdict
+```
+
+---
+
+## 5. Composite Score and Verdicts
+
+### 5.1 Weights
+
+| Category | Weight |
+|----------|--------|
+| QC-01 Coherence | 0.25 |
+| QC-02 Tension | 0.15 |
+| QC-03 Wonder | 0.20 |
+| QC-04 Character Depth | 0.20 |
+| QC-05 Genre Fidelity | 0.10 |
+| QC-06 Consequence Weight | 0.10 |
+
+If a category is `not_evaluated`, its weight is redistributed proportionally
+across the remaining evaluated categories.
+
+### 5.2 Verdicts
+
+| Verdict | Condition |
+|---------|-----------|
+| **pass** | `composite_score >= 0.65` AND no individual category score < 0.40 |
+| **fail** | `composite_score < 0.65` OR any individual category score < 0.40 |
+| **inconclusive** | Three or more categories are `not_evaluated` |
+
+---
+
+## 6. Acceptance Criteria (Gherkin)
+
+```gherkin
+Feature: Narrative Quality Evaluation
+
+  Scenario: AC-44.01 — All 6 categories scored for a complete session
+    Given a PlaytestReport (S42) AND a FeedbackRecord (S43)
+    When NarrativeQualityEvaluator.evaluate(session_id) is called
+    Then the report has 6 CategoryScore entries
+    And none have status = "not_evaluated" when both sources are present
+
+  Scenario: AC-44.02 — Wonder is not_evaluated without S43 data
+    Given a PlaytestReport without a corresponding S43 FeedbackRecord
+    When NarrativeQualityEvaluator.evaluate(session_id) is called
+    Then QC-03 has status = "not_evaluated"
+    And QC-03 weight is redistributed to remaining categories
+
+  Scenario: AC-44.03 — Character depth fails if AC-2.3 enforcement missed
+    Given the first gameplay turn does not contain the character name
+    When QC-04 is computed
+    Then the automated component contributes 0.0
+    And CategoryScore.notes mentions "AC-2.3 enforcement miss"
+
+  Scenario: AC-44.04 — Fail verdict when any category below 0.40
+    Given a session where QC-01 coherence = 0.35
+    When the composite score is computed
+    Then verdict = "fail"
+    And fail_reasons contains "QC-01 Coherence below threshold"
+
+  Scenario: AC-44.05 — Inconclusive when 3+ categories not_evaluated
+    Given a session with only S42 data (no S43 data)
+    And QC-03 Wonder requires S43
+    When evaluated
+    Then if 3+ categories are not_evaluated
+    Then verdict = "inconclusive"
+```
+
+---
+
+## 7. Out of Scope
+
+- Therapeutic outcome measurement — S18 (future stub).
+- Automated A/B scoring of narrative variants (future).
+- Cross-session longitudinal quality tracking (future).
+- Bias or representation audits of narrative content.
+
+---
+
+## 8. Open Questions
+
+| ID | Question | Status | Resolution |
+|---|----------|--------|------------|
+| OQ-44.01 | Scoring normalized 0–1 or categorical? | ✅ Resolved | **0.0–1.0 float** for all categories. Categorical thresholds (pass/fail) applied at verdict stage, not during scoring. This allows fine-grained regression tracking. |
+| OQ-44.02 | Inter-rater reliability across LLM runs? | ✅ Resolved | For genre fidelity (QC-05): LLM scorer called with `temperature=0` for consistency; rationale stored for human review. Coherence (QC-01) is rule-based to maximize reproducibility. |
+| OQ-44.03 | Weighting LLM vs human signal? | ✅ Resolved | Per-category weights defined in §5.1. Wonder (QC-03) and Character Depth (QC-04) weight human signal more heavily (0.7 and 0.5 respectively). Coherence (QC-01) is fully automated. |
+
+---
+
+## Appendix A — Scoring Rubric
+
+*(Reference table for evaluators and LLM genre scorer prompt.)*
+
+**QC-01 Coherence** — Score guide:
+- 1.0: No contradictions; all references accurate; character consistent throughout
+- 0.7: Minor inconsistency (e.g., location name varies slightly); no character contradiction
+- 0.5: One notable contradiction player would notice
+- 0.3: Multiple contradictions; character traits change without narrative reason
+- 0.0: Session is incoherent; player unable to follow causal chain
+
+**QC-03 Wonder** — Score guide (S43 q_wonder, 1–5 → 0.0–1.0):
+- 5/1.0: "I felt genuinely surprised and delighted at least once."
+- 4/0.8: "There was a moment that stood out, even if brief."
+- 3/0.6: "The story was fine but nothing surprised me."
+- 2/0.4: "It felt mechanical — I never forgot I was playing a game."
+- 1/0.2: "I felt nothing. The narrative was empty."
+
+**QC-05 Genre Fidelity** — Prompt fragment for LLM scorer:
+```
+You are evaluating a text adventure narrative for genre fidelity.
+The declared genre is: {primary_genre}
+The declared themes are: {themes}
+The declared tone is: {tone}
+
+Below are 5 sample narrative fragments from the session.
+Score genre fidelity 1–5 where:
+5 = All fragments are clearly and consistently in genre
+4 = Mostly in genre; minor drift in one fragment
+3 = Partially in genre; some elements feel out of place
+2 = Genre is inconsistent; player would notice the drift
+1 = Genre is absent or contradicted
+
+Respond in JSON: {"score": <int>, "rationale": "<one sentence>"}
+```

--- a/specs/44-narrative-quality-evaluation.md
+++ b/specs/44-narrative-quality-evaluation.md
@@ -186,8 +186,8 @@ Feature: Narrative Quality Evaluation
     Given a session with only S42 data (no S43 data)
     And QC-03 Wonder requires S43
     When evaluated
-    Then if 3+ categories are not_evaluated
-    Then verdict = "inconclusive"
+    Then 3 or more categories have status "not_evaluated"
+    And verdict = "inconclusive"
 ```
 
 ---

--- a/specs/45-evaluation-pipeline.md
+++ b/specs/45-evaluation-pipeline.md
@@ -1,0 +1,290 @@
+# S45 — Evaluation Pipeline
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v2.1
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 4 — Operations
+> **Dependencies**: S42 (LLM Playtester), S43 (Human Playtester Program), S44 (Narrative Quality Evaluation)
+> **Related**: v1 S15 (Observability), v1 S16 (Testing Strategy)
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+S45 defines the orchestration layer that ties the evaluation stack together:
+- Launches S42 LLM playtester runs (in parallel)
+- Ingests S43 human feedback records as they arrive
+- Invokes S44 evaluators to score each session
+- Aggregates scores across a release batch
+- Produces verdicts that CI can act on
+- Ships results to Langfuse for long-term trend visibility
+
+The pipeline is designed to be runnable in two modes:
+1. **CI mode**: triggered by a GitHub Actions workflow after a PR merges to `main`.
+   Runs a fixed batch of automated playtests; fails the workflow if quality regresses.
+2. **Release mode**: run manually by the program coordinator before a v2.1 milestone
+   tag. Incorporates human playtester feedback and produces the release verdict.
+
+---
+
+## 2. Design Principles
+
+### 2.1 Results Are Data, Not Opinions
+
+Every verdict is backed by a `NarrativeQualityReport` (S44) with score,
+sources, and fail_reasons. No black-box pass/fail. Engineers can always read
+why a run failed.
+
+### 2.2 CI Runs on LLM Signal Only
+
+Human playtester data is not available in CI (humans are not standing by for
+every PR). CI uses S42 automated runs only. S44 handles the missing S43 data
+gracefully (Wonder marked `not_evaluated`; weight redistributed).
+
+### 2.3 Regression Detection Via Baseline
+
+Every CI run is compared against a **baseline** stored in `data/eval_baseline.json`.
+If any category regresses by > 0.10 from baseline, CI fails. This catches
+silent narrative degradation.
+
+### 2.4 Langfuse as Long-Term Store
+
+All `NarrativeQualityReport` values are logged as Langfuse scores, keyed by
+`session_id`. This gives Langfuse-level visibility into narrative quality
+trends across releases without a custom dashboard.
+
+---
+
+## 3. Pipeline Architecture
+
+```
+                    ┌──────────────────────────────────────────────┐
+                    │           EvaluationPipeline                  │
+                    │                                              │
+  Trigger ──────►  │  1. plan_runs(scenario_seeds, personas)       │
+                    │  2. run_llm_playtesters()  ──────────────────►│── S42 (parallel)
+  S43 feedback ──► │  3. ingest_human_feedback()                   │
+                    │  4. evaluate_sessions()  ────────────────────►│── S44
+                    │  5. aggregate()                               │
+                    │  6. compare_to_baseline()                     │
+                    │  7. emit_verdict()  ──────────────────────────►│── CI / release gate
+                    │  8. ship_to_langfuse()  ─────────────────────►│── Langfuse
+                    │  9. write_report(csv / json)                  │
+                    └──────────────────────────────────────────────┘
+```
+
+---
+
+## 4. Functional Requirements
+
+### FR-45.01 — Run Planning
+
+`EvaluationPipeline.plan_runs(batch_config: BatchConfig) -> list[PlannedRun]`
+
+A `BatchConfig` specifies:
+```python
+@dataclass
+class BatchConfig:
+    scenario_seed_ids: list[str]       # seeds to test; default: all S41 seeds
+    persona_ids: list[str]             # personas to use; default: all 5 S42 personas
+    runs_per_combination: int = 1      # number of independent runs per (seed, persona) pair
+    max_parallel_runs: int = 5         # concurrency ceiling
+    mode: str = "ci"                   # "ci" or "release"
+```
+
+For CI mode: default 4 seeds × 5 personas × 1 = 20 runs.
+For release mode: same batch + human feedback ingestion.
+
+### FR-45.02 — Parallel LLM Playtester Execution
+
+Planned runs are dispatched to a `asyncio.Semaphore(max_parallel_runs)` pool.
+Each run is an independent `PlaytesterAgent` (S42) invocation. Completed
+`PlaytestReport` objects are buffered in memory and immediately passed to S44.
+
+Failed runs (agent status = `abandoned` or exception) are retried once. If
+the retry also fails, the run is marked as `error` and excluded from scoring.
+If more than 25% of runs end in `error`, the pipeline MUST abort and emit a
+CRITICAL log: `eval_pipeline_run_error_rate_too_high`.
+
+### FR-45.03 — Human Feedback Ingestion
+
+In release mode, the pipeline reads S43 feedback JSON records from a
+configured path (`EVAL_HUMAN_FEEDBACK_DIR`). Records are matched to sessions
+by `session_id`. Unmatched records are logged as warnings.
+
+### FR-45.04 — Session Evaluation
+
+For each session with a completed playtester run (and optionally human
+feedback), `NarrativeQualityEvaluator.evaluate(session_id)` (S44) is called.
+Results are collected into a `BatchEvalResult`.
+
+### FR-45.05 — Batch Aggregation
+
+`BatchEvalResult` contains per-session reports and batch-level aggregates:
+
+```python
+@dataclass
+class BatchEvalResult:
+    batch_id: str
+    mode: str
+    total_runs: int
+    evaluated_runs: int
+    error_runs: int
+    per_session: list[NarrativeQualityReport]  # S44
+    batch_category_medians: dict[str, float]   # category_id -> median score
+    batch_composite_median: float
+    pass_count: int
+    fail_count: int
+    inconclusive_count: int
+    batch_verdict: str  # "pass", "fail", "inconclusive"
+```
+
+### FR-45.06 — Baseline Comparison
+
+The baseline file at `data/eval_baseline.json` stores the last-known-good
+batch medians per category:
+
+```json
+{
+  "QC-01": 0.82,
+  "QC-02": 0.71,
+  "QC-03": 0.78,
+  "QC-04": 0.85,
+  "QC-05": 0.80,
+  "QC-06": 0.74
+}
+```
+
+If any `batch_category_medians[cat] < baseline[cat] - 0.10`, the pipeline
+marks the comparison as **regression** and includes the category and delta
+in the verdict output.
+
+The baseline MUST be updated manually after a human-reviewed release pass.
+Automated CI runs MUST NOT update the baseline.
+
+### FR-45.07 — Verdict Emission
+
+In CI mode the pipeline exits with:
+- **Exit code 0**: `batch_verdict == "pass"` AND no category regression
+- **Exit code 1**: `batch_verdict == "fail"` OR category regression detected
+- **Exit code 2**: pipeline error (> 25% runs errored, or unrecoverable failure)
+
+The verdict is also written to `GITHUB_OUTPUT` (if in GitHub Actions) as
+`eval_verdict` and `eval_batch_composite` for downstream use.
+
+### FR-45.08 — Langfuse Export
+
+Every `NarrativeQualityReport` is logged to Langfuse as a set of scores on
+the session's trace:
+- Score name: `narrative_quality_{category_id.lower()}` (e.g., `narrative_quality_qc_01`)
+- Score value: category score (float)
+- Score comment: category notes
+
+Langfuse export is fire-and-forget: failure to export MUST NOT block the
+pipeline verdict.
+
+### FR-45.09 — Report Output
+
+Two files are written at `EVAL_OUTPUT_DIR`:
+1. `batch_{batch_id}.json` — full `BatchEvalResult` serialized
+2. `batch_{batch_id}_summary.csv` — one row per session: session_id,
+   scenario_seed_id, persona_id, composite_score, verdict, per-category scores
+
+---
+
+## 5. GitHub Actions Integration
+
+A workflow file `.github/workflows/eval.yml` runs the pipeline in CI mode.
+
+```yaml
+name: Narrative Quality Evaluation
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "ci or release"
+        default: "ci"
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<SHA>
+      - name: Run evaluation pipeline
+        run: |
+          uv run python -m tta.eval.pipeline --mode ${{ inputs.mode || 'ci' }}
+        env:
+          TTA_API_URL: ${{ secrets.TTA_STAGING_URL }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+      - name: Upload eval report
+        if: always()
+        uses: actions/upload-artifact@<SHA>
+        with:
+          name: eval-report
+          path: eval_output/
+```
+
+---
+
+## 6. Acceptance Criteria (Gherkin)
+
+```gherkin
+Feature: Evaluation Pipeline
+
+  Scenario: AC-45.01 — CI pipeline runs 20 sessions and produces verdict
+    Given BatchConfig with default seeds, personas, mode = "ci"
+    When EvaluationPipeline.run(batch_config) completes
+    Then BatchEvalResult.total_runs = 20
+    And batch_verdict is one of: "pass", "fail", "inconclusive"
+    And batch_*.json and batch_*_summary.csv are written
+
+  Scenario: AC-45.02 — Category regression triggers CI failure
+    Given baseline QC-01 = 0.82
+    And batch QC-01 median = 0.70
+    When compare_to_baseline is called
+    Then verdict includes regression flag for QC-01
+    And pipeline exits with code 1
+
+  Scenario: AC-45.03 — All sessions logged to Langfuse
+    Given a completed batch
+    When the Langfuse export step runs
+    Then each session has 6 scores logged (one per QC category)
+    And Langfuse export failure does not abort the pipeline
+
+  Scenario: AC-45.04 — Abort on >25% error runs
+    Given 6 of 20 planned runs return status = "error" after retry
+    When the pipeline checks error rate (6/20 = 30%)
+    Then the pipeline aborts
+    And CRITICAL log is emitted with eval_pipeline_run_error_rate_too_high
+    And exit code 2 is returned
+
+  Scenario: AC-45.05 — Release mode ingests human feedback
+    Given EVAL_HUMAN_FEEDBACK_DIR contains 12 S43 feedback records
+    And mode = "release"
+    When the pipeline runs
+    Then 12 sessions have Wonder (QC-03) scored from human data
+    And unmatched feedback records are logged as warnings
+```
+
+---
+
+## 7. Out of Scope
+
+- A live dashboard UI for evaluation results (Langfuse serves this role).
+- Automated baseline updates (manual gate to prevent silent standard degradation).
+- Real-time evaluation during active gameplay sessions.
+- Per-user personalized quality scoring.
+
+---
+
+## 8. Open Questions
+
+| ID | Question | Status | Resolution |
+|---|----------|--------|------------|
+| OQ-45.01 | Results destination — dashboard, CSV, Langfuse? | ✅ Resolved | **All three**: CSV + JSON files as artifacts; Langfuse as long-term score store; no custom dashboard built. Langfuse's built-in score visualization is sufficient for v2.1. |
+| OQ-45.02 | What is the CI trigger? Every commit or every PR merge to main? | ✅ Resolved | **Push to main** (post-merge). Running on every PR commit is too expensive (20 LLM sessions per run). `workflow_dispatch` allows manual runs in release mode. |
+| OQ-45.03 | Should baseline updates be automated or manual? | ✅ Resolved | **Manual only**. Automated baseline updates would allow gradual quality regression to go undetected. A human must review and approve a baseline update after each release pass. |

--- a/specs/45-evaluation-pipeline.md
+++ b/specs/45-evaluation-pipeline.md
@@ -158,7 +158,9 @@ batch medians per category:
 
 If any `batch_category_medians[cat] < baseline[cat] - 0.10`, the pipeline
 marks the comparison as **regression** and includes the category and delta
-in the verdict output.
+in the verdict output. Categories with `status == "not_evaluated"` (i.e.,
+absent from `batch_category_medians`) are **skipped** during baseline
+comparison — they do not trigger a regression.
 
 The baseline MUST be updated manually after a human-reviewed release pass.
 Automated CI runs MUST NOT update the baseline.
@@ -180,6 +182,9 @@ the session's trace:
 - Score name: `narrative_quality_{category_id.lower()}` (e.g., `narrative_quality_qc_01`)
 - Score value: category score (float)
 - Score comment: category notes
+
+Categories with `score == None` (i.e., `status == "not_evaluated"`) are
+**omitted** from the Langfuse export — no score is emitted for them.
 
 Langfuse export is fire-and-forget: failure to export MUST NOT block the
 pipeline verdict.
@@ -212,7 +217,7 @@ jobs:
   evaluate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@<SHA>
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Run evaluation pipeline
         run: |
           uv run python -m tta.eval.pipeline --mode ${{ inputs.mode || 'ci' }}
@@ -222,7 +227,7 @@ jobs:
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
       - name: Upload eval report
         if: always()
-        uses: actions/upload-artifact@<SHA>
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: eval-report
           path: eval_output/

--- a/specs/README.md
+++ b/specs/README.md
@@ -128,10 +128,10 @@ for the full roadmap rationale, dependency graph, and open questions per spec.
 
 | # | Name | Description |
 |---|------|-------------|
-| [S41](41-scenario-seed-library.md) | Scenario Seed Library | Curated/community scenario seeds; YAML/JSON format; discovery registry |
+| [S41](41-scenario-seed-library.md) | Scenario Seed Library | Curated/community scenario seeds; YAML format; discovery registry |
 | [S42](42-llm-playtester-agent-harness.md) | LLM Playtester Agent Harness | LLM-persona agents; semi-randomized taste profiles; end-to-end session runs; transcript + commentary |
-| [S43](43-human-playtester-program.md) | Human Playtester Program | Recruitment, consent, NDA; structured feedback protocol |
-| [S44](44-narrative-quality-evaluation.md) | Narrative Quality Evaluation | Scoring rubric; 0–1 normalisation; LLM + human signal weighting |
+| [S43](43-human-playtester-program.md) | Human Playtester Program | Recruitment, consent; structured feedback protocol |
+| [S44](44-narrative-quality-evaluation.md) | Narrative Quality Evaluation | Scoring rubric; 0–1 normalization; LLM + human signal weighting |
 | [S45](45-evaluation-pipeline.md) | Evaluation Pipeline | Orchestration of parallel LLM-playtester runs; human-playtester intake; result aggregation; CI thresholds |
 
 ### v3 — "Ship It" (S46–S49)

--- a/specs/README.md
+++ b/specs/README.md
@@ -128,11 +128,11 @@ for the full roadmap rationale, dependency graph, and open questions per spec.
 
 | # | Name | Description |
 |---|------|-------------|
-| S41 | Scenario Seed Library | Curated/community scenario seeds; YAML/JSON format; discovery registry |
-| S42 | LLM Playtester Agent Harness | LLM-persona agents; semi-randomized taste profiles; end-to-end session runs; transcript + commentary |
-| S43 | Human Playtester Program | Recruitment, consent, NDA; structured feedback protocol |
-| S44 | Narrative Quality Evaluation | Scoring rubric; 0–1 normalisation; LLM + human signal weighting |
-| S45 | Evaluation Pipeline | Orchestration of parallel LLM-playtester runs; human-playtester intake; result aggregation; CI thresholds |
+| [S41](41-scenario-seed-library.md) | Scenario Seed Library | Curated/community scenario seeds; YAML/JSON format; discovery registry |
+| [S42](42-llm-playtester-agent-harness.md) | LLM Playtester Agent Harness | LLM-persona agents; semi-randomized taste profiles; end-to-end session runs; transcript + commentary |
+| [S43](43-human-playtester-program.md) | Human Playtester Program | Recruitment, consent, NDA; structured feedback protocol |
+| [S44](44-narrative-quality-evaluation.md) | Narrative Quality Evaluation | Scoring rubric; 0–1 normalisation; LLM + human signal weighting |
+| [S45](45-evaluation-pipeline.md) | Evaluation Pipeline | Orchestration of parallel LLM-playtester runs; human-playtester intake; result aggregation; CI thresholds |
 
 ### v3 — "Ship It" (S46–S49)
 


### PR DESCRIPTION
## Summary

Adds 5 specs for the v2.1 "Prove It's Fun" release: scenario seed library, LLM playtester agent harness, human playtester program, narrative quality evaluation, and evaluation pipeline.

**Stacked PR** — base is #164 (S40); GitHub will auto-retarget to \`main\` once upstream PRs merge.

## Scope

- S41: Scenario Seed Library — YAML format; 4 canonical seeds preserved (\`bus-stop-shimmer\`, \`cafe-with-strange-symbols\`, \`library-forbidden-book\`, \`dirty-frodo\`)
- S42: LLM Playtester Agent Harness — semi-randomized taste profiles; end-to-end session runs
- S43: Human Playtester Program — 10–30 participants; consent, NDA, intake form
- S44: Narrative Quality Evaluation — LLM + human signal weighting
- S45: Evaluation Pipeline — parallel runs; CI mode + release mode; Langfuse integration

## Decision Record

See [docs/superpowers/specs/2026-04-21-v2-v3-roadmap-design.md](docs/superpowers/specs/2026-04-21-v2-v3-roadmap-design.md) §5. S43 was added in the review round to close the HIGH-1 gap identified by the spec reviewer.

## Test plan

- [ ] \`make validate-all\` passes
- [ ] S41–S45 cross-references resolve correctly
- [ ] S43 recruitment/consent text flagged for later legal review

🤖 Generated with [Claude Code](https://claude.com/claude-code)