### PR TITLE
docs(specs): add v3 cloud deployment suite S46-S49

### DIFF
--- a/specs/46-cloud-deployment-target.md
+++ b/specs/46-cloud-deployment-target.md
@@ -1,0 +1,236 @@
+# S46 — Cloud Deployment Target
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v3
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 4 — Operations
+> **Dependencies**: v1 S14 (Deployment — local Docker Compose)
+> **Related**: S49 (Horizontal Scaling), v1 S15 (Observability)
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+S14 defined Docker Compose on a single host as the v1 deployment target. S46
+extends TTA to a cloud-hosted production deployment. At v3 release, S46
+supersedes S14's role in the *live system*. S14 remains closed and unchanged;
+Docker Compose continues to be the canonical local development environment.
+
+This spec answers:
+- Which cloud platform hosts production and staging?
+- How are the three data stores (PostgreSQL, Neo4j, Redis) provisioned?
+- How are secrets managed across environments?
+- What is the zero-downtime deploy procedure?
+- How is environment parity enforced across dev, staging, and prod?
+
+---
+
+## 2. Design Decisions
+
+### 2.1 Cloud Platform: Fly.io
+
+**Decision**: TTA deploys to **Fly.io** at v3.
+
+Rationale:
+- Native Docker image deployment (same image as local S14 dev)
+- Fly Postgres (managed PostgreSQL) is directly integrated
+- Fly Volumes support Neo4j and Redis persistence without a third-party service
+- Fly Machines API supports rolling deploys with zero-downtime
+- Free tier sufficient for staging; pay-as-you-go for production
+- No Kubernetes complexity; matches the single-process-per-instance mandate
+
+Alternatives considered:
+- **Cloud Run**: Stateless containers only; Neo4j volume persistence is awkward.
+- **Railway**: Suitable, but less control over machine sizing and roll-out.
+- **VPS (Hetzner/DO)**: Requires manual ops for rolling deploys and certs.
+
+### 2.2 Data Store Provisioning
+
+| Store | Provisioning | Notes |
+|---|---|---|
+| PostgreSQL | Fly Postgres cluster (1 primary, v3 stage) | Managed backups, HA at v4 if needed |
+| Neo4j | Fly Machine + persistent Volume (`/data`) | CE 5.x Docker image |
+| Redis | Fly Machine + persistent Volume (`/data`) | Redis 7+ Docker image |
+
+### 2.3 Environments
+
+Three environments are required:
+
+| Environment | Purpose | Auto-deploy |
+|---|---|---|
+| `development` | Local Docker Compose (S14) | No |
+| `staging` | Fly.io; triggers on merge to `main` | Yes |
+| `production` | Fly.io; manual promotion from staging | No |
+
+Staging uses the same `fly.toml` as production but a separate Fly app
+(`tta-staging`). Both apps share the same Docker image published per commit.
+
+---
+
+## 3. Functional Requirements
+
+### FR-46.01 — Single Docker Image for All Environments
+
+The same Docker image (built by S14's Dockerfile) SHALL be deployed to local
+dev, staging, and production. Environment-specific behavior is controlled
+entirely by environment variables. No image variant builds are permitted.
+
+### FR-46.02 — Fly.io App Configuration
+
+A `fly.toml` at the repository root SHALL configure the TTA API machine:
+
+```toml
+app = "tta-production"
+primary_region = "iad"
+
+[build]
+  image = "registry.fly.io/tta-production:latest"
+
+[env]
+  TTA_ENV = "staging"  # overridden in prod app
+  PORT = "8000"
+
+[[services]]
+  internal_port = 8000
+  protocol = "tcp"
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+    force_https = true
+
+[deploy]
+  release_command = "uv run alembic upgrade head"
+  strategy = "rolling"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"
+```
+
+### FR-46.03 — Secrets Management
+
+All secrets SHALL be stored as Fly secrets (`fly secrets set KEY=VALUE`).
+Secrets are never stored in `fly.toml`, source code, or CI environment
+variable logs.
+
+Required secrets in every Fly environment:
+- `DATABASE_URL` — PostgreSQL connection string
+- `NEO4J_URI`, `NEO4J_USERNAME`, `NEO4J_PASSWORD`
+- `REDIS_URL`
+- `TTA_API_SECRET_KEY`
+- `LANGFUSE_SECRET_KEY`, `LANGFUSE_PUBLIC_KEY`
+- `LITELLM_API_KEY` (or provider-specific key)
+
+The `.env.example` (S14) continues to serve as the canonical list of required
+variables. It is the source of truth for which secrets must exist in each
+Fly environment.
+
+### FR-46.04 — Zero-Downtime Deployments
+
+Deployments SHALL use Fly's `rolling` strategy: new machines start and pass
+health checks before old machines are stopped. The `release_command` runs
+Alembic migrations before any machine is replaced. Migrations MUST be
+backward-compatible with the previous running version (expand/contract pattern).
+
+### FR-46.05 — Neo4j and Redis Machines
+
+Neo4j and Redis SHALL run as dedicated Fly Machines in the same Fly
+organization. Each SHALL have a Fly Volume mounted at `/data` (10 GB minimum).
+These machines are NOT auto-replaced on deploy; they are persistent state
+nodes. Fly Volumes provide AZ-local persistence.
+
+### FR-46.06 — CI/CD Pipeline Extension
+
+The existing CI pipeline (S14 FR-14.19, FR-14.20) SHALL be extended with:
+1. `fly deploy --app tta-staging --image registry.fly.io/tta:$SHA` — on merge
+   to `main`, after all tests pass
+2. `fly deploy --app tta-production --image registry.fly.io/tta:$TAG` — on
+   manual tag push (`v*`), after staging smoke tests pass
+
+The CI job requires `FLY_API_TOKEN` stored as a GitHub Actions secret.
+
+### FR-46.07 — Environment Parity Audit
+
+Before every production deploy, a parity check script SHALL verify that the
+staging and production Fly secrets have the same *key set* (values differ;
+keys must match). Any key present in staging but absent in production SHALL
+block the deploy.
+
+### FR-46.08 — TTA_ENV = "production" Constraints
+
+When `TTA_ENV=production`, the application MUST:
+- Disable debug endpoints
+- Emit structured JSON logs (no human-readable dev format)
+- Reject startup if any `CHANGE_ME` placeholder remains in loaded config
+
+### FR-46.09 — Backup and Recovery
+
+PostgreSQL: Fly Postgres provides daily snapshots. A weekly manual restore
+drill is required before v3 launch.
+
+Neo4j: A daily backup script SHALL run `neo4j-admin database dump` and upload
+the dump to a cloud object store (Tigris / S3-compatible). Retention: 14 days.
+
+Redis: Redis is ephemeral session/cache storage; durability is provided by
+`appendonly yes` (AOF). If AOF is lost, sessions are invalidated gracefully.
+
+---
+
+## 4. Acceptance Criteria (Gherkin)
+
+```gherkin
+Feature: Cloud Deployment
+
+  Scenario: AC-46.01 — Staging auto-deploys on main merge
+    Given a PR is merged to main
+    And all CI checks pass
+    When the deploy job runs
+    Then fly deploy runs for tta-staging with the new image SHA
+    And the Alembic migration runs before machines are replaced
+    And the staging app responds 200 to GET /api/v1/health within 120s
+
+  Scenario: AC-46.02 — Production deploys only on manual tag
+    Given a git tag matching v* is pushed
+    When the production deploy job runs
+    Then parity check confirms staging and prod have the same secret key set
+    And fly deploy runs for tta-production with the tagged image
+
+  Scenario: AC-46.03 — Secrets never in source or logs
+    Given CI workflow logs for a staging deploy
+    When the logs are scanned for secret values
+    Then no DATABASE_URL, API keys, or passwords are present in any log line
+
+  Scenario: AC-46.04 — Zero-downtime rolling deploy
+    Given a staging deploy is in progress (rolling strategy)
+    When a new machine starts
+    Then health check passes before old machine stops
+    And requests to staging return 200 throughout the deploy
+
+  Scenario: AC-46.05 — TTA_ENV=production rejects CHANGE_ME placeholders
+    Given TTA_ENV=production
+    And TTA_API_SECRET_KEY = "CHANGE_ME_BEFORE_RUNNING"
+    When the application starts
+    Then startup fails with a clear error identifying the variable
+```
+
+---
+
+## 5. Out of Scope
+
+- Multi-region deployments (v4+, depends on S49 horizontal scaling).
+- Kubernetes or ECS (single-process mandate; Fly Machines are sufficient for v3).
+- CDN or edge caching (static asset serving not a v3 requirement).
+- Database high-availability (single Fly Postgres machine is sufficient for v3
+  scale; HA upgrade deferred to v4+).
+
+---
+
+## 6. Open Questions
+
+| ID | Question | Status | Resolution |
+|---|----------|--------|------------|
+| OQ-46.01 | Cloud target — Fly.io vs Cloud Run vs other | ✅ Resolved | **Fly.io** — native Docker deployment, volume persistence for Neo4j/Redis, rolling deploy, managed Postgres, minimal ops overhead. |

--- a/specs/47-live-neo4j-in-ci.md
+++ b/specs/47-live-neo4j-in-ci.md
@@ -1,0 +1,187 @@
+# S47 — Live Neo4j in CI
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v3
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 4 — Operations
+> **Dependencies**: v1 S13 (World Graph Schema), v1 S16 (Testing Infrastructure)
+> **Related**: S46 (Cloud Deployment), S49 (Horizontal Scaling)
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+The v1 closeout identified a gap in the test suite: integration tests covering
+the Neo4j world graph (S13) rely on mocked drivers, not a live database.
+This means schema mistakes, Cypher query bugs, and relationship-model
+regressions can pass CI and only surface in staging.
+
+S47 replaces the mocked Neo4j integration tests with **ephemeral live Neo4j
+containers** in CI, defines canonical test-data fixtures, and specifies
+setup/teardown cost targets.
+
+---
+
+## 2. Design Decisions
+
+### 2.1 Ephemeral Container per CI Job
+
+Each CI test job that exercises the world graph gets its own Neo4j container.
+GitHub Actions `services:` block provides this at no extra configuration cost.
+The container is thrown away at job end; no shared state between jobs.
+
+### 2.2 Community Edition, No Auth in CI
+
+Neo4j CE 5.x is the production target (S13). In CI, the container runs with
+`NEO4J_AUTH=none` to eliminate credential setup overhead. Production always
+requires credentials; CI tests are sandboxed to the Actions runner.
+
+### 2.3 Fixture Strategy: Cypher Seed Files
+
+Test-data fixtures are `.cypher` files committed to `tests/fixtures/neo4j/`.
+The test framework applies them via the Neo4j Bolt driver at session setup.
+This makes fixtures readable, diffable, and independent of Python ORM state.
+
+---
+
+## 3. Functional Requirements
+
+### FR-47.01 — CI Service Container
+
+The GitHub Actions workflow for integration tests SHALL include a `neo4j`
+service container:
+
+```yaml
+services:
+  neo4j:
+    image: neo4j:5-community
+    env:
+      NEO4J_AUTH: none
+    ports:
+      - 7687:7687
+    options: >-
+      --health-cmd "cypher-shell 'RETURN 1' || exit 1"
+      --health-interval 10s
+      --health-timeout 5s
+      --health-retries 10
+```
+
+Tests connect to `bolt://localhost:7687` with no credentials.
+
+### FR-47.02 — Test Infrastructure Fixture
+
+A pytest fixture `neo4j_session` (scope `function`) SHALL:
+1. Open a Bolt session to the CI Neo4j instance
+2. Load the appropriate seed file(s) from `tests/fixtures/neo4j/`
+3. Yield the session
+4. Execute `MATCH (n) DETACH DELETE n` after each test to reset state
+
+A `neo4j_db` fixture (scope `session`) SHALL verify connectivity at the start
+of the test run and skip all Neo4j tests with a clear message if the service
+is unreachable (prevents hanging in dev environments without Docker).
+
+### FR-47.03 — Canonical Fixture Files
+
+The following seed files SHALL exist in `tests/fixtures/neo4j/`:
+
+| File | Contents | Used by |
+|---|---|---|
+| `world_minimal.cypher` | 1 Universe, 1 Location, 1 Actor | Basic graph CRUD tests |
+| `world_with_npcs.cypher` | 3 Locations, 2 NPCs, relationship edges | NPC presence tests |
+| `world_full.cypher` | Full canonical test world (all node types from S13) | Schema validation, query tests |
+| `empty.cypher` | No nodes (empty file / comment only) | Negative-path tests |
+
+Fixture files are plain Cypher; they MUST be valid against the S13 schema.
+A CI step SHALL perform a dry-run import of each fixture file using the
+`neo4j-driver` connection (established in FR-47.01) to validate Cypher syntax
+and schema conformance before the full test suite runs.
+
+### FR-47.04 — Replaced Mocked Tests
+
+All integration test files in `tests/integration/` that import a mock Neo4j
+driver (e.g., `AsyncMock`, `MagicMock` for `AsyncDriver`) SHALL be replaced
+with live-driver equivalents using `neo4j_session`. Mock-based Neo4j tests
+are not permitted after S47 is merged.
+
+Unit tests MAY continue to mock Neo4j for pure query-construction or
+transformation logic where no database interaction is tested.
+
+### FR-47.05 — Startup Cost Budget
+
+The Neo4j service container MUST be health-ready within **60 seconds** of
+GitHub Actions job start. Tests SHALL NOT begin until the health check passes.
+If the health check does not pass within 60 seconds, the job fails.
+
+The complete Neo4j-dependent integration test suite SHOULD run in under
+**3 minutes** (excluding container startup). Tests exceeding this budget MUST
+be documented with a justification comment.
+
+### FR-47.06 — Local Development Support
+
+Developers running `make test` locally without a running Neo4j instance MUST
+see a clear skip message, not a hanging test or cryptic connection error.
+
+The `neo4j_db` session fixture detects the missing service via a 2-second
+connection timeout and calls `pytest.skip("Neo4j not available — skipping",
+allow_module_level=True)` on all affected tests.
+
+### FR-47.07 — Schema Version Gate
+
+The `world_full.cypher` fixture includes a constraint set that mirrors the
+S13-defined uniqueness constraints. The `neo4j_session` fixture verifies
+these constraints are present before any test runs. If constraints are
+missing or wrong, tests fail with `Neo4jSchemaError`, not silent wrong data.
+
+---
+
+## 4. Acceptance Criteria (Gherkin)
+
+```gherkin
+Feature: Live Neo4j in CI
+
+  Scenario: AC-47.01 — Neo4j service starts and is ready within 60s
+    Given a GitHub Actions integration test job starts
+    When the neo4j service container is launched
+    Then the health check passes within 60 seconds
+    And tests begin only after health check passes
+
+  Scenario: AC-47.02 — Each test runs against a fresh graph
+    Given test A writes nodes to the graph
+    When test A ends
+    Then MATCH (n) DETACH DELETE n is executed
+    And test B starts with an empty database
+
+  Scenario: AC-47.03 — No mock Neo4j drivers in integration tests
+    Given the integration test directory is scanned
+    When any test file is checked for AsyncMock or MagicMock on AsyncDriver
+    Then zero files match (all Neo4j interaction uses the live driver)
+
+  Scenario: AC-47.04 — Neo4j absent in dev does not hang
+    Given Neo4j is not running locally
+    When make test is run
+    Then all Neo4j integration tests are skipped within 5 seconds
+    And the skip message includes "Neo4j not available"
+
+  Scenario: AC-47.05 — world_full.cypher validates against S13 schema
+    Given world_full.cypher is loaded
+    When a dry-run import is performed via neo4j-driver
+    Then the file passes syntax validation
+    And the uniqueness constraints from S13 are present
+```
+
+---
+
+## 5. Out of Scope
+
+- Live Neo4j in load/performance tests (those use synthetic data).
+- Neo4j cluster testing (CE is single-instance; cluster deferred to v4+).
+- Replacing unit-level Neo4j mocks (only integration tests are affected).
+
+---
+
+## 6. Open Questions
+
+| ID | Question | Status | Resolution |
+|---|----------|--------|------------|
+| OQ-47.01 | Which Cypher linter to use for fixture validation? | ✅ Resolved | **`neo4j-driver`'s built-in query validation** via `AsyncDriver.verify_connectivity()` plus a dry-run fixture import. No separate linter dependency required in v3. |

--- a/specs/48-async-job-runner.md
+++ b/specs/48-async-job-runner.md
@@ -1,0 +1,217 @@
+# S48 — Async Job Runner
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v3
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 4 — Operations
+> **Dependencies**: v1 S17 (Data Privacy / GDPR), v1 S26 (Admin Tooling)
+> **Related**: S46 (Cloud Deployment), v1 S15 (Observability)
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+In v1, operations that should run asynchronously (GDPR deletion requests,
+data-retention sweeps, backfill jobs) are either handled inline on the
+request path (causing latency spikes) or simply deferred. S48 introduces a
+minimal async job runner: a persistent worker process that consumes jobs from
+a Redis queue, runs them, and reports results.
+
+The worker process is explicitly **not a microservice**. It shares the same
+codebase and image as the FastAPI process; it is started with a different
+entrypoint. Both processes run within a single Fly Machine (or on the same
+host in local dev). The single-process-per-deployment-unit mandate from the
+project charter applies per-instance; a worker co-located on the same machine
+is a separate process, not a separate service.
+
+---
+
+## 2. Design Decisions
+
+### 2.1 Job Runner Library: ARQ
+
+**Decision**: TTA uses **ARQ** (Async Redis Queue) as the job runner.
+
+Rationale:
+- ARQ is asyncio-native; jobs are `async def` coroutines — no sync/async
+  bridge required.
+- TTA already depends on Redis (S11 sessions, S12 persistence). No new
+  infrastructure is added.
+- ARQ's dependency set is minimal: `arq` + the existing `redis` client.
+- ARQ supports job retries, timeouts, cron scheduling, and result storage.
+- Celery requires a broker abstraction layer and heavier dependencies.
+- RQ is sync-only; Dramatiq lacks built-in asyncio support.
+
+### 2.2 Worker Entrypoint
+
+The worker is started via:
+```bash
+uv run arq tta.jobs.worker.WorkerSettings
+```
+
+In Docker Compose, a `tta-worker` service (already defined in S14 FR-14.2)
+runs this command. In Fly.io (S46), the worker runs as a separate process
+entrypoint on the same Fly Machine as the API.
+
+### 2.3 Job Catalog
+
+The following job types are defined in v3:
+
+| Job ID | Trigger | Description | Timeout |
+|---|---|---|---|
+| `gdpr_delete_player` | API: POST /admin/players/{id}/delete | Full GDPR erasure (S17 FR-17.09) | 120s |
+| `retention_sweep` | Cron: daily 03:00 UTC | Delete data past retention window (S17 FR-17.07) | 600s |
+| `session_cleanup` | Cron: hourly | Remove expired Redis session keys (S11) | 60s |
+| `game_backfill` | Admin: POST /admin/jobs/game-backfill | Rebuild derived data from event log | 1800s |
+
+---
+
+## 3. Functional Requirements
+
+### FR-48.01 — ARQ WorkerSettings
+
+A `WorkerSettings` class in `src/tta/jobs/worker.py` SHALL define:
+```python
+class WorkerSettings:
+    functions = [gdpr_delete_player, retention_sweep, session_cleanup, game_backfill]
+    redis_settings = RedisSettings.from_dsn(settings.redis_url)
+    max_jobs = 10
+    job_timeout = 1800  # global max; per-job timeouts enforce tighter limits
+    keep_result = 3600  # seconds to retain job result in Redis
+    queue_name = "tta:jobs"
+    cron_jobs = [
+        cron(retention_sweep, hour=3, minute=0),
+        cron(session_cleanup, minute=0),
+    ]
+```
+
+### FR-48.02 — Job Enqueue API
+
+Jobs SHALL be enqueued via an `ArqQueue` abstraction in `src/tta/jobs/queue.py`
+that is injected as `app.state.job_queue` in the FastAPI lifespan. Job callers
+MUST NOT access ARQ's `ArqRedis` directly; all enqueue calls go through the
+abstraction. This allows the queue to be mocked in tests.
+
+```python
+class ArqQueue:
+    async def enqueue(self, job_fn: str, *args, _job_id: str | None = None, **kwargs) -> str:
+        ...
+    async def job_status(self, job_id: str) -> JobStatus | None:
+        ...
+```
+
+### FR-48.03 — GDPR Deletion Job
+
+The `gdpr_delete_player` job implements the erasure sequence from S17 FR-17.09:
+1. Delete player record from PostgreSQL (cascades to sessions, consent records)
+2. Delete all `MemoryRecord` nodes for the player from Neo4j
+3. Delete player session keys from Redis
+4. Emit `player_erased` audit log event
+5. If any step fails, the job retries up to 3 times before marking `failed`
+
+Idempotency: if the player no longer exists at job start, the job returns
+`already_erased` and exits successfully.
+
+### FR-48.04 — Retention Sweep Job
+
+The `retention_sweep` job queries PostgreSQL for records past the S17
+retention window. It deletes them in batches of 500 with a 100ms sleep
+between batches to prevent lock contention. The job logs the count of
+deleted records as a structured event.
+
+### FR-48.05 — Job Observability
+
+For every job execution, the worker SHALL emit a structured log event with:
+- `job_id`, `job_fn`, `status` (queued/started/complete/failed)
+- `duration_ms` (on complete/failed)
+- `error` (on failed, without PII)
+
+Prometheus metrics SHALL include:
+- `tta_job_runs_total{job_fn, status}` (counter)
+- `tta_job_duration_seconds{job_fn}` (histogram)
+
+### FR-48.06 — Graceful Shutdown
+
+The ARQ worker SHALL handle `SIGTERM` by completing the current job (up to
+its individual timeout) and then exiting. In-flight jobs are not interrupted
+mid-execution on graceful shutdown. A `SIGKILL` fallback occurs after the
+deployment max stop timeout (configurable; default 30s in Fly).
+
+### FR-48.07 — Admin Job Enqueueing
+
+The existing admin API (S26) SHALL gain two endpoints:
+- `POST /admin/jobs/{job_id}/enqueue` — enqueues a named job on demand
+- `GET /admin/jobs/{job_id}/status` — returns current status from ARQ result store
+
+These endpoints require admin authentication (S26 AC).
+
+### FR-48.08 — Dead Letter Handling
+
+Jobs that exhaust their retries SHALL be moved to a `tta:jobs:dead` dead-letter
+queue key in Redis. A Prometheus alert SHALL fire if the dead-letter count
+exceeds 5. The admin can inspect dead-letter jobs via `GET /admin/jobs/dead`.
+
+---
+
+## 4. Acceptance Criteria (Gherkin)
+
+```gherkin
+Feature: Async Job Runner
+
+  Scenario: AC-48.01 — GDPR erasure job runs end-to-end
+    Given a player with sessions, memory records, and consent records
+    When gdpr_delete_player(player_id) is enqueued and runs
+    Then all player records are deleted from PostgreSQL
+    And all MemoryRecord nodes are deleted from Neo4j
+    And all Redis session keys for the player are removed
+    And an audit log event player_erased is emitted
+
+  Scenario: AC-48.02 — GDPR job is idempotent
+    Given a player has already been erased
+    When gdpr_delete_player(player_id) is enqueued again
+    Then the job returns already_erased
+    And exits with success (no retry)
+
+  Scenario: AC-48.03 — Retention sweep deletes expired records in batches
+    Given 1200 records past the retention window exist
+    When retention_sweep runs
+    Then records are deleted in batches of 500
+    And a structured log event records deleted_count = 1200
+
+  Scenario: AC-48.04 — Failed jobs after 3 retries land in dead-letter queue
+    Given a job fails 3 times consecutively
+    When the worker exhausts retries
+    Then the job is added to tta:jobs:dead
+    And tta_job_runs_total{status="failed"} is incremented
+
+  Scenario: AC-48.05 — Worker shuts down gracefully on SIGTERM
+    Given the worker is processing a job
+    When SIGTERM is received
+    Then the current job completes before the process exits
+    And no job is left in an inconsistent state
+
+  Scenario: AC-48.06 — Admin can enqueue and check job status
+    Given an authenticated admin request
+    When POST /admin/jobs/session_cleanup/enqueue is called
+    Then a job_id is returned
+    And GET /admin/jobs/{job_id}/status returns the current state
+```
+
+---
+
+## 5. Out of Scope
+
+- Distributed job locking across multiple worker instances (S49 concern).
+- Priority queues (all jobs share one queue in v3).
+- Job scheduling UI (admin API endpoints are sufficient for v3).
+- Long-running generative jobs (LLM calls happen on the request path; S08).
+
+---
+
+## 6. Open Questions
+
+| ID | Question | Status | Resolution |
+|---|----------|--------|------------|
+| OQ-48.01 | ARQ vs Celery vs RQ? | ✅ Resolved | **ARQ** — asyncio-native, Redis-backed (no new infra), minimal dependencies, built-in cron. |
+| OQ-48.02 | Worker co-location or separate host? | ✅ Resolved | **Same Fly Machine in v3** (entrypoint process; fits single-unit mandate). S49 review will address scaling the worker separately if needed. |

--- a/specs/49-horizontal-scaling.md
+++ b/specs/49-horizontal-scaling.md
@@ -1,0 +1,213 @@
+# S49 — Horizontal Scaling & Multi-Instance Sessions
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v3
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 4 — Operations
+> **Dependencies**: v1 S11 (Player Identity & Sessions), v1 S12 (Persistence Strategy)
+> **Related**: S46 (Cloud Deployment), S48 (Async Job Runner), v1 S10 (API & Streaming)
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+v1 TTA runs as a single process. For v3, TTA must tolerate multiple instances
+of the FastAPI process running behind a load balancer without any session
+data loss or routing failures.
+
+**Clarifying note on the project charter's "single FastAPI process, no
+microservices" mandate.** S49 does not introduce microservices. Each instance
+is a full, self-contained FastAPI process. Horizontal scaling runs multiple
+*identical* copies. No service decomposition occurs.
+
+This spec answers:
+- Session affinity vs. stateless sessions: which approach?
+- How are Redis-backed sessions shared across instances?
+- How is SSE (streaming) handled when a player's instance restarts or moves?
+- What is the ARQ job deduplication strategy across multiple workers?
+
+---
+
+## 2. Design Decisions
+
+### 2.1 Stateless Sessions via Redis (No Affinity)
+
+**Decision**: TTA uses **stateless sessions** stored entirely in Redis. No
+session affinity (sticky sessions) at the load balancer is required.
+
+Rationale:
+- All session state is already in Redis (S11). Per-instance in-memory session
+  caches are not used. Any instance can serve any request.
+- Session affinity complicates rolling deploys and health-check routing.
+- Fly.io's proxy does not guarantee sticky sessions for free; stateless is
+  more reliable.
+- The only complication is SSE streams (see §2.2).
+
+Alternatives considered:
+- **Session affinity**: Simpler for SSE but creates hot spots and complicates
+  deploys. Rejected.
+
+### 2.2 SSE and Multi-Instance Routing
+
+SSE connections (S10 streaming) are long-lived; they must remain on the same
+instance for the duration of the stream. However, when an instance restarts
+(e.g., rolling deploy), the client MUST reconnect to another instance.
+
+**Decision**: Use **Fly.io session affinity** for SSE connections only.
+Fly's `fly-force-instance-id` response header enables affinity for a specific
+request type. SSE endpoints set this header; non-streaming endpoints do not.
+
+If the pinned instance disappears, the client sees a stream error and the
+existing SSE reconnect logic (S10 FR-10.41–FR-10.44, AC-10.05) handles reconnection to a new
+instance. The new instance reconstructs turn state from Redis + PostgreSQL.
+
+### 2.3 Redis PubSub for Cross-Instance Notifications
+
+In-process event notifications (e.g., admin broadcast, session invalidation)
+that previously relied on in-process state MUST be migrated to Redis PubSub
+channels so all instances receive the event.
+
+---
+
+## 3. Functional Requirements
+
+### FR-49.01 — No In-Process Session State
+
+After S49, no in-process Python object SHALL hold the canonical copy of any
+session attribute. All reads and writes to session state MUST go through Redis.
+A code audit SHALL be performed as part of S49 to identify and remove any
+remaining in-process caches of session data.
+
+### FR-49.02 — Redis Session Key Schema
+
+Session keys in Redis SHALL follow the pattern:
+- `tta:session:{session_id}` → JSON blob (all session fields from S11)
+- `tta:session_idx:player:{player_id}` → sorted set of active session IDs for the player (score = creation Unix timestamp)
+
+All reads use `GET`; all writes use `SET ... EX {ttl}`. No instance-local
+shadow copies.
+
+### FR-49.03 — SSE Affinity Header
+
+Every SSE response from `GET /api/v1/games/{id}/stream` SHALL include:
+```
+fly-force-instance-id: {fly_machine_id}
+```
+where `fly_machine_id` is read from the `FLY_MACHINE_ID` environment variable.
+In non-Fly environments (local dev, CI), this header is omitted.
+
+### FR-49.04 — Cross-Instance Event Log
+
+SSE reconnect protocol (EventSource `onerror`, 2 s delay, `Last-Event-ID`
+header) is governed by S10 (FR-10.41–FR-10.44, AC-10.05). S49's novel
+addition is the backing store that makes reconnection to *any* instance
+possible:
+
+- All instances that stream events to clients SHALL publish each SSE event to
+  a Redis stream keyed `tta:stream:{session_id}` (XADD, `MAXLEN ~` 500).
+- On reconnect, the receiving instance (which may differ from the original)
+  SHALL replay events from that stream since `Last-Event-ID` using XRANGE,
+  rather than relying on in-process memory.
+- If the stream entry for `Last-Event-ID` has been evicted, the instance SHALL
+  return a snapshot of current game state instead of replaying.
+
+### FR-49.05 — Redis PubSub for Admin Broadcasts
+
+Admin operations that must reach all instances (e.g., session invalidation,
+game termination signals) SHALL publish to a Redis channel `tta:broadcast`.
+Each instance subscribes to this channel on startup and acts on messages
+it receives. Instances that are not subscribed when a message is published
+will pick up state from Redis on next request (eventual consistency).
+
+### FR-49.06 — ARQ Job Deduplication
+
+When multiple worker processes are running (one per Fly Machine), ARQ's
+built-in job deduplication via `_job_id` SHALL be used for all cron jobs.
+The `job_id` for cron jobs is the job function name + UTC date (truncated to
+the hour). This prevents multiple workers from running the same retention
+sweep simultaneously.
+
+### FR-49.07 — Fly Autoscale Configuration
+
+For v3, Fly autoscaling SHALL be configured to scale between 1 and 3
+instances based on HTTP request concurrency (`min = 1, max = 3`).
+Scaling thresholds and instance sizes are defined in `fly.toml`.
+
+### FR-49.08 — Health Check Ensures Redis Connectivity
+
+The `/api/v1/health/ready` endpoint (S15) SHALL include a Redis connectivity
+check. If Redis is unreachable, the instance returns `503`. The load balancer
+removes it from rotation until Redis is restored. This prevents an instance
+without session access from serving requests.
+
+### FR-49.09 — Load Test Requirement
+
+Before v3 release, a load test SHALL be run against the staging environment
+with 2 instances and 50 concurrent SSE connections. The test verifies:
+- No session data loss when a request hits a different instance than the SSE
+  stream
+- P95 response time for `POST /api/v1/games/{id}/turn` < 2 seconds under load
+- Zero session corruption events in Redis during the test
+
+---
+
+## 4. Acceptance Criteria (Gherkin)
+
+```gherkin
+Feature: Horizontal Scaling
+
+  Scenario: AC-49.01 — Session readable from any instance
+    Given a session created on instance A
+    When a request for that session arrives on instance B
+    Then instance B reads the full session from Redis
+    And returns a correct response without re-authentication
+
+  Scenario: AC-49.02 — SSE affinity header is set
+    Given FLY_MACHINE_ID = "machine-xyz"
+    When GET /api/v1/games/{id}/stream is called
+    Then the response includes header fly-force-instance-id: machine-xyz
+
+  Scenario: AC-49.03 — SSE client reconnects after instance restart
+    Given a client is receiving an SSE stream on instance A
+    When instance A is stopped (simulated rolling deploy)
+    Then the client reconnects within 5 seconds
+    And the new SSE stream resumes from Last-Event-ID
+
+  Scenario: AC-49.04 — Admin session invalidation reaches all instances
+    Given 2 instances are running
+    And admin invalidates session S on instance A
+    When any subsequent request with session S arrives on instance B
+    Then instance B rejects the session as invalid
+
+  Scenario: AC-49.05 — Duplicate cron jobs are prevented
+    Given 2 ARQ workers are running
+    When the hourly cron fires at 03:00 UTC
+    Then only one instance of retention_sweep runs
+    And the second worker's job is deduplicated by job_id
+
+  Scenario: AC-49.06 — Instance without Redis is removed from rotation
+    Given an instance cannot reach Redis
+    When GET /api/v1/health/ready is called on that instance
+    Then 503 is returned
+    And the load balancer stops routing to the instance
+```
+
+---
+
+## 5. Out of Scope
+
+- Multi-region deployments (all instances in a single Fly region for v3).
+- Database read replicas (all instances share one PostgreSQL primary).
+- Redis clustering (single Redis instance is sufficient for v3 scale).
+- Distributed Neo4j (CE is single-instance; clustering deferred to v4+).
+- WebSocket transport (handled by S59 in v4+; SSE is the v3 streaming model).
+
+---
+
+## 6. Open Questions
+
+| ID | Question | Status | Resolution |
+|---|----------|--------|------------|
+| OQ-49.01 | Session affinity vs stateless sessions? | ✅ Resolved | **Stateless sessions via Redis** for all request types; **Fly-instance affinity for SSE only** via `fly-force-instance-id` response header. |
+| OQ-49.02 | How to handle SSE on instance loss? | ✅ Resolved | Client reconnects via existing SSE `onerror` + `Last-Event-ID` replay from Redis stream. No additional server-side machinery needed. |

--- a/specs/README.md
+++ b/specs/README.md
@@ -138,10 +138,10 @@ for the full roadmap rationale, dependency graph, and open questions per spec.
 
 | # | Name | Description |
 |---|------|-------------|
-| S46 | Cloud Deployment v2 | Fly.io / Cloud Run; live-DB CI; TLS; secrets rotation |
-| S47 | Live Neo4j in CI | Ephemeral Neo4j per test run; replaces mocked integration tests; fixture setup/teardown |
-| S48 | Async Job Runner | Job queue + worker for GDPR deletion, retention sweeps, backfills; worker permitted alongside FastAPI process |
-| S49 | Horizontal Scaling | Session affinity policy; Redis cluster; load-balancer config |
+| [S46](46-cloud-deployment-target.md) | Cloud Deployment Target | Fly.io deployment; Fly Postgres + Neo4j/Redis machines; secrets via `fly secrets`; rolling zero-downtime deploys; staging auto-deploy on main merge |
+| [S47](47-live-neo4j-in-ci.md) | Live Neo4j in CI | Ephemeral Neo4j per test run; replaces mocked integration tests; Cypher fixture files; 60s startup budget |
+| [S48](48-async-job-runner.md) | Async Job Runner | ARQ (asyncio Redis queue); jobs: GDPR delete, retention sweep, session cleanup, backfill; dead-letter queue; admin enqueue API |
+| [S49](49-horizontal-scaling.md) | Horizontal Scaling & Multi-Instance Sessions | Stateless Redis sessions (no affinity); SSE affinity via Fly header; Redis PubSub broadcasts; ARQ job deduplication |
 
 ### v4+ — "Multiverse Unlock" (S50–S59)
 


### PR DESCRIPTION
## Summary

Adds 4 specs for the v3 "Ship It" release: cloud deployment target, live Neo4j in CI, async job runner, and horizontal scaling & multi-instance sessions.

**Stacked PR** — base is #165 (v2.1); GitHub will auto-retarget to \`main\` once upstream PRs merge.

## Scope

- S46: Cloud Deployment Target — Fly.io; Fly Postgres + Neo4j/Redis; staging auto-deploy
- S47: Live Neo4j in CI — ephemeral Neo4j per test run; replaces mocked integration tests
- S48: Async Job Runner — ARQ (asyncio Redis queue); GDPR delete, retention sweep, DLQ
- S49: Horizontal Scaling — stateless Redis sessions; SSE affinity via Fly header; Redis PubSub broadcasts

## Decision Record

See [docs/superpowers/specs/2026-04-21-v2-v3-roadmap-design.md](docs/superpowers/specs/2026-04-21-v2-v3-roadmap-design.md) §6. v3 inverts v1 charter priority: "fun & wonder" ships in v2, "deployment" ships in v3.

## Test plan

- [ ] \`make validate-all\` passes
- [ ] S49 single-process reinterpretation clause is present and correct
- [ ] All v3 specs cite v1 predecessors that they extend (not supersede)

🤖 Generated with [Claude Code](https://claude.com/claude-code)