### PR TITLE
docs(specs): add v5+ long vision suite S60-S63

### DIFF
--- a/specs/60-crisis-safety-protocol.md
+++ b/specs/60-crisis-safety-protocol.md
@@ -1,0 +1,156 @@
+# S60 — Crisis Safety Protocol
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v5+
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 4 — Operations
+> **Dependencies**: S08 (Turn Pipeline), S24 (Content Moderation), S07 (LLM Integration)
+> **Related**: S61 (Therapeutic Framework — gated on S60), S23 (Error Handling)
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+S60 is the **gate spec** for S61. Before any therapeutic feature (CBT, mindfulness,
+emotional support) is deployed, a robust crisis safety layer must be in place.
+
+The core concern: a player may arrive in a dark emotional state and engage with TTA
+as an indirect outlet. The game MUST detect signals of acute crisis (suicidal
+ideation, self-harm) and respond with safety-first behavior — regardless of what
+narrative is in progress.
+
+S60 is explicitly **not** a general content moderation spec (S24 handles that).
+S60 is a narrow, high-confidence detection and response protocol for acute crisis.
+
+---
+
+## 2. Detection Approach
+
+Crisis detection uses a **two-tier model**:
+
+| Tier | Method | Latency | Sensitivity |
+|---|---|---|---|
+| **T1 — Fast pattern match** | Regex + keyword list (curated by clinical consultants) | < 5 ms | High recall, lower precision |
+| **T2 — LLM classifier** | Dedicated LLM call with crisis classification prompt | 300–800 ms | High precision |
+
+T1 runs on every player input before the main turn pipeline. T2 is triggered only
+when T1 returns a positive signal. If T2 confirms crisis, the safety response fires.
+If T2 returns negative, the turn pipeline proceeds normally.
+
+**Clinical review requirement**: Both the T1 keyword list and the T2 classifier
+prompt MUST be reviewed and approved by a licensed mental health professional
+before v5 is deployed.
+
+---
+
+## 3. Safety Response
+
+When a confirmed crisis signal is detected:
+
+1. **Interrupt**: the main turn pipeline is halted; the LLM does NOT generate
+   game narration
+2. **Step out of fiction**: a clearly-labeled, out-of-fiction message is
+   delivered to the player (not in character, no narrative framing)
+3. **Provide resources**: the message includes crisis hotline numbers appropriate
+   to the player's configured locale (default: international resources)
+4. **Offer continuation**: the player is told they can return to the story when
+   ready, or end the session
+5. **Log event**: a `crisis_signal_detected` event is logged (no PII; signal
+   context hash only) for internal safety review
+6. **No auto-notify**: TTA does NOT contact anyone on behalf of the player
+   (respects player autonomy; no surveillance)
+
+The out-of-fiction message is a fixed, human-written string (not LLM-generated).
+It is localized per player locale.
+
+---
+
+## 4. Functional Requirements
+
+### FR-60.01 — T1 Pattern Match
+
+T1 runs synchronously in the turn pipeline ingress, before any LLM call.
+T1 MUST complete within 5 ms. Pattern list is loaded from a static config file
+(not from the database) to ensure availability even if services are degraded.
+
+### FR-60.02 — T2 Classifier
+
+T2 uses a dedicated LLM call via S07 with a fixed, audited prompt template
+registered in S09 as `crisis_classifier`. Output is a structured JSON:
+`{signal: bool, confidence: float, category: str}`. If the LLM call fails,
+the system defaults to the T1 signal (fail-safe).
+
+### FR-60.03 — Response Delivery
+
+The safety response is delivered via the same transport as the current session
+(SSE stream or WebSocket). It includes a `message_type: safety_response` field
+so the client can render it with distinct styling.
+
+### FR-60.04 — Audit Trail
+
+Every T2 invocation is logged with `{timestamp, signal_hash, confidence, action_taken}`.
+Logs are retained for 90 days for internal safety review. This is a dedicated audit
+trail for safety events, distinct from the standard application log retention policy
+defined in S17 (30 days).
+
+### FR-60.05 — No Therapeutic Content Without S60
+
+The S61 therapeutic framework module MUST NOT be loaded if S60 is not active.
+This is enforced at application startup:
+
+```python
+if not settings.crisis_safety_enabled:
+    raise ConfigurationError("S61 requires S60")
+```
+
+---
+
+## 5. Acceptance Criteria (Gherkin)
+
+```gherkin
+Feature: Crisis Safety Protocol
+
+  Scenario: AC-60.01 — T1 positive triggers T2
+    Given player input contains a T1 crisis keyword
+    When the turn ingress processes the input
+    Then T2 classifier is invoked
+    And the main turn pipeline is paused
+
+  Scenario: AC-60.02 — T2 confirmed crisis delivers safety response
+    Given T2 classifier returns signal=true, confidence=0.95
+    When the safety response fires
+    Then a non-fiction message with crisis resources is delivered
+    And the game narrative is NOT generated
+    And a crisis_signal_detected log event is emitted
+
+  Scenario: AC-60.03 — T2 negative allows turn to proceed
+    Given T1 triggers but T2 returns signal=false
+    When T2 result is processed
+    Then the main turn pipeline resumes
+    And no safety message is delivered
+
+  Scenario: AC-60.04 — T2 failure defaults to T1 signal
+    Given T2 LLM call times out
+    When the timeout occurs
+    Then the T1 positive signal is treated as confirmed
+    And the safety response fires
+```
+
+---
+
+## 6. Out of Scope
+
+- General content moderation (S24).
+- Mandatory reporting or third-party notification.
+- Long-term user support or follow-up.
+- Diagnosis or clinical assessment.
+
+---
+
+## 7. Open Questions
+
+| ID | Question | Status |
+|---|----------|--------|
+| OQ-60.01 | Which clinical consultant(s) will review T1 and T2 content? | 🔓 Open — external partnership required before v5 deployment. |
+| OQ-60.02 | Which crisis resources are included by locale? | 🔓 Open — curated list to be assembled with clinical input. |

--- a/specs/61-therapeutic-framework.md
+++ b/specs/61-therapeutic-framework.md
@@ -1,0 +1,149 @@
+# S61 — Therapeutic Framework
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v5+
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 1 — Core Game
+> **Dependencies**: S60 (Crisis Safety — required gate), S08 (Turn Pipeline), S09 (Prompt Management), S37 (Memory Records)
+> **Related**: S62 (Story Sharing), S56 (Resonance Correlation)
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+S61 defines TTA's optional therapeutic enrichment layer: evidence-informed
+techniques woven into the narrative by the LLM to support emotional wellbeing.
+
+**Critical framing**: TTA is a *game*, not a therapy product. S61 adds
+therapeutic-informed narrative techniques (drawn from CBT and Mindfulness)
+to deepen emotional resonance and support self-reflection. It does NOT
+diagnose, prescribe, or replace professional mental health care.
+
+S61 is gated on S60 (crisis safety must be active). A player may opt out
+of therapeutic enrichment at any time.
+
+---
+
+## 2. Techniques in MVP Scope
+
+Two modalities are in scope for v5 MVP:
+
+| Modality | Source | Application in TTA |
+|---|---|---|
+| **Cognitive Reframing** (CBT-informed) | Cognitive Behavioral Therapy | LLM offers alternative perspectives on a character's interpretations of events; "What if the stranger's silence meant something other than rejection?" |
+| **Grounding Anchors** (Mindfulness-informed) | Mindfulness-Based Stress Reduction | LLM occasionally invites the player to notice a sensory detail in the narrative, anchoring attention to the present |
+
+These are woven into narrative naturally by the LLM — not presented as clinical
+exercises. A player may not consciously recognize them as techniques.
+
+**Out of scope for MVP**: Exposure therapy patterns, motivational interviewing,
+grief work, trauma-informed techniques (all require higher clinical oversight).
+
+---
+
+## 3. Annotation Hook
+
+S61 introduces a `TurnAnnotations` model that the turn pipeline (S08) emits as
+part of its output. S08 defines the hook point; S61 supplies the schema and
+populates it when a technique is applied:
+
+```python
+class TurnAnnotations(BaseModel):
+    therapeutic_technique: str | None  # e.g. "cognitive_reframing", "grounding"
+    emotional_tone: str | None
+    arc_phase: str | None
+```
+
+S61 populates `therapeutic_technique` when a technique is applied in a turn.
+This annotation is used by S45 (evaluation) to measure technique frequency
+and by S62 (story sharing) to contextualize exported stories.
+
+---
+
+## 4. Functional Requirements
+
+### FR-61.01 — Opt-In / Opt-Out
+
+Therapeutic enrichment is opt-in at the player level. A `therapeutic_enrichment`
+preference field is added to the player profile (default: false). Players can
+toggle this in session settings. When false, the therapeutic technique prompt
+hints are omitted from LLM context.
+
+### FR-61.02 — Technique Prompt Injection
+
+When enrichment is enabled, the turn pipeline injects a technique hint into the
+LLM context. The hint is a short directive registered in S09 as one of:
+- `therapeutic_cognitive_reframing_hint`
+- `therapeutic_grounding_anchor_hint`
+
+The technique is selected based on the current narrative arc phase and
+emotional tone annotation from the previous turn.
+
+### FR-61.03 — Frequency Cap
+
+A therapeutic technique is applied at most once per 3 turns (to avoid over-
+saturation). The frequency cap is enforced by the pipeline, not the LLM.
+
+### FR-61.04 — Clinical Review Requirement
+
+All therapeutic technique prompt templates (FR-61.02) MUST be reviewed and
+approved by a licensed mental health professional before v5 deployment.
+This is a non-negotiable gate requirement alongside S60.
+
+### FR-61.05 — No Clinical Claims
+
+Player-facing copy (onboarding, settings, marketing) MUST NOT claim that TTA
+provides therapy, treats mental health conditions, or replaces professional care.
+Copy is reviewed by legal and clinical before publication.
+
+---
+
+## 5. Acceptance Criteria (Gherkin)
+
+```gherkin
+Feature: Therapeutic Framework
+
+  Scenario: AC-61.01 — Enrichment disabled skips technique injection
+    Given a player with therapeutic_enrichment = false
+    When a turn is processed
+    Then no therapeutic technique hint is in the LLM context
+    And turn_annotation.therapeutic_technique is null
+
+  Scenario: AC-61.02 — Enrichment enabled injects a technique
+    Given a player with therapeutic_enrichment = true
+    And the narrative arc is in a reflective phase
+    When a turn is processed
+    Then a therapeutic technique hint is injected into LLM context
+    And turn_annotation.therapeutic_technique is set
+
+  Scenario: AC-61.03 — Frequency cap limits techniques to 1 per 3 turns
+    Given a player with therapeutic_enrichment = true
+    When 3 consecutive turns are processed
+    Then at most 1 turn has a therapeutic technique annotation
+
+  Scenario: AC-61.04 — S60 inactive blocks S61 from loading
+    Given crisis_safety_enabled = false
+    When the application starts
+    Then a ConfigurationError is raised
+    And S61 module is not initialized
+```
+
+---
+
+## 6. Out of Scope
+
+- Diagnosis, clinical assessment, or treatment recommendations.
+- Therapeutic modalities beyond CBT-informed and Mindfulness-informed techniques.
+- Mandatory therapeutic content (always opt-in).
+- Progress tracking or therapeutic outcome measurement.
+
+---
+
+## 7. Open Questions
+
+| ID | Question | Status |
+|---|----------|--------|
+| OQ-61.01 | Which licensed MHP will review prompt templates? | 🔓 Open — external clinical partnership required. |
+| OQ-61.02 | Should the player be informed a technique was used, post-turn? | 🔓 Open — transparency vs. narrative immersion tradeoff; deferred to v5 UX research. |
+| OQ-61.03 | Is CBT-informed sufficient, or do we need a clinical advisory board? | 🔓 Open — legal/ethics review required before v5. |

--- a/specs/62-story-sharing.md
+++ b/specs/62-story-sharing.md
@@ -1,0 +1,144 @@
+# S62 — Story Sharing
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v5+
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 1 — Core Game
+> **Dependencies**: S37 (Memory Records), S17 (Privacy and Data Retention), S27 (Save/Load and Game Management)
+> **Related**: S61 (Therapeutic Framework annotations), S48 (Async Job Runner for export)
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+S62 enables players to export their TTA stories — the narrative journey of a
+completed game — in human-readable formats for personal keeping, sharing, or
+reflection.
+
+Stories are derived from **MemoryRecords** (S37), not raw turn transcripts.
+This ensures exports are curated, meaningful narratives rather than verbose
+logs. It also respects S17 privacy requirements: PII that is not part of the
+narrative is never included in exports.
+
+---
+
+## 2. Export Formats
+
+| Format | Description | Use case |
+|---|---|---|
+| **PDF** | Formatted narrative document with title, chapter structure, cover art prompt | Personal archive, printing |
+| **ePub** | E-reader compatible format | Reading on Kindle/Kobo |
+| **Web (HTML)** | Shareable URL to a read-only hosted story page | Social sharing |
+
+PDF and ePub are generated as downloadable files. Web format is a hosted page
+at `app.tta.io/stories/{story_id}` (public URL; unlisted by default).
+
+---
+
+## 3. Story Structure
+
+The export pipeline constructs a story document from:
+
+1. **Act structure**: MemoryRecords grouped by story arc phase (S05)
+   into chapters (Opening, Rising Action, Climax, Resolution)
+2. **Scene summaries**: each chapter contains the MemoryRecords from that
+   phase, condensed into prose by a dedicated LLM summarization call
+3. **Character portrait**: a brief description of the actor's character
+   derived from their identity attributes (S31) and echo memories
+4. **World colophon**: a short description of the universe the story took place in
+5. **Therapeutic annotations** (optional, if S61 enabled and player opts in):
+   a short reflection section at the end, drawn from `therapeutic_technique`
+   annotations (S61 FR-61.02)
+
+---
+
+## 4. Privacy Safeguards
+
+- Exports MUST NOT include raw player inputs (only the MemoryRecord-derived narrative)
+- Exports MUST NOT include session IDs, player IDs, or account information
+- Web stories are unlisted (not indexed) by default; player must opt-in to public indexing
+- Exports are subject to retention policy: web story URLs expire after
+  `story_url_retention_days` (default: 365) unless renewed
+- On GDPR deletion (S17), all exports and web story URLs are deleted
+
+---
+
+## 5. Functional Requirements
+
+### FR-62.01 — Export Request
+
+A player may request an export of a completed game via `POST /api/v1/games/{game_id}/export`
+with `{format: "pdf" | "epub" | "web"}`. The request is enqueued as an ARQ job
+(S48). A `202 Accepted` response with a `job_id` is returned immediately.
+
+### FR-62.02 — Story Assembly
+
+The ARQ job runs the story assembly pipeline: MemoryRecord retrieval →
+arc grouping → LLM summarization → format rendering. Total pipeline target:
+≤ 60 seconds for a standard-length game (25 turns).
+
+### FR-62.03 — Download / URL Delivery
+
+On job completion, the player receives:
+- For PDF/ePub: a signed S3 URL valid for 24 hours
+- For web: the permanent (until expiry) story URL
+
+### FR-62.04 — Source as MemoryRecords
+
+Export content is derived exclusively from MemoryRecords with `importance_score ≥ 0.5`.
+Raw turn transcripts are never used as export source material.
+
+### FR-62.05 — Game Must Be Completed
+
+Export is only available for games in `completed` or `abandoned` state.
+In-progress games cannot be exported.
+
+---
+
+## 6. Acceptance Criteria (Gherkin)
+
+```gherkin
+Feature: Story Sharing
+
+  Scenario: AC-62.01 — Export request returns 202 with job_id
+    Given a player with a completed game
+    When POST /api/v1/games/{game_id}/export {format: pdf} is called
+    Then a 202 response is returned with a job_id
+    And an ARQ job is enqueued
+
+  Scenario: AC-62.02 — PDF export completes within 60 seconds
+    Given a standard 25-turn game
+    When the export ARQ job runs
+    Then a signed S3 URL is produced within 60 seconds
+
+  Scenario: AC-62.03 — Web story URL uses unguessable token and is unlisted by default
+    Given a web export is completed
+    When the story URL is generated
+    Then the story_id embedded in the URL is a high-entropy, unguessable UUID (not sequential)
+    And the URL is not indexed by search engines (noindex header)
+    And viewer authentication is not required when the request carries a valid story_id
+    And requests that omit a valid story_id return a 404 response
+
+  Scenario: AC-62.04 — GDPR deletion removes all exports
+    Given a player with an exported story
+    When a GDPR deletion request is processed (S17)
+    Then the story file and web URL are deleted
+```
+
+---
+
+## 7. Out of Scope
+
+- Social feed or discovery (S63).
+- Export of in-progress games.
+- Video or audio formats.
+
+---
+
+## 8. Open Questions
+
+| ID | Question | Status |
+|---|----------|--------|
+| OQ-62.01 | Which S3-compatible storage provider? | 🔓 Open — Fly.io Tigris is the likely choice (already on Fly.io per S46). |
+| OQ-62.02 | What PDF rendering library? | 🔓 Open — WeasyPrint (CSS-based, Python) or Reportlab; deferred to v5 impl. |

--- a/specs/63-community-and-user-generated-worlds.md
+++ b/specs/63-community-and-user-generated-worlds.md
@@ -1,0 +1,152 @@
+# S63 — Community and User-Generated Worlds
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v5+
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 1 — Core Game
+> **Dependencies**: S41 (Scenario Seed Library), S39 (Universe Composition Model), S24 (Content Moderation), S17 (Privacy)
+> **Related**: S62 (Story Sharing), S48 (Async Job Runner for moderation)
+> **Last Updated**: 2026-04-21
+
+---
+
+## 1. Purpose
+
+S63 enables players and designers to author, share, and play community-created
+world templates. It extends the S39/S41 template system to include a submission,
+moderation, and discovery pipeline.
+
+The primary use cases are:
+1. **Creator**: a player authors a world template and publishes it
+2. **Explorer**: a player discovers and starts a game in a community-created world
+3. **Moderator**: an admin reviews and approves/rejects submissions
+
+---
+
+## 2. Template Authoring
+
+Community templates use the same S39 universe composition schema as built-in
+templates. A web-based template editor (not in scope for v5 engine spec;
+UI design is deferred) allows creators to define:
+- Universe composition (genre, themes, reality_coherence, etc.)
+- Scenario seeds (S41 format)
+- NPC archetypes
+- Location definitions
+- Nexus ritual (optional, S53)
+
+Templates are submitted as YAML blobs via `POST /community/templates`.
+
+---
+
+## 3. Moderation Pipeline
+
+Submitted templates are NOT immediately published. They enter a moderation queue:
+
+```
+status:pending → (automated review) → status:approved
+                                    → status:pending_human_review → (admin decision) → status:approved / status:rejected
+```
+
+**Automated review**: an LLM moderation call (S24) evaluates the template YAML
+for prohibited content (S24 categories), policy violations, and safety concerns.
+Templates with no flags are auto-approved. Templates with flags enter human review.
+
+**Human review**: an admin uses the `GET /admin/community/templates/pending` queue
+and `POST /admin/community/templates/{id}/decision` endpoint.
+
+---
+
+## 4. Functional Requirements
+
+### FR-63.01 — Template Submission
+
+`POST /community/templates` accepts a template YAML payload. On submission:
+- Template is validated against the S39 schema
+- A `community_template_id` is assigned
+- An ARQ job (S48) is enqueued for automated review
+- A `201 Created` response is returned with `community_template_id` and `status: pending`
+
+### FR-63.02 — Automated Review
+
+The ARQ job runs S24 moderation on the template content. If the template
+passes, `status` is set to `approved` and the template is discoverable.
+If flags are detected, `status` is set to `pending_human_review`.
+
+### FR-63.03 — Template Discovery
+
+`GET /community/templates` returns approved templates with pagination, filtering
+by genre/theme, and sorted by `play_count desc` (most-played first).
+
+### FR-63.04 — Starting a Community Game
+
+A player starts a game using a community template via the standard
+`POST /api/v1/games` endpoint with a `template_id` pointing to the community
+template. The game instantiation pipeline (S02/S03 Genesis) is unchanged.
+
+### FR-63.05 — Attribution
+
+Community templates include a `creator_display_name` field (not player ID).
+Attribution is shown on the template discovery page and game genesis.
+Creator identity is pseudonymous; real identity is not exposed.
+
+### FR-63.06 — Template Versioning
+
+Templates are immutable once approved. A creator may submit a new version,
+which enters the moderation queue independently. Existing games using
+an older version continue on that version.
+
+### FR-63.07 — Takedown
+
+Admins may unpublish a template at any time. Unpublished templates are hidden
+from discovery; existing games using the template are unaffected.
+
+---
+
+## 5. Acceptance Criteria (Gherkin)
+
+```gherkin
+Feature: Community and User-Generated Worlds
+
+  Scenario: AC-63.01 — Template submission creates pending record
+    Given a valid S39 template YAML
+    When POST /community/templates is called
+    Then a 201 response is returned with community_template_id
+    And the template has status = pending
+    And an ARQ review job is enqueued
+
+  Scenario: AC-63.02 — Clean template is auto-approved
+    Given a template with no moderation flags
+    When the ARQ review job runs
+    Then the template status is set to approved
+    And it appears in GET /community/templates
+
+  Scenario: AC-63.03 — Flagged template enters human review
+    Given a template with a content flag from S24
+    When the ARQ review job runs
+    Then the template status is set to pending_human_review
+    And it appears in GET /admin/community/templates/pending
+
+  Scenario: AC-63.04 — Player can start a game with community template
+    Given an approved community template
+    When POST /api/v1/games {template_id: community_template_id} is called
+    Then a game is instantiated using that template
+    And the genesis pipeline runs normally
+```
+
+---
+
+## 6. Out of Scope
+
+- Template editor UI (deferred to v5 UX design).
+- Collaborative template authoring (single creator per template in v5).
+- Revenue sharing or monetization.
+- Template comments or ratings (v6+ community features).
+
+---
+
+## 7. Open Questions
+
+| ID | Question | Status |
+|---|----------|--------|
+| OQ-63.01 | Should community templates be sandboxed from core templates? | 🔓 Open — yes, a `source: community` field separates them; same engine, different discovery path. |
+| OQ-63.02 | What is the SLA for human review turnaround? | 🔓 Open — 48-hour target for v5 launch; depends on moderation staffing. |


### PR DESCRIPTION
## Summary

Adds 4 specs for the v5+ "Long Vision" release: crisis safety protocol (gate spec), therapeutic framework, story sharing, and community & user-generated worlds.

Deliberately thinner than v2.0 specs — they lock scope and non-goals for long-term vision items that depend on clinical consultation (S60/S61) and community infrastructure maturity (S62/S63).

**Stacked PR** — base is #167 (v4+); GitHub will auto-retarget to \`main\` once upstream PRs merge.

## Scope

- S60: Crisis Safety Protocol — two-tier detection (T1 pattern <5ms + T2 LLM classifier); gate spec for S61
- S61: Therapeutic Framework — CBT, mindfulness, emotional support; startup-gated on S60
- S62: Story Sharing
- S63: Community & User-Generated Worlds

## Decision Record

See [docs/superpowers/specs/2026-04-21-v2-v3-roadmap-design.md](docs/superpowers/specs/2026-04-21-v2-v3-roadmap-design.md) §8. S60 is explicitly load-bearing: \`if not settings.crisis_safety_enabled: raise ConfigurationError("S61 requires S60")\`.

## Test plan

- [ ] \`make validate-all\` passes
- [ ] S60 FR-60.05 startup gate language is unambiguous
- [ ] S60/S61 clinical review open questions are captured and visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)