### PR TITLE
feat(wave-37): AC traceability sweep — S06, S10, S11 compliance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       - run: uv run ruff check
       - run: uv run ruff format --check
       - run: uv run pyright
+      - run: uv run pytest tests/unit/api/test_s10_ac_compliance.py::TestAC1002OpenAPIValidity -v
+        name: Validate OpenAPI spec
 
   unit-test:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 # ---------------------------------------------------------------------------
 # Self-documenting help — parses '## ' comments after targets
 # ---------------------------------------------------------------------------
-.PHONY: help validate-specs validate-plans validate-all regen-indexes dashboard trace trace-html \
+.PHONY: help validate-specs validate-plans validate-openapi validate-all regen-indexes \
+	dashboard trace trace-html \
         lint format typecheck test test-unit test-integration test-watch \
         test-bdd test-hypothesis \
         test-up test-down quality check check-format \
@@ -24,7 +25,10 @@ validate-specs: ## Run spec indexer with validation
 validate-plans: ## Run plan indexer with validation
 	uv run python plans/index_plans.py --validate
 
-validate-all: validate-specs validate-plans trace ## Run all validators including AC traceability
+validate-openapi: ## Validate OpenAPI spec passes openapi-spec-validator
+	uv run pytest tests/unit/api/test_s10_ac_compliance.py::TestAC1002OpenAPIValidity -v
+
+validate-all: validate-specs validate-plans validate-openapi trace ## Run all validators including AC traceability
 
 regen-indexes: ## Regenerate spec and plan index files
 	uv run python specs/index_specs.py

--- a/migrations/postgres/versions/013_paused_at.py
+++ b/migrations/postgres/versions/013_paused_at.py
@@ -1,0 +1,31 @@
+"""Add paused_at column to game_sessions (S11 FR-11.41).
+
+Tracks when a game entered paused state so the 30-day expiry window
+is measured from pause time rather than last-played time.
+
+Revision ID: 013
+Revises: 012
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "013"
+down_revision = "012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "game_sessions",
+        sa.Column("paused_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    # Backfill: for existing paused games, use updated_at as a best-effort proxy
+    op.execute(
+        "UPDATE game_sessions SET paused_at = updated_at WHERE status = 'paused'"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("game_sessions", "paused_at")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "ruff>=0.8",
     "pyright>=1.1",
     "locust>=2.0",
+    "openapi-spec-validator>=0.7.2",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/tta/api/routes/games.py
+++ b/src/tta/api/routes/games.py
@@ -2040,9 +2040,12 @@ async def resume_game(
             if intro:
                 recap = str(intro)
 
-    # AC-11.07: Prepend "welcome back" for expired game resumes
-    if previous_status == "expired" and recap:
-        recap = f"Welcome back! It's been a while. {recap}"
+    # AC-11.07: Always emit welcome-back narrative for expired game resumes
+    if previous_status == "expired":
+        if recap:
+            recap = f"Welcome back! It's been a while. {recap}"
+        else:
+            recap = "Welcome back! It's been a while."
 
     # Use actual timestamps — only reflect `now` when we updated.
     resp_updated = now.isoformat() if status_updated else row.updated_at.isoformat()
@@ -2090,13 +2093,22 @@ async def update_game(
         )
 
     now = datetime.now(UTC)
-    await pg.execute(
-        sa.text(
-            "UPDATE game_sessions SET status = :status, "
-            "updated_at = :now WHERE id = :id"
-        ),
-        {"id": game_id, "status": body.status, "now": now},
-    )
+    if body.status == "paused":
+        await pg.execute(
+            sa.text(
+                "UPDATE game_sessions SET status = :status, "
+                "paused_at = :now, updated_at = :now WHERE id = :id"
+            ),
+            {"id": game_id, "status": body.status, "now": now},
+        )
+    else:
+        await pg.execute(
+            sa.text(
+                "UPDATE game_sessions SET status = :status, "
+                "updated_at = :now WHERE id = :id"
+            ),
+            {"id": game_id, "status": body.status, "now": now},
+        )
     await pg.commit()
 
     turn_count = await _get_turn_count(pg, game_id)

--- a/src/tta/api/routes/games.py
+++ b/src/tta/api/routes/games.py
@@ -1949,6 +1949,7 @@ async def resume_game(
         )
 
     recovery_warning: str | None = None
+    previous_status = row.status  # AC-11.07: capture for welcome back narrative
 
     # FR-27.15: attempt recovery if previous save failed
     if row.needs_recovery:
@@ -2038,6 +2039,10 @@ async def resume_game(
             intro = genesis.get("narrative_intro")
             if intro:
                 recap = str(intro)
+
+    # AC-11.07: Prepend "welcome back" for expired game resumes
+    if previous_status == "expired" and recap:
+        recap = f"Welcome back! It's been a while. {recap}"
 
     # Use actual timestamps — only reflect `now` when we updated.
     resp_updated = now.isoformat() if status_updated else row.updated_at.isoformat()

--- a/src/tta/lifecycle/cleanup.py
+++ b/src/tta/lifecycle/cleanup.py
@@ -63,13 +63,13 @@ async def run_lifecycle_pass(
         )
         abandoned = abandon_result.rowcount or 0
 
-        # Rule 2: paused + last_played > 30 days → expired
+        # Rule 2: paused + paused_at > 30 days → expired (NULL fallback for old rows)
         expire_result = await pg.execute(
             sa.text(
                 "UPDATE game_sessions "
                 "SET status = 'expired', updated_at = :now "
                 "WHERE status = 'paused' "
-                "AND last_played_at < :cutoff "
+                "AND (paused_at < :cutoff OR (paused_at IS NULL AND last_played_at < :cutoff)) "
                 "AND deleted_at IS NULL"
             ),
             {"now": now, "cutoff": expire_cutoff},
@@ -80,7 +80,7 @@ async def run_lifecycle_pass(
         idle_result = await pg.execute(
             sa.text(
                 "UPDATE game_sessions "
-                "SET status = 'paused', updated_at = :now "
+                "SET status = 'paused', paused_at = :now, updated_at = :now "
                 "WHERE status = 'active' "
                 "AND turn_count > 0 "
                 "AND updated_at < :cutoff "

--- a/src/tta/lifecycle/cleanup.py
+++ b/src/tta/lifecycle/cleanup.py
@@ -2,7 +2,7 @@
 
 Transitions enforced:
   - ``created``/``active``  + 0 turns + age > 24 h  →  ``abandoned``
-  - ``paused``  + last_played > 30 days  →  ``expired``
+  - ``paused``  + paused_at older than 30 days  →  ``expired``
   - ``active``  + turn_count > 0 + idle > 30 min  →  ``paused``  (AC-1.7)
   - Anonymous players with no active games + 30 d old  →  soft-deleted
     (FR-11.12, FR-11.59)
@@ -63,7 +63,7 @@ async def run_lifecycle_pass(
         )
         abandoned = abandon_result.rowcount or 0
 
-        # Rule 2: paused + paused_at > 30 days → expired (NULL fallback for old rows)
+        # Rule 2: paused + paused_at < cutoff (>30 days ago) → expired; NULL fallback uses last_played_at
         expire_result = await pg.execute(
             sa.text(
                 "UPDATE game_sessions "

--- a/src/tta/lifecycle/cleanup.py
+++ b/src/tta/lifecycle/cleanup.py
@@ -56,7 +56,7 @@ async def run_lifecycle_pass(
                 "SET status = 'abandoned', updated_at = :now "
                 "WHERE status IN ('created', 'active') "
                 "AND turn_count = 0 "
-                "AND created_at <= :cutoff "
+                "AND created_at < :cutoff "
                 "AND deleted_at IS NULL"
             ),
             {"now": now, "cutoff": abandon_cutoff},
@@ -69,7 +69,7 @@ async def run_lifecycle_pass(
                 "UPDATE game_sessions "
                 "SET status = 'expired', updated_at = :now "
                 "WHERE status = 'paused' "
-                "AND last_played_at <= :cutoff "
+                "AND last_played_at < :cutoff "
                 "AND deleted_at IS NULL"
             ),
             {"now": now, "cutoff": expire_cutoff},

--- a/src/tta/lifecycle/cleanup.py
+++ b/src/tta/lifecycle/cleanup.py
@@ -63,13 +63,17 @@ async def run_lifecycle_pass(
         )
         abandoned = abandon_result.rowcount or 0
 
-        # Rule 2: paused + paused_at < cutoff (>30 days ago) → expired; NULL fallback uses last_played_at
+        # Rule 2: paused + paused_at < cutoff (older than 30 days) → expired
+        # NULL fallback: pre-migration rows use last_played_at instead
         expire_result = await pg.execute(
             sa.text(
                 "UPDATE game_sessions "
                 "SET status = 'expired', updated_at = :now "
                 "WHERE status = 'paused' "
-                "AND (paused_at < :cutoff OR (paused_at IS NULL AND last_played_at < :cutoff)) "
+                "AND ("
+                "paused_at < :cutoff "
+                "OR (paused_at IS NULL AND last_played_at < :cutoff)"
+                ") "
                 "AND deleted_at IS NULL"
             ),
             {"now": now, "cutoff": expire_cutoff},

--- a/src/tta/lifecycle/cleanup.py
+++ b/src/tta/lifecycle/cleanup.py
@@ -56,7 +56,7 @@ async def run_lifecycle_pass(
                 "SET status = 'abandoned', updated_at = :now "
                 "WHERE status IN ('created', 'active') "
                 "AND turn_count = 0 "
-                "AND created_at < :cutoff "
+                "AND created_at <= :cutoff "
                 "AND deleted_at IS NULL"
             ),
             {"now": now, "cutoff": abandon_cutoff},
@@ -69,7 +69,7 @@ async def run_lifecycle_pass(
                 "UPDATE game_sessions "
                 "SET status = 'expired', updated_at = :now "
                 "WHERE status = 'paused' "
-                "AND last_played_at < :cutoff "
+                "AND last_played_at <= :cutoff "
                 "AND deleted_at IS NULL"
             ),
             {"now": now, "cutoff": expire_cutoff},

--- a/src/tta/models/game.py
+++ b/src/tta/models/game.py
@@ -39,6 +39,7 @@ class GameSession(BaseModel):
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     last_played_at: datetime | None = None
+    paused_at: datetime | None = None
     deleted_at: datetime | None = None
 
 

--- a/tests/unit/api/test_s10_ac_compliance.py
+++ b/tests/unit/api/test_s10_ac_compliance.py
@@ -1030,3 +1030,37 @@ class TestAC1002OpenAPIValidity:
         spec = resp.json()
         # validate() raises if the spec is invalid
         validate(spec)
+
+
+# ---------------------------------------------------------------------------
+# AC-10.08: Rate-limit headers present on responses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.spec("AC-10.08")
+class TestAC1008RateLimitHeaders:
+    """AC-10.08: Server includes X-RateLimit-* headers on API responses."""
+
+    def test_rate_limit_headers_present_on_game_get(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        """AC-10.08: GET /api/v1/games/{id} includes rate-limit headers."""
+        pg.execute = AsyncMock(return_value=_make_result())
+        resp = client.get(f"/api/v1/games/{uuid4()}")
+        assert "x-ratelimit-limit" in resp.headers
+        assert "x-ratelimit-remaining" in resp.headers
+        assert "x-ratelimit-reset" in resp.headers
+
+    def test_rate_limit_headers_values_are_valid(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        """AC-10.08: Rate-limit header values are valid integers."""
+        pg.execute = AsyncMock(return_value=_make_result())
+        resp = client.get(f"/api/v1/games/{uuid4()}")
+        limit = int(resp.headers.get("x-ratelimit-limit", 0))
+        remaining = int(resp.headers.get("x-ratelimit-remaining", 0))
+        reset_at = int(resp.headers.get("x-ratelimit-reset", 0))
+
+        assert limit > 0
+        assert remaining >= 0
+        assert reset_at > 0

--- a/tests/unit/api/test_s10_ac_compliance.py
+++ b/tests/unit/api/test_s10_ac_compliance.py
@@ -1,18 +1,16 @@
 """S10 API & Streaming — Acceptance Criteria compliance tests.
 
-Covers AC-10.01, AC-10.03, AC-10.07, AC-10.09, AC-10.10, AC-10.11, AC-10.12.
+Covers AC-10.01, AC-10.02, AC-10.03, AC-10.06, AC-10.07, AC-10.08, AC-10.09,
+AC-10.10, AC-10.11, AC-10.12, AC-10.13.
 Also covers S10 §6.2/§6.4/§6.5 canonical event taxonomy:
   FR-10.34 — narrative events with 0-indexed sequence per chunk
   FR-10.35 — narrative_end.total_chunks == number of narrative events
   FR-10.36 — error event on failure includes turn_id; stream continues (returns)
   FR-10.38 — heartbeat event (not keepalive) used for idle connections
 
-v2 ACs (deferred, require integration infra):
-  AC-10.02 — OpenAPI spec validation (openapi-spec-validator tooling)
+Unit-only ACs (require integration infra for full validation):
   AC-10.04 — SSE chunk delivery within 2 s (real-time timing, integration only)
-  AC-10.05 — Reconnect / missed events within 30 s (Redis pub/sub)
-  AC-10.06 — Keepalive heartbeats every 15 s (SSE middleware, integration only)
-  AC-10.08 — Rate-limit headers on every authenticated response (middleware)
+  AC-10.05 — Reconnect / missed events within 30 s (Redis pub/sub, integration only)
 """
 
 from __future__ import annotations

--- a/tests/unit/api/test_s10_ac_compliance.py
+++ b/tests/unit/api/test_s10_ac_compliance.py
@@ -1013,3 +1013,20 @@ class TestAC1013EmptyTurnInput:
         )
         assert resp.status_code == 400
         assert resp.json()["error"]["code"] == "EMPTY_TURN_INPUT"
+
+
+@pytest.mark.spec("AC-10.02")
+class TestAC1002OpenAPIValidity:
+    """AC-10.02: The app's OpenAPI spec validates against the OpenAPI 3.x schema."""
+
+    def test_openapi_spec_is_valid(self) -> None:
+        """Fetch /openapi.json and validate with openapi-spec-validator."""
+        from openapi_spec_validator import validate
+
+        application = create_app(_settings())
+        with TestClient(application) as c:
+            resp = c.get("/openapi.json")
+        assert resp.status_code == 200
+        spec = resp.json()
+        # validate() raises if the spec is invalid
+        validate(spec)

--- a/tests/unit/api/test_s10_ac_compliance.py
+++ b/tests/unit/api/test_s10_ac_compliance.py
@@ -886,6 +886,8 @@ class TestS10FR1036ErrorEventTurnId:
 class TestS10FR1038HeartbeatEvent:
     """FR-10.38: SSE stream uses 'heartbeat' event type (not legacy 'keepalive')."""
 
+    pytestmark = [pytest.mark.spec("AC-10.06")]
+
     def test_heartbeat_event_model_type(self) -> None:
         """HeartbeatEvent serialises with event_type 'heartbeat'."""
         evt = HeartbeatEvent()
@@ -978,3 +980,53 @@ class TestS10FR1038HeartbeatEvent:
 
         assert "event: heartbeat\n" in body
         assert "event: keepalive" not in body
+
+
+# ---------------------------------------------------------------------------
+# AC-10.13: Empty / whitespace-only turn input → 400 input_invalid
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.spec("AC-10.13")
+class TestAC1013EmptyTurnInput:
+    """AC-10.13: Submitting empty or whitespace-only input returns 400 input_invalid."""
+
+    def test_empty_string_returns_400(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        """AC-10.13: Empty string input → 400."""
+        pg.execute = AsyncMock(
+            side_effect=[
+                _make_result([_game_row()]),  # _get_owned_game
+                _make_result(),              # advisory lock
+                _make_result(),              # in-flight check
+            ]
+        )
+        pg.commit = AsyncMock()
+        resp = client.post(
+            f"/api/v1/games/{_GAME_ID}/turns",
+            json={"input": ""},
+        )
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["error"]["code"] == "EMPTY_TURN_INPUT"
+
+    def test_whitespace_only_returns_400(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        """AC-10.13: Whitespace-only input → 400."""
+        pg.execute = AsyncMock(
+            side_effect=[
+                _make_result([_game_row()]),
+                _make_result(),
+                _make_result(),
+            ]
+        )
+        pg.commit = AsyncMock()
+        resp = client.post(
+            f"/api/v1/games/{_GAME_ID}/turns",
+            json={"input": "   "},
+        )
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["error"]["code"] == "EMPTY_TURN_INPUT"

--- a/tests/unit/api/test_s10_ac_compliance.py
+++ b/tests/unit/api/test_s10_ac_compliance.py
@@ -1000,8 +1000,8 @@ class TestAC1013EmptyTurnInput:
         pg.execute = AsyncMock(
             side_effect=[
                 _make_result([_game_row()]),  # _get_owned_game
-                _make_result(),              # advisory lock
-                _make_result(),              # in-flight check
+                _make_result(),  # advisory lock
+                _make_result(),  # in-flight check
             ]
         )
         pg.commit = AsyncMock()

--- a/tests/unit/api/test_s10_ac_compliance.py
+++ b/tests/unit/api/test_s10_ac_compliance.py
@@ -883,10 +883,13 @@ class TestS10FR1036ErrorEventTurnId:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.spec("AC-10.06")
 class TestS10FR1038HeartbeatEvent:
-    """FR-10.38: SSE stream uses 'heartbeat' event type (not legacy 'keepalive')."""
+    """FR-10.38: SSE stream uses 'heartbeat' event type (not legacy 'keepalive').
 
-    pytestmark = [pytest.mark.spec("AC-10.06")]
+    Covers the unit-testable portion of AC-10.06 (heartbeat format and emission).
+    The 15-second timing SLA requires integration tests and is deferred.
+    """
 
     def test_heartbeat_event_model_type(self) -> None:
         """HeartbeatEvent serialises with event_type 'heartbeat'."""
@@ -991,10 +994,11 @@ class TestS10FR1038HeartbeatEvent:
 class TestAC1013EmptyTurnInput:
     """AC-10.13: Submitting empty or whitespace-only input returns 400 input_invalid."""
 
-    def test_empty_string_returns_400(
-        self, client: TestClient, pg: AsyncMock
+    @pytest.mark.parametrize("bad_input", ["", "   ", "\t", "\n"])
+    def test_empty_or_whitespace_returns_400(
+        self, bad_input: str, client: TestClient, pg: AsyncMock
     ) -> None:
-        """AC-10.13: Empty string input → 400."""
+        """AC-10.13: Empty or whitespace-only input → 400 with EMPTY_TURN_INPUT code."""
         pg.execute = AsyncMock(
             side_effect=[
                 _make_result([_game_row()]),  # _get_owned_game
@@ -1005,28 +1009,7 @@ class TestAC1013EmptyTurnInput:
         pg.commit = AsyncMock()
         resp = client.post(
             f"/api/v1/games/{_GAME_ID}/turns",
-            json={"input": ""},
+            json={"input": bad_input},
         )
         assert resp.status_code == 400
-        body = resp.json()
-        assert body["error"]["code"] == "EMPTY_TURN_INPUT"
-
-    def test_whitespace_only_returns_400(
-        self, client: TestClient, pg: AsyncMock
-    ) -> None:
-        """AC-10.13: Whitespace-only input → 400."""
-        pg.execute = AsyncMock(
-            side_effect=[
-                _make_result([_game_row()]),
-                _make_result(),
-                _make_result(),
-            ]
-        )
-        pg.commit = AsyncMock()
-        resp = client.post(
-            f"/api/v1/games/{_GAME_ID}/turns",
-            json={"input": "   "},
-        )
-        assert resp.status_code == 400
-        body = resp.json()
-        assert body["error"]["code"] == "EMPTY_TURN_INPUT"
+        assert resp.json()["error"]["code"] == "EMPTY_TURN_INPUT"

--- a/tests/unit/api/test_s11_ac_compliance.py
+++ b/tests/unit/api/test_s11_ac_compliance.py
@@ -617,7 +617,6 @@ class TestAC1112NoPasswordInResponses:
         self._assert_no_password_fields(resp.json(), "/api/v1/auth/refresh")
 
 
-
 # ---------------------------------------------------------------------------
 # AC-11.07: Expired game can be resumed
 # ---------------------------------------------------------------------------
@@ -635,7 +634,9 @@ class TestAC1107ExpiredGameCanBeResumed:
 
         async def track_execute(stmt: Any, params: Any = None) -> MagicMock:
             call_idx = len(execute_calls)
-            execute_calls.append((str(stmt) if hasattr(stmt, "__str__") else "", params))
+            execute_calls.append(
+                (str(stmt) if hasattr(stmt, "__str__") else "", params)
+            )
             if call_idx == 0:
                 # _get_owned_game: game in 'expired' status
                 return _make_result(
@@ -703,7 +704,9 @@ class TestAC1107ExpiredGameCanBeResumed:
 
         async def track_execute(stmt: Any, params: Any = None) -> MagicMock:
             call_idx = len(execute_calls)
-            execute_calls.append((str(stmt) if hasattr(stmt, "__str__") else "", params))
+            execute_calls.append(
+                (str(stmt) if hasattr(stmt, "__str__") else "", params)
+            )
             if call_idx == 0:
                 # _get_owned_game: game in 'expired' status, no summary, 0 turns
                 return _make_result(
@@ -845,7 +848,7 @@ class TestAC1114PlayerIdNotReassignable:
         )
 
     def test_player_model_id_is_uuid(self) -> None:
-        """Player.id is a UUID field; two freshly constructed instances have distinct ids."""
+        """Player.id is UUID; two freshly constructed instances have distinct ids."""
         from uuid import UUID
 
         from tta.models.player import Player

--- a/tests/unit/api/test_s11_ac_compliance.py
+++ b/tests/unit/api/test_s11_ac_compliance.py
@@ -690,6 +690,10 @@ class TestAC1107ExpiredGameCanBeResumed:
             f"AC-11.07: resume expired game expected 2xx, "
             f"got {resp.status_code}: {resp.text}"
         )
-        assert resp.json()["data"]["status"] == "active", (
+        data = resp.json()["data"]
+        assert data["status"] == "active", (
             "AC-11.07: expired game status should transition to 'active' upon resume"
+        )
+        assert data["recap"] and "welcome back" in data["recap"].lower(), (
+            "AC-11.07: expired game resume must include 'welcome back' narrative"
         )

--- a/tests/unit/api/test_s11_ac_compliance.py
+++ b/tests/unit/api/test_s11_ac_compliance.py
@@ -1,13 +1,11 @@
 """S11 Player Identity & Sessions — Acceptance Criteria compliance tests.
 
-Covers AC-11.01, AC-11.02, AC-11.04, AC-11.10, AC-11.12.
+Covers AC-11.01, AC-11.02, AC-11.04, AC-11.07, AC-11.10, AC-11.12.
 
-v2 ACs (deferred):
+AC-11.05, AC-11.06, AC-11.08 covered in tests/unit/lifecycle/test_cleanup.py.
+
+Deferred ACs (require login endpoint or async jobs not yet implemented):
   AC-11.03 — Multi-device login (login endpoint deferred per S11 §14)
-  AC-11.05 — Paused game resumable at 29 days (background task + time)
-  AC-11.06 — Game expired after 31 days (background task + time)
-  AC-11.07 — Expired game resume with welcome back (background task)
-  AC-11.08 — Abandoned after 25 hours (background task + time)
   AC-11.09 — Login lockout (login endpoint deferred per S11 §14)
   AC-11.11 — Deleted player cannot login (login endpoint deferred per S11 §14)
   AC-11.13 — Data not retrievable within 72h (async deletion job)

--- a/tests/unit/api/test_s11_ac_compliance.py
+++ b/tests/unit/api/test_s11_ac_compliance.py
@@ -690,3 +690,6 @@ class TestAC1107ExpiredGameCanBeResumed:
             f"AC-11.07: resume expired game expected 2xx, "
             f"got {resp.status_code}: {resp.text}"
         )
+        assert resp.json()["data"]["status"] == "active", (
+            "AC-11.07: expired game status should transition to 'active' upon resume"
+        )

--- a/tests/unit/api/test_s11_ac_compliance.py
+++ b/tests/unit/api/test_s11_ac_compliance.py
@@ -1,6 +1,6 @@
 """S11 Player Identity & Sessions — Acceptance Criteria compliance tests.
 
-Covers AC-11.01, AC-11.02, AC-11.04, AC-11.07, AC-11.10, AC-11.12.
+Covers AC-11.01, AC-11.02, AC-11.04, AC-11.07, AC-11.10, AC-11.12, AC-11.14.
 
 AC-11.05, AC-11.06, AC-11.08 covered in tests/unit/lifecycle/test_cleanup.py.
 
@@ -9,7 +9,6 @@ Deferred ACs (require login endpoint or async jobs not yet implemented):
   AC-11.09 — Login lockout (login endpoint deferred per S11 §14)
   AC-11.11 — Deleted player cannot login (login endpoint deferred per S11 §14)
   AC-11.13 — Data not retrievable within 72h (async deletion job)
-  AC-11.14 — Deleted player_id not reassignable (DB constraint only)
 """
 
 from __future__ import annotations

--- a/tests/unit/api/test_s11_ac_compliance.py
+++ b/tests/unit/api/test_s11_ac_compliance.py
@@ -618,3 +618,75 @@ class TestAC1112NoPasswordInResponses:
             f"AC-11.12: refresh expected 200, got {resp.status_code}: {resp.text}"
         )
         self._assert_no_password_fields(resp.json(), "/api/v1/auth/refresh")
+
+
+
+# ---------------------------------------------------------------------------
+# AC-11.07: Expired game can be resumed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.spec("AC-11.07")
+class TestAC1107ExpiredGameCanBeResumed:
+    """AC-11.07: POST /games/{id}/resume allows expired status → active."""
+
+    def test_resume_endpoint_accepts_expired_status(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        """AC-11.07: Resume endpoint accepts game in 'expired' status."""
+        execute_calls: list[Any] = []
+
+        async def track_execute(stmt: Any, params: Any = None) -> MagicMock:
+            call_idx = len(execute_calls)
+            execute_calls.append((str(stmt) if hasattr(stmt, "__str__") else "", params))
+            if call_idx == 0:
+                # _get_owned_game: game in 'expired' status
+                return _make_result(
+                    [
+                        _game_row(
+                            status="expired",
+                            turn_count=2,
+                            summary="Test summary",
+                            needs_recovery=False,
+                        )
+                    ]
+                )
+            elif call_idx == 1:
+                # Advisory lock result
+                return _make_result()
+            elif call_idx == 2:
+                # Check for in-flight processing
+                return _make_result()
+            elif call_idx == 3:
+                # Get turn count for context
+                return _make_result(scalar=2)
+            elif call_idx == 4:
+                # Get recent turns for context
+                return _make_result([])
+            elif call_idx == 5:
+                # UPDATE game_sessions status to active
+                result = MagicMock()
+                result.rowcount = 1
+                return result
+            elif call_idx == 6:
+                # UPDATE game_sessions last_played_at
+                result = MagicMock()
+                result.rowcount = 1
+                return result
+            # Catch-all for other queries
+            result = MagicMock()
+            result.scalar_one.return_value = None
+            result.one_or_none.return_value = None
+            return result
+
+        pg.execute = track_execute
+        pg.commit = AsyncMock()
+
+        resp = client.post(
+            f"/api/v1/games/{_GAME_ID}/resume",
+        )
+
+        assert resp.status_code in (200, 202), (
+            f"AC-11.07: resume expired game expected 2xx, "
+            f"got {resp.status_code}: {resp.text}"
+        )

--- a/tests/unit/api/test_s11_ac_compliance.py
+++ b/tests/unit/api/test_s11_ac_compliance.py
@@ -697,3 +697,66 @@ class TestAC1107ExpiredGameCanBeResumed:
         assert data["recap"] and "welcome back" in data["recap"].lower(), (
             "AC-11.07: expired game resume must include 'welcome back' narrative"
         )
+
+    def test_resume_expired_no_summary_still_emits_welcome_back(
+        self, client: TestClient, pg: AsyncMock
+    ) -> None:
+        """AC-11.07: Welcome-back is emitted even when game has no summary/recap."""
+        execute_calls: list[Any] = []
+
+        async def track_execute(stmt: Any, params: Any = None) -> MagicMock:
+            call_idx = len(execute_calls)
+            execute_calls.append((str(stmt) if hasattr(stmt, "__str__") else "", params))
+            if call_idx == 0:
+                # _get_owned_game: game in 'expired' status, no summary, 0 turns
+                return _make_result(
+                    [
+                        _game_row(
+                            status="expired",
+                            turn_count=0,
+                            summary=None,
+                            world_seed="{}",
+                            needs_recovery=False,
+                        )
+                    ]
+                )
+            elif call_idx == 1:
+                return _make_result()  # Advisory lock
+            elif call_idx == 2:
+                return _make_result()  # In-flight check
+            elif call_idx == 3:
+                return _make_result(scalar=0)  # Turn count
+            elif call_idx == 4:
+                return _make_result([])  # Recent turns
+            elif call_idx == 5:
+                result = MagicMock()
+                result.rowcount = 1
+                return result  # UPDATE status to active
+            elif call_idx == 6:
+                result = MagicMock()
+                result.rowcount = 1
+                return result  # UPDATE last_played_at
+            result = MagicMock()
+            result.scalar_one.return_value = None
+            result.one_or_none.return_value = None
+            return result
+
+        pg.execute = track_execute
+        pg.commit = AsyncMock()
+
+        resp = client.post(
+            f"/api/v1/games/{_GAME_ID}/resume",
+        )
+
+        assert resp.status_code in (200, 202), (
+            f"AC-11.07: resume expired game (no summary) expected 2xx, "
+            f"got {resp.status_code}: {resp.text}"
+        )
+        data = resp.json()["data"]
+        assert data["status"] == "active", (
+            "AC-11.07: expired game status should transition to 'active' upon resume"
+        )
+        assert data["recap"] and "welcome back" in data["recap"].lower(), (
+            "AC-11.07: expired game resume must include 'welcome back' narrative "
+            "even when no summary/genesis intro exists"
+        )

--- a/tests/unit/api/test_s11_ac_compliance.py
+++ b/tests/unit/api/test_s11_ac_compliance.py
@@ -758,3 +758,101 @@ class TestAC1107ExpiredGameCanBeResumed:
             "AC-11.07: expired game resume must include 'welcome back' narrative "
             "even when no summary/genesis intro exists"
         )
+
+
+# ---------------------------------------------------------------------------
+# AC-11.14 — Deleted player_id cannot be reassigned
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.spec("AC-11.14")
+class TestAC1114PlayerIdNotReassignable:
+    """AC-11.14: The deleted player's player_id cannot be reassigned to a new player.
+
+    The invariant is enforced by two complementary mechanisms:
+    1. ``players.id`` is a UUID PRIMARY KEY — the DB rejects any INSERT that reuses
+       an existing UUID while the row exists.
+    2. New player creation always generates a fresh ``uuid4()`` — client-supplied IDs
+       are never accepted, making accidental reuse negligible (~1 in 2^122 chance).
+
+    Note: the async GDPR purge job performs a hard ``DELETE FROM players`` 72 h after
+    a deletion request (S17 compliance).  After that point, the PK constraint no longer
+    applies, but uuid4() randomness provides the practical reassignment barrier.
+    """
+
+    def test_players_table_primary_key_in_migration(self) -> None:
+        """players.id is the PRIMARY KEY in the initial migration DDL.
+
+        Confirms the DB-level ``PRIMARY KEY (id)`` constraint that prevents any two
+        players from sharing the same UUID while their rows coexist in the table.
+        """
+        migration_path = "migrations/postgres/versions/001_initial_schema.py"
+        with open(migration_path) as f:
+            src = f.read()
+
+        players_start = src.index('"players"')
+        next_create = src.find("op.create_table", players_start + 1)
+        players_block = src[players_start:next_create]
+
+        assert 'PrimaryKeyConstraint("id")' in players_block, (
+            "AC-11.14: players table must have PrimaryKeyConstraint on 'id' "
+            "to prevent UUID reassignment at the DB level"
+        )
+
+    def test_immediate_deletion_route_is_soft_delete(self) -> None:
+        """DELETE /me (the synchronous deletion path) marks the player as
+        'pending_deletion' and does NOT hard-delete the row.
+
+        The asynchronous GDPR purge job performs the eventual hard delete
+        (S17 FR-17.10); that job is intentional and separate from this check.
+        This test verifies the immediate-deletion route preserves the player row
+        so that the UUID is not freed before the GDPR purge window.
+        """
+        route_path = "src/tta/api/routes/players.py"
+        with open(route_path) as f:
+            src = f.read()
+
+        assert "pending_deletion" in src, (
+            "AC-11.14: DELETE /me must set status='pending_deletion' "
+            "(soft delete) to retain the UUID row in the DB during the GDPR window"
+        )
+
+        # The route file itself must not issue a hard DELETE on the players table
+        # (the hard delete belongs exclusively to the async GDPR purge job)
+        import re
+
+        hard_deletes = re.findall(r"DELETE\s+FROM\s+players", src, re.IGNORECASE)
+        assert not hard_deletes, (
+            "AC-11.14: the synchronous DELETE /me route must not issue "
+            "DELETE FROM players — hard deletion must go through the async GDPR job"
+        )
+
+    def test_new_player_id_generated_by_uuid4(self) -> None:
+        """Player registration always generates a fresh uuid4() — callers cannot
+        supply a pre-existing id.
+
+        Verifies that ``register_player`` uses ``uuid4()`` to create the player_id,
+        making accidental collision with a previously-used (even hard-deleted) UUID
+        negligible in practice.
+        """
+        route_path = "src/tta/api/routes/players.py"
+        with open(route_path) as f:
+            src = f.read()
+
+        # The register_player function must use uuid4() to generate the player id
+        assert "player_id = uuid4()" in src, (
+            "AC-11.14: player registration must generate player_id via uuid4() "
+            "— client-supplied IDs are not accepted, preventing intentional reuse"
+        )
+
+    def test_player_model_id_is_uuid(self) -> None:
+        """Player.id is a UUID field; two freshly constructed instances have distinct ids."""
+        from uuid import UUID
+
+        from tta.models.player import Player
+
+        p1 = Player(handle="player-one")
+        p2 = Player(handle="player-two")
+
+        assert isinstance(p1.id, UUID), "AC-11.14: Player.id must be a UUID instance"
+        assert p1.id != p2.id, "AC-11.14: Each new Player must receive a unique UUID"

--- a/tests/unit/lifecycle/test_cleanup.py
+++ b/tests/unit/lifecycle/test_cleanup.py
@@ -43,6 +43,7 @@ def _make_factory(pg: AsyncMock):  # noqa: ANN201
     return factory
 
 
+@pytest.mark.spec("AC-11.08")
 class TestAbandonRule:
     """created/active + 0 turns + >24h → abandoned."""
 
@@ -86,6 +87,7 @@ class TestAbandonRule:
         assert abs((cutoff - expected).total_seconds()) < 5
 
 
+@pytest.mark.spec("AC-11.06")
 class TestExpireRule:
     """paused + last_played > 30 days → expired."""
 
@@ -210,3 +212,39 @@ class TestIdleTimeoutRule:
         idle_call = pg.execute.call_args_list[2]
         sql_text = str(idle_call.args[0].text)
         assert "turn_count > 0" in sql_text
+
+
+@pytest.mark.spec("AC-11.05")
+class TestAC1105PausedGameNotExpiredBefore30Days:
+    """Paused game within 30 days MUST NOT be expired."""
+
+    @pytest.mark.anyio
+    async def test_paused_game_not_expired_before_30_days(self) -> None:
+        """AC-11.05: Game paused 29 days ago should NOT be expired."""
+        pg = _make_pg(expire_rowcount=0)
+        factory = _make_factory(pg)
+
+        result = await run_lifecycle_pass(factory, expire_days=30)
+
+        expire_call = pg.execute.call_args_list[1]
+        params = expire_call.args[1]
+        cutoff = params["cutoff"]
+
+        now = datetime.now(UTC)
+        expected_cutoff = now - timedelta(days=30)
+        assert abs((cutoff - expected_cutoff).total_seconds()) < 5
+
+        assert result["expired"] == 0
+
+
+@pytest.mark.spec("AC-11.07")
+class TestAC1107ExpiredGameCanBeResumed:
+    """Expired game MUST be resumable."""
+
+    @pytest.mark.anyio
+    async def test_expired_status_allows_resume(self) -> None:
+        """AC-11.07: Expired games should appear in allowed statuses."""
+        from tta.api.routes.games import _VALID_TRANSITIONS
+
+        allowed_to_active = _VALID_TRANSITIONS.get("expired", set())
+        assert "active" in allowed_to_active

--- a/tests/unit/lifecycle/test_cleanup.py
+++ b/tests/unit/lifecycle/test_cleanup.py
@@ -89,7 +89,7 @@ class TestAbandonRule:
     @pytest.mark.anyio
     async def test_abandon_not_triggered_at_exactly_24h(self) -> None:
         """AC-11.08: Game created exactly 24h ago should NOT be abandoned.
-        
+
         Spec says "more than 24 hours" → strict `<` excludes games at boundary.
         """
         pg = _make_pg(abandon_rowcount=0)
@@ -139,7 +139,7 @@ class TestExpireRule:
     @pytest.mark.anyio
     async def test_expire_not_triggered_at_exactly_30_days(self) -> None:
         """AC-11.06: Game paused exactly 30 days ago should NOT be expired.
-        
+
         Spec says "more than 30 days" → strict `<` excludes games at boundary.
         """
         pg = _make_pg(expire_rowcount=0)
@@ -275,4 +275,3 @@ class TestAC1105PausedGameNotExpiredBefore30Days:
             "AC-11.05: SQL should use strict < on paused_at to exclude games "
             "exactly at 30-day boundary"
         )
-

--- a/tests/unit/lifecycle/test_cleanup.py
+++ b/tests/unit/lifecycle/test_cleanup.py
@@ -87,18 +87,21 @@ class TestAbandonRule:
         assert abs((cutoff - expected).total_seconds()) < 5
 
     @pytest.mark.anyio
-    async def test_abandon_boundary_created_exactly_24h_ago(self) -> None:
-        """AC-11.08: Game created exactly 24h ago MUST be abandoned."""
-        pg = _make_pg(abandon_rowcount=1)
+    async def test_abandon_not_triggered_at_exactly_24h(self) -> None:
+        """AC-11.08: Game created exactly 24h ago should NOT be abandoned.
+        
+        Spec says "more than 24 hours" → strict `<` excludes games at boundary.
+        """
+        pg = _make_pg(abandon_rowcount=0)
         factory = _make_factory(pg)
 
         await run_lifecycle_pass(factory, abandon_hours=24)
 
         abandon_call = pg.execute.call_args_list[0]
         sql_text = str(abandon_call.args[0].text)
-        assert "<= :cutoff" in sql_text, (
-            "AC-11.08: SQL should use <= not < to catch games "
-            "exactly at 24h boundary"
+        assert "< :cutoff" in sql_text and "<=" not in sql_text, (
+            "AC-11.08: SQL must use strict < (not <=) so games "
+            "exactly at 24h boundary are not caught"
         )
 
 
@@ -134,18 +137,21 @@ class TestExpireRule:
         assert abs((cutoff - expected).total_seconds()) < 5
 
     @pytest.mark.anyio
-    async def test_expire_boundary_paused_exactly_30_days_ago(self) -> None:
-        """AC-11.06: Game paused exactly 30 days ago MUST be expired."""
-        pg = _make_pg(expire_rowcount=1)
+    async def test_expire_not_triggered_at_exactly_30_days(self) -> None:
+        """AC-11.06: Game paused exactly 30 days ago should NOT be expired.
+        
+        Spec says "more than 30 days" → strict `<` excludes games at boundary.
+        """
+        pg = _make_pg(expire_rowcount=0)
         factory = _make_factory(pg)
 
         await run_lifecycle_pass(factory, expire_days=30)
 
         expire_call = pg.execute.call_args_list[1]
         sql_text = str(expire_call.args[0].text)
-        assert "<= :cutoff" in sql_text, (
-            "AC-11.06: SQL should use <= not < to catch games "
-            "exactly at 30-day boundary"
+        assert "< :cutoff" in sql_text and "<=" not in sql_text, (
+            "AC-11.06: SQL must use strict < (not <=) so games "
+            "exactly at 30-day boundary are not caught"
         )
 
 
@@ -265,5 +271,8 @@ class TestAC1105PausedGameNotExpiredBefore30Days:
         assert abs((cutoff - expected_cutoff).total_seconds()) < 5
 
         sql_text = str(expire_call.args[0].text)
-        assert "<= :cutoff" in sql_text or "last_played_at <=" in sql_text
+        assert "< :cutoff" in sql_text and "last_played_at <" in sql_text, (
+            "AC-11.05: SQL should use strict < to exclude games "
+            "exactly at 30-day boundary"
+        )
 

--- a/tests/unit/lifecycle/test_cleanup.py
+++ b/tests/unit/lifecycle/test_cleanup.py
@@ -120,7 +120,7 @@ class TestExpireRule:
         expire_call = pg.execute.call_args_list[1]
         sql_text = str(expire_call.args[0].text)
         assert "status = 'paused'" in sql_text
-        assert "last_played_at" in sql_text
+        assert "paused_at" in sql_text
         assert "deleted_at IS NULL" in sql_text
         pg.commit.assert_awaited_once()
 
@@ -271,8 +271,8 @@ class TestAC1105PausedGameNotExpiredBefore30Days:
         assert abs((cutoff - expected_cutoff).total_seconds()) < 5
 
         sql_text = str(expire_call.args[0].text)
-        assert "< :cutoff" in sql_text and "last_played_at <" in sql_text, (
-            "AC-11.05: SQL should use strict < to exclude games "
+        assert "< :cutoff" in sql_text and "paused_at" in sql_text, (
+            "AC-11.05: SQL should use strict < on paused_at to exclude games "
             "exactly at 30-day boundary"
         )
 

--- a/tests/unit/lifecycle/test_cleanup.py
+++ b/tests/unit/lifecycle/test_cleanup.py
@@ -86,6 +86,21 @@ class TestAbandonRule:
         expected = datetime.now(UTC) - timedelta(hours=24)
         assert abs((cutoff - expected).total_seconds()) < 5
 
+    @pytest.mark.anyio
+    async def test_abandon_boundary_created_exactly_24h_ago(self) -> None:
+        """AC-11.08: Game created exactly 24h ago MUST be abandoned."""
+        pg = _make_pg(abandon_rowcount=1)
+        factory = _make_factory(pg)
+
+        await run_lifecycle_pass(factory, abandon_hours=24)
+
+        abandon_call = pg.execute.call_args_list[0]
+        sql_text = str(abandon_call.args[0].text)
+        assert "<= :cutoff" in sql_text, (
+            "AC-11.08: SQL should use <= not < to catch games "
+            "exactly at 24h boundary"
+        )
+
 
 @pytest.mark.spec("AC-11.06")
 class TestExpireRule:
@@ -117,6 +132,21 @@ class TestExpireRule:
         cutoff = params["cutoff"]
         expected = datetime.now(UTC) - timedelta(days=30)
         assert abs((cutoff - expected).total_seconds()) < 5
+
+    @pytest.mark.anyio
+    async def test_expire_boundary_paused_exactly_30_days_ago(self) -> None:
+        """AC-11.06: Game paused exactly 30 days ago MUST be expired."""
+        pg = _make_pg(expire_rowcount=1)
+        factory = _make_factory(pg)
+
+        await run_lifecycle_pass(factory, expire_days=30)
+
+        expire_call = pg.execute.call_args_list[1]
+        sql_text = str(expire_call.args[0].text)
+        assert "<= :cutoff" in sql_text, (
+            "AC-11.06: SQL should use <= not < to catch games "
+            "exactly at 30-day boundary"
+        )
 
 
 class TestMixedTransitions:
@@ -219,12 +249,12 @@ class TestAC1105PausedGameNotExpiredBefore30Days:
     """Paused game within 30 days MUST NOT be expired."""
 
     @pytest.mark.anyio
-    async def test_paused_game_not_expired_before_30_days(self) -> None:
-        """AC-11.05: Game paused 29 days ago should NOT be expired."""
+    async def test_paused_game_cutoff_is_exactly_30_days(self) -> None:
+        """AC-11.05: Verify cutoff is 30 days, not 29 or 31."""
         pg = _make_pg(expire_rowcount=0)
         factory = _make_factory(pg)
 
-        result = await run_lifecycle_pass(factory, expire_days=30)
+        await run_lifecycle_pass(factory, expire_days=30)
 
         expire_call = pg.execute.call_args_list[1]
         params = expire_call.args[1]
@@ -234,17 +264,6 @@ class TestAC1105PausedGameNotExpiredBefore30Days:
         expected_cutoff = now - timedelta(days=30)
         assert abs((cutoff - expected_cutoff).total_seconds()) < 5
 
-        assert result["expired"] == 0
+        sql_text = str(expire_call.args[0].text)
+        assert "<= :cutoff" in sql_text or "last_played_at <=" in sql_text
 
-
-@pytest.mark.spec("AC-11.07")
-class TestAC1107ExpiredGameCanBeResumed:
-    """Expired game MUST be resumable."""
-
-    @pytest.mark.anyio
-    async def test_expired_status_allows_resume(self) -> None:
-        """AC-11.07: Expired games should appear in allowed statuses."""
-        from tta.api.routes.games import _VALID_TRANSITIONS
-
-        allowed_to_active = _VALID_TRANSITIONS.get("expired", set())
-        assert "active" in allowed_to_active

--- a/tests/unit/pipeline/test_s06_character_system.py
+++ b/tests/unit/pipeline/test_s06_character_system.py
@@ -68,6 +68,8 @@ def _make_turn_state(**overrides):
 class TestCharacterDisplay:
     """Item 1: _build_character_response shows all available fields."""
 
+    pytestmark = [pytest.mark.spec("AC-06.01")]
+
     def test_all_fields_shown(self):
         from tta.api.routes.games import _build_character_response
 
@@ -117,6 +119,8 @@ class TestCharacterDisplay:
 class TestNPCDialogueSalience:
     """Item 2: NPC section rendered in generation prompt."""
 
+    pytestmark = [pytest.mark.spec("AC-06.05")]
+
     def test_npc_section_rendered(self):
         npc = {
             "npc_name": "Elder Mirren",
@@ -163,6 +167,8 @@ class TestNPCDialogueSalience:
 
 class TestCompanionPresence:
     """Item 3: Companion identification and generation injection."""
+
+    pytestmark = [pytest.mark.spec("AC-06.07")]
 
     def test_companion_injected_when_eligible(self):
         wc = {
@@ -221,6 +227,8 @@ class TestCompanionPresence:
 class TestRevealedGoalInfluence:
     """Item 4: Goals injected in NPC section when present."""
 
+    pytestmark = [pytest.mark.spec("AC-06.06")]
+
     def test_goals_injected_when_present(self):
         npc = {
             "npc_name": "Sage",
@@ -246,6 +254,8 @@ class TestRevealedGoalInfluence:
 
 class TestRuntimeRelationships:
     """Item 5: /relationships with runtime dimensions."""
+
+    pytestmark = [pytest.mark.spec("AC-06.03")]
 
     @pytest.mark.anyio
     async def test_runtime_dimensions_shown(self):

--- a/uv.lock
+++ b/uv.lock
@@ -1347,6 +1347,21 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema-path"
+version = "0.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/45/41ebc679c2a4fced6a722f624c18d658dee42612b83ea24c1caf7c0eb3a8/jsonschema_path-0.3.4.tar.gz", hash = "sha256:8365356039f16cc65fddffafda5f58766e34bebab7d6d105616ab52bc4297001", size = 11159, upload-time = "2025-01-24T14:33:16.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/58/3485da8cb93d2f393bce453adeef16896751f14ba3e2024bc21dc9597646/jsonschema_path-0.3.4-py3-none-any.whl", hash = "sha256:f502191fdc2b22050f9a81c9237be9d27145b9001c55842bece5e94e382e52f8", size = 14810, upload-time = "2025-01-24T14:33:14.652Z" },
+]
+
+[[package]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1375,6 +1390,38 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ab/d0/6d79ed5614f86f27f5df199cf10c6facf6874ff6f91b828ae4dad90aa86d/langfuse-4.0.6.tar.gz", hash = "sha256:83a6f8cc8f1431fa2958c91e2673bc4179f993297e9b1acd1dbf001785e6cf83", size = 274094, upload-time = "2026-04-01T20:04:15.153Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/b4/088048e37b6d7ec1b52c6a11bc33101454285a22eaab8303dcccfd78344d/langfuse-4.0.6-py3-none-any.whl", hash = "sha256:0562b1dcf83247f9d8349f0f755eaed9a7f952fee67e66580970f0738bf3adbf", size = 472841, upload-time = "2026-04-01T20:04:16.451Z" },
+]
+
+[[package]]
+name = "lazy-object-proxy"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a2/69df9c6ba6d316cfd81fe2381e464db3e6de5db45f8c43c6a23504abf8cb/lazy_object_proxy-1.12.0.tar.gz", hash = "sha256:1f5a462d92fd0cfb82f1fab28b51bfb209fabbe6aabf7f0d51472c0c124c0c61", size = 43681, upload-time = "2025-08-22T13:50:06.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/1b/b5f5bd6bda26f1e15cd3232b223892e4498e34ec70a7f4f11c401ac969f1/lazy_object_proxy-1.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8ee0d6027b760a11cc18281e702c0309dd92da458a74b4c15025d7fc490deede", size = 26746, upload-time = "2025-08-22T13:42:37.572Z" },
+    { url = "https://files.pythonhosted.org/packages/55/64/314889b618075c2bfc19293ffa9153ce880ac6153aacfd0a52fcabf21a66/lazy_object_proxy-1.12.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4ab2c584e3cc8be0dfca422e05ad30a9abe3555ce63e9ab7a559f62f8dbc6ff9", size = 71457, upload-time = "2025-08-22T13:42:38.743Z" },
+    { url = "https://files.pythonhosted.org/packages/11/53/857fc2827fc1e13fbdfc0ba2629a7d2579645a06192d5461809540b78913/lazy_object_proxy-1.12.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:14e348185adbd03ec17d051e169ec45686dcd840a3779c9d4c10aabe2ca6e1c0", size = 71036, upload-time = "2025-08-22T13:42:40.184Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/24/e581ffed864cd33c1b445b5763d617448ebb880f48675fc9de0471a95cbc/lazy_object_proxy-1.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c4fcbe74fb85df8ba7825fa05eddca764138da752904b378f0ae5ab33a36c308", size = 69329, upload-time = "2025-08-22T13:42:41.311Z" },
+    { url = "https://files.pythonhosted.org/packages/78/be/15f8f5a0b0b2e668e756a152257d26370132c97f2f1943329b08f057eff0/lazy_object_proxy-1.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:563d2ec8e4d4b68ee7848c5ab4d6057a6d703cb7963b342968bb8758dda33a23", size = 70690, upload-time = "2025-08-22T13:42:42.51Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/aa/f02be9bbfb270e13ee608c2b28b8771f20a5f64356c6d9317b20043c6129/lazy_object_proxy-1.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:53c7fd99eb156bbb82cbc5d5188891d8fdd805ba6c1e3b92b90092da2a837073", size = 26563, upload-time = "2025-08-22T13:42:43.685Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/26/b74c791008841f8ad896c7f293415136c66cc27e7c7577de4ee68040c110/lazy_object_proxy-1.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:86fd61cb2ba249b9f436d789d1356deae69ad3231dc3c0f17293ac535162672e", size = 26745, upload-time = "2025-08-22T13:42:44.982Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/52/641870d309e5d1fb1ea7d462a818ca727e43bfa431d8c34b173eb090348c/lazy_object_proxy-1.12.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:81d1852fb30fab81696f93db1b1e55a5d1ff7940838191062f5f56987d5fcc3e", size = 71537, upload-time = "2025-08-22T13:42:46.141Z" },
+    { url = "https://files.pythonhosted.org/packages/47/b6/919118e99d51c5e76e8bf5a27df406884921c0acf2c7b8a3b38d847ab3e9/lazy_object_proxy-1.12.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be9045646d83f6c2664c1330904b245ae2371b5c57a3195e4028aedc9f999655", size = 71141, upload-time = "2025-08-22T13:42:47.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/47/1d20e626567b41de085cf4d4fb3661a56c159feaa73c825917b3b4d4f806/lazy_object_proxy-1.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:67f07ab742f1adfb3966c40f630baaa7902be4222a17941f3d85fd1dae5565ff", size = 69449, upload-time = "2025-08-22T13:42:48.49Z" },
+    { url = "https://files.pythonhosted.org/packages/58/8d/25c20ff1a1a8426d9af2d0b6f29f6388005fc8cd10d6ee71f48bff86fdd0/lazy_object_proxy-1.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ba769017b944fcacbf6a80c18b2761a1795b03f8899acdad1f1c39db4409be", size = 70744, upload-time = "2025-08-22T13:42:49.608Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/67/8ec9abe15c4f8a4bcc6e65160a2c667240d025cbb6591b879bea55625263/lazy_object_proxy-1.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:7b22c2bbfb155706b928ac4d74c1a63ac8552a55ba7fff4445155523ea4067e1", size = 26568, upload-time = "2025-08-22T13:42:57.719Z" },
+    { url = "https://files.pythonhosted.org/packages/23/12/cd2235463f3469fd6c62d41d92b7f120e8134f76e52421413a0ad16d493e/lazy_object_proxy-1.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4a79b909aa16bde8ae606f06e6bbc9d3219d2e57fb3e0076e17879072b742c65", size = 27391, upload-time = "2025-08-22T13:42:50.62Z" },
+    { url = "https://files.pythonhosted.org/packages/60/9e/f1c53e39bbebad2e8609c67d0830cc275f694d0ea23d78e8f6db526c12d3/lazy_object_proxy-1.12.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:338ab2f132276203e404951205fe80c3fd59429b3a724e7b662b2eb539bb1be9", size = 80552, upload-time = "2025-08-22T13:42:51.731Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b6/6c513693448dcb317d9d8c91d91f47addc09553613379e504435b4cc8b3e/lazy_object_proxy-1.12.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c40b3c9faee2e32bfce0df4ae63f4e73529766893258eca78548bac801c8f66", size = 82857, upload-time = "2025-08-22T13:42:53.225Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1c/d9c4aaa4c75da11eb7c22c43d7c90a53b4fca0e27784a5ab207768debea7/lazy_object_proxy-1.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:717484c309df78cedf48396e420fa57fc8a2b1f06ea889df7248fdd156e58847", size = 80833, upload-time = "2025-08-22T13:42:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ae/29117275aac7d7d78ae4f5a4787f36ff33262499d486ac0bf3e0b97889f6/lazy_object_proxy-1.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a6b7ea5ea1ffe15059eb44bcbcb258f97bcb40e139b88152c40d07b1a1dfc9ac", size = 79516, upload-time = "2025-08-22T13:42:55.812Z" },
+    { url = "https://files.pythonhosted.org/packages/19/40/b4e48b2c38c69392ae702ae7afa7b6551e0ca5d38263198b7c79de8b3bdf/lazy_object_proxy-1.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:08c465fb5cd23527512f9bd7b4c7ba6cec33e28aad36fbbe46bf7b858f9f3f7f", size = 27656, upload-time = "2025-08-22T13:42:56.793Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/3a/277857b51ae419a1574557c0b12e0d06bf327b758ba94cafc664cb1e2f66/lazy_object_proxy-1.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c9defba70ab943f1df98a656247966d7729da2fe9c2d5d85346464bf320820a3", size = 26582, upload-time = "2025-08-22T13:49:49.366Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b6/c5e0fa43535bb9c87880e0ba037cdb1c50e01850b0831e80eb4f4762f270/lazy_object_proxy-1.12.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6763941dbf97eea6b90f5b06eb4da9418cc088fce0e3883f5816090f9afcde4a", size = 71059, upload-time = "2025-08-22T13:49:50.488Z" },
+    { url = "https://files.pythonhosted.org/packages/06/8a/7dcad19c685963c652624702f1a968ff10220b16bfcc442257038216bf55/lazy_object_proxy-1.12.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fdc70d81235fc586b9e3d1aeef7d1553259b62ecaae9db2167a5d2550dcc391a", size = 71034, upload-time = "2025-08-22T13:49:54.224Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ac/34cbfb433a10e28c7fd830f91c5a348462ba748413cbb950c7f259e67aa7/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0a83c6f7a6b2bfc11ef3ed67f8cbe99f8ff500b05655d8e7df9aab993a6abc95", size = 69529, upload-time = "2025-08-22T13:49:55.29Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6a/11ad7e349307c3ca4c0175db7a77d60ce42a41c60bcb11800aabd6a8acb8/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:256262384ebd2a77b023ad02fbcc9326282bcfd16484d5531154b02bc304f4c5", size = 70391, upload-time = "2025-08-22T13:49:56.35Z" },
+    { url = "https://files.pythonhosted.org/packages/59/97/9b410ed8fbc6e79c1ee8b13f8777a80137d4bc189caf2c6202358e66192c/lazy_object_proxy-1.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:7601ec171c7e8584f8ff3f4e440aa2eebf93e854f04639263875b8c2971f819f", size = 26988, upload-time = "2025-08-22T13:49:57.302Z" },
 ]
 
 [[package]]
@@ -1706,6 +1753,35 @@ wheels = [
 ]
 
 [[package]]
+name = "openapi-schema-validator"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "jsonschema-specifications" },
+    { name = "rfc3339-validator" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/f3/5507ad3325169347cd8ced61c232ff3df70e2b250c49f0fe140edb4973c6/openapi_schema_validator-0.6.3.tar.gz", hash = "sha256:f37bace4fc2a5d96692f4f8b31dc0f8d7400fd04f3a937798eaf880d425de6ee", size = 11550, upload-time = "2025-01-10T18:08:22.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/c6/ad0fba32775ae749016829dace42ed80f4407b171da41313d1a3a5f102e4/openapi_schema_validator-0.6.3-py3-none-any.whl", hash = "sha256:f3b9870f4e556b5a62a1c39da72a6b4b16f3ad9c73dc80084b1b11e74ba148a3", size = 8755, upload-time = "2025-01-10T18:08:19.758Z" },
+]
+
+[[package]]
+name = "openapi-spec-validator"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "jsonschema-path" },
+    { name = "lazy-object-proxy" },
+    { name = "openapi-schema-validator" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/af/fe2d7618d6eae6fb3a82766a44ed87cd8d6d82b4564ed1c7cfb0f6378e91/openapi_spec_validator-0.7.2.tar.gz", hash = "sha256:cc029309b5c5dbc7859df0372d55e9d1ff43e96d678b9ba087f7c56fc586f734", size = 36855, upload-time = "2025-06-07T14:48:56.299Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/dd/b3fd642260cb17532f66cc1e8250f3507d1e580483e209dc1e9d13bd980d/openapi_spec_validator-0.7.2-py3-none-any.whl", hash = "sha256:4bbdc0894ec85f1d1bea1d6d9c8b2c3c8d7ccaa13577ef40da9c006c9fd0eb60", size = 39713, upload-time = "2025-06-07T14:48:54.077Z" },
+]
+
+[[package]]
 name = "opentelemetry-api"
 version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1834,6 +1910,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/ea/42ba6ce0abba04ab6e0b997dcb9b528a4661b62af1fe1b0d498120d5ea78/parse_type-0.6.6.tar.gz", hash = "sha256:513a3784104839770d690e04339a8b4d33439fcd5dd99f2e4580f9fc1097bfb2", size = 98012, upload-time = "2025-08-11T22:53:48.066Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/8d/eef3d8cdccc32abdd91b1286884c99b8c3a6d3b135affcc2a7a0f383bb32/parse_type-0.6.6-py2.py3-none-any.whl", hash = "sha256:3ca79bbe71e170dfccc8ec6c341edfd1c2a0fc1e5cfd18330f93af938de2348c", size = 27085, upload-time = "2025-08-11T22:53:46.396Z" },
+]
+
+[[package]]
+name = "pathable"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/93/8f2c2075b180c12c1e9f6a09d1a985bc2036906b13dff1d8917e395f2048/pathable-0.4.4.tar.gz", hash = "sha256:6905a3cd17804edfac7875b5f6c9142a218c7caef78693c2dbbbfbac186d88b2", size = 8124, upload-time = "2025-01-10T18:43:13.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/eb/b6260b31b1a96386c0a880edebe26f89669098acea8e0318bff6adb378fd/pathable-0.4.4-py3-none-any.whl", hash = "sha256:5ae9e94793b6ef5a4cbe0a7ce9dbbefc1eec38df253763fd0aeeacf2762dbbc2", size = 9592, upload-time = "2025-01-10T18:43:11.88Z" },
 ]
 
 [[package]]
@@ -2459,16 +2544,16 @@ hiredis = [
 
 [[package]]
 name = "referencing"
-version = "0.37.0"
+version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744, upload-time = "2025-01-25T08:48:16.138Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0", size = 26775, upload-time = "2025-01-25T08:48:14.241Z" },
 ]
 
 [[package]]
@@ -2572,6 +2657,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
 ]
 
 [[package]]
@@ -2951,6 +3048,7 @@ dependencies = [
 dev = [
     { name = "hypothesis" },
     { name = "locust" },
+    { name = "openapi-spec-validator" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -2993,6 +3091,7 @@ requires-dist = [
 dev = [
     { name = "hypothesis", specifier = ">=6.0" },
     { name = "locust", specifier = ">=2.0" },
+    { name = "openapi-spec-validator", specifier = ">=0.7.2" },
     { name = "pyright", specifier = ">=1.1" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.24" },


### PR DESCRIPTION
## Summary

Wave 37 AC traceability sweep targeting S06 (Characters), S10 (API), and S11 (Sessions/Lifecycle).

**Scope:** Add `@pytest.mark.spec` markers to existing tests, write missing unit tests, and fill implementation gaps discovered during the sweep.

## Changes

### S06 — Character System (AC-06.01/03/05/06/07)
- Added `@pytest.mark.spec` markers to existing character system tests

### S10 — API (AC-10.02/06/08/13)
- Added `@pytest.mark.spec` markers to 35 existing API tests
- **AC-10.02**: Added OpenAPI spec validation to `Makefile` (`validate-openapi`) and CI quality job; dev dep `openapi-spec-validator>=0.7.2`
- **AC-10.08**: Added assertion that SSE responses include `X-RateLimit-*` headers

### S11 — Player Sessions / Lifecycle (AC-11.05/06/07/08/14)
- **AC-11.05/06**: Added `paused_at` field to `Game` model and migration `013_paused_at.py`; expiry now measured from pause time (spec requirement); backfills existing paused rows
- **AC-11.06**: Cleanup expire rule now uses `(paused_at < :cutoff OR (paused_at IS NULL AND last_played_at < :cutoff))` with strict `<` semantics (>30 days, not ≥)
- **AC-11.07**: `resume_game()` always emits "Welcome back! It's been a while." when `previous_status == "expired"`, whether or not a recap exists
- **AC-11.08**: Confirmed and marked auto-pause/abandon rule tests
- **AC-11.14**: Added 4 tests verifying UUID PK constraint + soft-delete pattern + uuid4() generation prevent player_id reassignment

## Test Results

```
2751 passed, 12 skipped (+177 new tests vs baseline)
```

## Verification

- [ ] `make quality` passes (ruff + pyright)
- [ ] `make test` passes (2751 tests)
- [ ] `make validate-openapi` passes (new CI step)
- [ ] `make trace` shows improved AC coverage for S06/S10/S11

## AC Coverage (this wave)

| Spec | ACs addressed |
|------|---------------|
| S06  | AC-06.01, AC-06.03, AC-06.05, AC-06.06, AC-06.07 |
| S10  | AC-10.02, AC-10.06, AC-10.08, AC-10.13 |
| S11  | AC-11.05, AC-11.06, AC-11.07, AC-11.08, AC-11.14 |

## Migration

`migrations/postgres/versions/013_paused_at.py` — adds `paused_at TIMESTAMPTZ` nullable to `game_sessions`; backfills `updated_at` for existing paused rows.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>