### PR TITLE
feat: persistence gate (Wave 3) — test-persistence target + PERF override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,16 +102,16 @@ test-persistence: ## Run persistence gate (S12/S13/S28) with structured report
 	done
 	@echo ""
 	@echo "--- Running S12 persistence tests ---"
-	-uv run pytest tests/integration/test_s12_persistence_integration.py -v --tb=short 2>&1 | tee /tmp/s12-result.txt
+	uv run pytest tests/integration/test_s12_persistence_integration.py -v --tb=short 2>&1 | tee /tmp/s12-$$$$.txt; S12_EXIT=$${PIPESTATUS[0]}
 	@echo ""
 	@echo "--- Running S13 Neo4j tests ---"
-	-uv run pytest tests/integration/test_s13_neo4j_integration.py -v --tb=short 2>&1 | tee /tmp/s13-result.txt
+	uv run pytest tests/integration/test_s13_neo4j_integration.py -v --tb=short 2>&1 | tee /tmp/s13-$$$$.txt; S13_EXIT=$${PIPESTATUS[0]}
 	@echo ""
 	@echo "--- Running S28 performance tests ---"
-	-PERF=1 uv run pytest tests/integration/test_s28_performance.py -v --tb=short 2>&1 | tee /tmp/s28-result.txt
+	PERF=1 uv run pytest tests/integration/test_s28_performance.py -v --tb=short 2>&1 | tee /tmp/s28-$$$$.txt; S28_EXIT=$${PIPESTATUS[0]}
 	@echo ""
 	@echo "=== Gate Summary ==="
-	@python3 -c "\nimport re\nfrom pathlib import Path\nsections = {'S12': '/tmp/s12-result.txt', 'S13': '/tmp/s13-result.txt', 'S28': '/tmp/s28-result.txt'}\nfor name, path in sections.items():\n    if not Path(path).exists():\n        print(f'{name}: SKIPPED (no results)')\n        continue\n    text = Path(path).read_text()\n    passed = len(re.findall(r'PASSED', text))\n    failed = len(re.findall(r'FAILED', text))\n    skipped = len(re.findall(r'SKIPPED', text))\n    status = 'PASS' if failed == 0 and passed > 0 else 'FAIL' if failed > 0 else 'SKIP'\n    print(f'{name}: {status} ({passed} passed, {failed} failed, {skipped} skipped)')\n"
+	@python3 -c "\nimport re, os\nfrom pathlib import Path\npid = os.getpid()\nsections = {\n    'S12': f'/tmp/s12-{pid}.txt',\n    'S13': f'/tmp/s13-{pid}.txt',\n    'S28': f'/tmp/s28-{pid}.txt',\n}\nexit_code = 0\nfor name, path in sections.items():\n    if not Path(path).exists():\n        print(f'{name}: SKIPPED (no results)')\n        continue\n    text = Path(path).read_text()\n    passed = len(re.findall(r'PASSED', text))\n    failed = len(re.findall(r'FAILED', text))\n    skipped = len(re.findall(r'SKIPPED', text))\n    if failed > 0:\n        exit_code = 1\n        status = 'FAIL'\n    elif passed > 0:\n        status = 'PASS'\n    else:\n        status = 'SKIP'\n    print(f'{name}: {status} ({passed} passed, {failed} failed, {skipped} skipped)')\nimport sys; sys.exit(exit_code)\n"
 	docker compose -f docker-compose.test.yml down
 
 test-watch: ## Continuous selective testing (reruns affected tests on save)

--- a/Makefile
+++ b/Makefile
@@ -94,11 +94,13 @@ test-persistence: ## Run persistence gate (S12/S13/S28) with structured report
 	@for i in $$(seq 1 30); do \
 		pg_isready -h localhost -p 5433 -U tta_test >/dev/null 2>&1 && break; \
 		sleep 1; \
+		test $$i -eq 30 && echo "ERROR: PostgreSQL did not become ready" && exit 1; \
 	done
 	@echo "Waiting for Neo4j..."
 	@for i in $$(seq 1 10); do \
 		curl -sf http://localhost:7474 >/dev/null 2>&1 && break; \
 		sleep 2; \
+		test $$i -eq 10 && echo "ERROR: Neo4j did not become ready" && exit 1; \
 	done
 	@echo ""
 	@echo "--- Running S12 persistence tests ---"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # ---------------------------------------------------------------------------
 .PHONY: help validate-specs validate-plans validate-openapi validate-all regen-indexes \
 	dashboard trace trace-html \
-        lint format typecheck test test-unit test-integration test-watch \
+        lint format typecheck test test-unit test-integration test-persistence test-watch \
         test-bdd test-hypothesis \
         test-up test-down quality check check-format \
         dev play playtest playtest-web up down build logs shell \
@@ -82,6 +82,37 @@ test-integration: ## Run integration tests (starts/stops test services)
 	EXIT_CODE=$$?; \
 	docker compose -f docker-compose.test.yml down; \
 	exit $$EXIT_CODE
+
+test-persistence: ## Run persistence gate (S12/S13/S28) with structured report
+	@echo "=== Persistence Gate ==="
+	@echo "S12: PostgreSQL + Redis + GDPR"
+	@echo "S13: Neo4j world graph"
+	@echo "S28: Performance benchmarks"
+	@echo ""
+	docker compose -f docker-compose.test.yml up -d
+	@echo "Waiting for PostgreSQL..."
+	@for i in $$(seq 1 30); do \
+		pg_isready -h localhost -p 5433 -U tta_test >/dev/null 2>&1 && break; \
+		sleep 1; \
+	done
+	@echo "Waiting for Neo4j..."
+	@for i in $$(seq 1 10); do \
+		curl -sf http://localhost:7474 >/dev/null 2>&1 && break; \
+		sleep 2; \
+	done
+	@echo ""
+	@echo "--- Running S12 persistence tests ---"
+	-uv run pytest tests/integration/test_s12_persistence_integration.py -v --tb=short 2>&1 | tee /tmp/s12-result.txt
+	@echo ""
+	@echo "--- Running S13 Neo4j tests ---"
+	-uv run pytest tests/integration/test_s13_neo4j_integration.py -v --tb=short 2>&1 | tee /tmp/s13-result.txt
+	@echo ""
+	@echo "--- Running S28 performance tests ---"
+	-PERF=1 uv run pytest tests/integration/test_s28_performance.py -v --tb=short 2>&1 | tee /tmp/s28-result.txt
+	@echo ""
+	@echo "=== Gate Summary ==="
+	@python3 -c "\nimport re\nfrom pathlib import Path\nsections = {'S12': '/tmp/s12-result.txt', 'S13': '/tmp/s13-result.txt', 'S28': '/tmp/s28-result.txt'}\nfor name, path in sections.items():\n    if not Path(path).exists():\n        print(f'{name}: SKIPPED (no results)')\n        continue\n    text = Path(path).read_text()\n    passed = len(re.findall(r'PASSED', text))\n    failed = len(re.findall(r'FAILED', text))\n    skipped = len(re.findall(r'SKIPPED', text))\n    status = 'PASS' if failed == 0 and passed > 0 else 'FAIL' if failed > 0 else 'SKIP'\n    print(f'{name}: {status} ({passed} passed, {failed} failed, {skipped} skipped)')\n"
+	docker compose -f docker-compose.test.yml down
 
 test-watch: ## Continuous selective testing (reruns affected tests on save)
 	uv run ptw . -- --testmon -x --tb=short

--- a/tests/integration/test_s13_neo4j_integration.py
+++ b/tests/integration/test_s13_neo4j_integration.py
@@ -36,7 +36,7 @@ LARGE_SESSION_ID = "perf_test_session"
 
 @pytest.mark.skipif(
     os.getenv("CI") == "true" and os.getenv("PERF") != "1",
-    reason="latency benchmarks are environment-dependent; skip in CI (override with PERF=1)",
+    reason="latency benchmarks vary by environment; skip in CI (PERF=1 to run)",
 )
 @pytest.mark.spec("AC-13.04")
 class TestAC1304LocationContextLatency:
@@ -65,7 +65,7 @@ class TestAC1304LocationContextLatency:
 
 @pytest.mark.skipif(
     os.getenv("CI") == "true" and os.getenv("PERF") != "1",
-    reason="latency benchmarks are environment-dependent; skip in CI (override with PERF=1)",
+    reason="latency benchmarks vary by environment; skip in CI (PERF=1 to run)",
 )
 @pytest.mark.spec("AC-13.05")
 class TestAC1305MovementValidationLatency:
@@ -94,7 +94,7 @@ class TestAC1305MovementValidationLatency:
 
 @pytest.mark.skipif(
     os.getenv("CI") == "true" and os.getenv("PERF") != "1",
-    reason="latency benchmarks are environment-dependent; skip in CI (override with PERF=1)",
+    reason="latency benchmarks vary by environment; skip in CI (PERF=1 to run)",
 )
 @pytest.mark.spec("AC-13.06")
 @pytest.mark.spec("AC-12.08")

--- a/tests/integration/test_s13_neo4j_integration.py
+++ b/tests/integration/test_s13_neo4j_integration.py
@@ -35,8 +35,8 @@ LARGE_SESSION_ID = "perf_test_session"
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="latency benchmarks are environment-dependent; skip in CI",
+    os.getenv("CI") == "true" and os.getenv("PERF") != "1",
+    reason="latency benchmarks are environment-dependent; skip in CI (override with PERF=1)",
 )
 @pytest.mark.spec("AC-13.04")
 class TestAC1304LocationContextLatency:
@@ -64,8 +64,8 @@ class TestAC1304LocationContextLatency:
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="latency benchmarks are environment-dependent; skip in CI",
+    os.getenv("CI") == "true" and os.getenv("PERF") != "1",
+    reason="latency benchmarks are environment-dependent; skip in CI (override with PERF=1)",
 )
 @pytest.mark.spec("AC-13.05")
 class TestAC1305MovementValidationLatency:
@@ -93,8 +93,8 @@ class TestAC1305MovementValidationLatency:
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="latency benchmarks are environment-dependent; skip in CI",
+    os.getenv("CI") == "true" and os.getenv("PERF") != "1",
+    reason="latency benchmarks are environment-dependent; skip in CI (override with PERF=1)",
 )
 @pytest.mark.spec("AC-13.06")
 @pytest.mark.spec("AC-12.08")


### PR DESCRIPTION
## Summary

Wave 3 — persistence gate: converts the S12/S13/S28 integration suite into a
reliable verification gate with structured output.

- New `make test-persistence` target: runs S12 (PostgreSQL + Redis + GDPR),
  S13 (Neo4j world graph), and S28 (performance benchmarks) with a
  structured pass/fail/skip summary
- `PERF=1` env override: Neo4j latency benchmarks are skipped in CI by
  default but can be forced with `PERF=1 make test-persistence`
- Uses the existing `docker-compose.test.yml` service stack

## Test plan
- [x] `make -n test-persistence` syntax check passes
- [x] PERF override logic verified: CI+PERF=1→run, CI+PERF=0→skip, CI+unset→skip
