### PR TITLE
feat: add Instructor for structured LLM output extraction

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,106 @@
+# Architecture Decision Records
+
+## ADR-001: Instructor for Structured LLM Output
+
+**Date**: 2026-05-13
+**Status**: Accepted
+**Decision**: Add `instructor` (≥1.7, <2) as a production dependency for structured LLM output extraction.
+
+### Context
+
+The TTA pipeline has ~15 call sites that parse JSON from LLM responses using `json.loads()` wrapped in `try/except`. These include:
+
+- Character trait extraction (genesis_v2.py)
+- Composition extraction (genesis_v2.py)
+- Commentary parsing (playtest/agent.py)
+- Quality evaluation scoring (quality/evaluator.py)
+- Snapshot deserialization (game/snapshot.py)
+
+Each call site must handle:
+1. The LLM wrapping JSON in markdown code blocks
+2. Missing or extra fields
+3. Type mismatches (string instead of number, etc.)
+4. Complete parse failures
+
+Instructor solves all of these with Pydantic model validation, automatic retries, and a consistent API across 15+ LLM providers.
+
+### Alternatives Considered
+
+| Option | Verdict | Reason |
+|--------|---------|--------|
+| **Instructor** | **Chosen** | Most popular Python structured output lib (3M monthly downloads, 11K stars). Works with LiteLLM, Pydantic-native, MIT licensed. |
+| Outlines | Rejected | Requires local model inference (token-level constraints). Doesn't work with API-based providers like our FMR backend. |
+| PydanticAI | Rejected | Full agent framework — overkill. We deliberately avoid agent frameworks for the main pipeline. |
+| Continue manual json.loads | Rejected | Works but fragile. Each call site reinvents validation. Instructor collapses ~8 lines of try/except + type checking into 1 type-safe call. |
+
+### Integration Pattern
+
+```python
+from pydantic import BaseModel, Field
+from tta.llm.structured import generate_structured
+
+class CharacterTraits(BaseModel):
+    traits: list[str] = Field(max_length=3)
+
+result = await generate_structured(
+    llm_client,
+    messages=[...],
+    response_model=CharacterTraits,
+)
+# result.traits is guaranteed list[str] with ≤3 items
+```
+
+Key design choices:
+- **Lazy import**: Instructor imports `litellm` which hangs when CWD is the project root. The structured module uses lazy initialization via `_get_instructor_client()`.
+- **from_litellm(), not from_provider()**: Model selection is controlled by our existing role configs, not hardcoded strings.
+- **Non-fatal by convention**: Callers still wrap in try/except — structured extraction is best-effort.
+
+### Migration Plan
+
+Existing `json.loads()` call sites will be converted opportunistically. The genesis_v2.py `_infer_traits` method is the first conversion. No rush — each conversion is a net improvement in type safety and error handling.
+
+---
+
+## ADR-002: Neo4j as Optional World Graph Backend
+
+**Date**: 2026-05-13
+**Status**: Accepted (reaffirmed)
+**Decision**: Keep Neo4j CE 5.x as an optional backend. Promote InMemoryWorldService as the default for development and single-session play. Require Neo4j only for multi-session universe persistence and complex graph traversals.
+
+### Context
+
+Neo4j provides Cypher-based graph queries for world state (locations, NPCs, items, relationships, memory records). It adds operational complexity: container dependency, auth, backup, separate migration path.
+
+The InMemoryWorldService (Python dicts) already handles all tests and single-session play. For a game where a player might spend hundreds or thousands of hours, the question is: at what scale does in-memory storage become insufficient?
+
+### Scale Analysis
+
+| Component | Per-Session Estimate | 1000-Hour Estimate | In-Memory Viable? |
+|-----------|---------------------|-------------------|-------------------|
+| Locations | 50–200 | 2,000–10,000 | Yes (Python dict: O(1) lookup) |
+| NPCs | 10–50 active | 500–2,000 total | Yes |
+| Items | 20–100 | 1,000–5,000 | Yes |
+| MemoryRecords | 100–500 | 50,000–200,000 | Borderline (compression keeps hot set small) |
+| NPC social edges | 50–500 | 10,000–50,000 | Graph traversal needed |
+
+The bottleneck isn't memory (Python dicts can hold millions of nodes) — it's **graph traversal complexity**. Queries like "all NPCs who know each other within 3 hops" or "consequence propagation through the world graph" become O(n²) in pure Python. Neo4j's Cypher engine handles these in O(n) with index-backed traversals.
+
+### Decision
+
+- **InMemoryWorldService** remains the default for development and single-session play
+- **Neo4jWorldService** is required for:
+  - Multi-session universe persistence (S33)
+  - NPC social graph queries (S38)
+  - Consequence propagation (S36)
+  - World memory compression (S37)
+
+The Neo4j startup migration path is preserved — new v2 tables and indexes are additive. The `TTA_NEO4J_URI` env var controls whether Neo4j is used; when unset, the app falls back to InMemoryWorldService.
+
+### Why Not Alternatives
+
+| Option | Verdict | Reason |
+|--------|---------|--------|
+| **Neo4j CE 5.x** | **Kept** | Cypher queries, graph traversal, active community. Container overhead is acceptable for the graph query power. |
+| networkx (in-memory) | Rejected | No persistence. Graph algorithms are Python-only (slower). Would need custom serialization for universe snapshots. |
+| SQL recursive CTEs | Rejected | Postgres can do graph traversal via recursive CTEs, but the syntax is painful and performance degrades beyond 3-4 hops. |
+| SurrealDB / ArcadeDB | Not evaluated | Multi-model databases with graph support exist, but Neo4j's Cypher + ecosystem maturity outweigh potential consolidation benefits at our scale. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "asyncpg>=0.30",
     "alembic>=1.13",
     "litellm>=1.83,<2",
+    "instructor>=1.7,<2",
     "neo4j>=6.0",
     "psycopg[binary]>=3.1",
     "redis>=5.0",

--- a/src/tta/genesis/genesis_v2.py
+++ b/src/tta/genesis/genesis_v2.py
@@ -26,10 +26,12 @@ from uuid import UUID
 
 import sqlalchemy as sa
 import structlog
+from pydantic import BaseModel, Field
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tta.llm.client import LLMClient, Message, MessageRole
 from tta.llm.roles import ModelRole
+from tta.llm.structured import generate_structured
 
 if TYPE_CHECKING:
     from tta.seeds.registry import SeedRegistry
@@ -555,7 +557,21 @@ class GenesisOrchestrator:
             state.composition_committed = False
 
     async def _infer_traits(self, state: GenesisState, player_input: str) -> None:
-        """Infer 2-3 character traits from conversation history."""
+        """Infer 2-3 character traits from conversation history.
+
+        Uses Instructor for structured extraction (replaces manual json.loads).
+        Non-fatal — defaults to empty traits on failure.
+        """
+
+        class CharacterTraits(BaseModel):
+            """Character personality traits extracted from conversation."""
+
+            traits: list[str] = Field(
+                default_factory=list,
+                max_length=3,
+                description="2-3 single adjective personality traits",
+            )
+
         history_text = "\n".join(
             f"{i['role'].upper()}: {i['content']}" for i in state.interactions[-6:]
         )
@@ -563,11 +579,9 @@ class GenesisOrchestrator:
             Message(
                 role=MessageRole.SYSTEM,
                 content=(
-                    "You are a character analyst. Based on the following conversation, "
-                    "infer 2-3 personality traits for this character. "
-                    "Respond with a JSON array of strings, "
-                    'e.g. ["curious", "cautious"]. '
-                    "Use single adjective words only."
+                    "You are a character analyst. Based on the following "
+                    "conversation, infer 2-3 personality traits for this "
+                    "character. Use single adjective words only."
                 ),
             ),
             Message(
@@ -576,11 +590,14 @@ class GenesisOrchestrator:
             ),
         ]
         try:
-            raw = await self._llm.generate(ModelRole.EXTRACTION, messages)
-            traits = json.loads(raw.content)
-            if isinstance(traits, list):
-                state.inferred_traits = [str(t) for t in traits[:3]]
-        except (json.JSONDecodeError, Exception):
+            result = await generate_structured(
+                self._llm,
+                messages,
+                CharacterTraits,
+                role=ModelRole.EXTRACTION,
+            )
+            state.inferred_traits = result.traits[:3]
+        except Exception:
             # Non-fatal — inferred traits default to empty
             pass
 

--- a/src/tta/llm/structured.py
+++ b/src/tta/llm/structured.py
@@ -1,0 +1,117 @@
+"""Structured output helpers using Instructor + LiteLLM.
+
+Provides type-safe LLM extraction that replaces manual json.loads()
+with Pydantic model validation, automatic retries, and proper error
+handling. Integrates with TTA's existing LLMClient abstraction.
+
+Usage:
+    from tta.llm.structured import generate_structured
+    from pydantic import BaseModel
+
+    class WorldTraits(BaseModel):
+        atmosphere: str
+        locations: list[str]
+        notable_npcs: list[str]
+
+    traits = await generate_structured(
+        llm_client,
+        messages=[...],
+        response_model=WorldTraits,
+    )
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeVar
+
+import structlog
+from pydantic import BaseModel
+
+from tta.llm.client import Message
+from tta.llm.roles import ModelRole
+
+if TYPE_CHECKING:
+    pass
+
+log = structlog.get_logger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+_instructor_client: object | None = None
+
+
+def _get_instructor_client() -> object:
+    """Lazily initialize the Instructor client to avoid import-time
+    litellm import (which hangs when CWD is the project root)."""
+    global _instructor_client
+    if _instructor_client is None:
+        import instructor
+        from litellm import acompletion
+
+        _instructor_client = instructor.from_litellm(acompletion)
+    return _instructor_client
+
+
+async def generate_structured[T: BaseModel](
+    llm_client: object,
+    messages: list[Message],
+    response_model: type[T],
+    *,
+    role: ModelRole = ModelRole.EXTRACTION,
+    max_retries: int = 2,
+) -> T:
+    """Extract structured data from an LLM response.
+
+    Args:
+        llm_client: A TTA LLMClient instance. Used to resolve the active
+            model from role configs.
+        messages: The prompt messages.
+        response_model: A Pydantic BaseModel subclass defining the expected
+            output schema.
+        role: The ModelRole for model selection (default: EXTRACTION).
+        max_retries: Number of retries on validation failure (default: 2).
+
+    Returns:
+        An instance of response_model with validated data.
+
+    Raises:
+        instructor.exceptions.InstructorRetryException: If all retries
+            are exhausted without valid output.
+    """
+    client = _get_instructor_client()
+
+    # Convert TTA Message objects to dicts for Instructor/LiteLLM
+    message_dicts = [{"role": m.role.value, "content": m.content} for m in messages]
+
+    # Resolve the active model from the LLM client's role configs
+    model = _resolve_model(llm_client, role)
+
+    try:
+        result = await client.chat.completions.create(
+            model=model,
+            messages=message_dicts,
+            response_model=response_model,
+            max_retries=max_retries,
+        )
+    except Exception:
+        log.warning(
+            "structured_extraction_failed",
+            response_model=response_model.__name__,
+            role=role.value,
+            exc_info=True,
+        )
+        raise
+
+    return result
+
+
+def _resolve_model(llm_client: object, role: ModelRole) -> str:
+    """Resolve the model name from the LLM client's role configs."""
+    try:
+        configs = getattr(llm_client, "_role_configs", None)
+        if configs and role in configs:
+            return configs[role].primary
+    except Exception:
+        pass
+    # Sensible default for extraction tasks on free models
+    return "openai/tta"

--- a/src/tta/llm/structured.py
+++ b/src/tta/llm/structured.py
@@ -22,7 +22,7 @@ Usage:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import structlog
 from pydantic import BaseModel
@@ -37,10 +37,10 @@ log = structlog.get_logger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
 
-_instructor_client: object | None = None
+_instructor_client: Any = None
 
 
-def _get_instructor_client() -> object:
+def _get_instructor_client() -> Any:
     """Lazily initialize the Instructor client to avoid import-time
     litellm import (which hangs when CWD is the project root)."""
     global _instructor_client

--- a/uv.lock
+++ b/uv.lock
@@ -615,6 +615,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.135.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1240,6 +1249,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "instructor"
+version = "1.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "docstring-parser" },
+    { name = "jinja2" },
+    { name = "jiter" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tenacity" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/a4/832cfb15420360e26d2d85bd9d5fe1e4b839d52587574d389bc31284bf6f/instructor-1.15.1.tar.gz", hash = "sha256:c72406469d9025b742e83cf0c13e914b317db2089d08d889944e74fcd659ef94", size = 69948370, upload-time = "2026-04-03T01:51:30.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/c8/36c5d9b80aaf40ba9a7084a8fc18c967db6bf248a4cc8d0f0816b14284be/instructor-1.15.1-py3-none-any.whl", hash = "sha256:be81d17ba2b154a04ab4720808f24f9d6b598f80992f82eaf9cc79006099cf6c", size = 178156, upload-time = "2026-04-03T01:51:23.098Z" },
 ]
 
 [[package]]
@@ -3025,6 +3056,7 @@ dependencies = [
     { name = "bcrypt" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "instructor" },
     { name = "jinja2" },
     { name = "langfuse" },
     { name = "litellm" },
@@ -3068,6 +3100,7 @@ requires-dist = [
     { name = "bcrypt", specifier = ">=4.2" },
     { name = "fastapi", specifier = ">=0.135" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "instructor", specifier = ">=1.7,<2" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "langfuse", specifier = ">=4.0,<5.0" },
     { name = "litellm", specifier = ">=1.83,<2" },


### PR DESCRIPTION
## What

Adds [Instructor](https://python.useinstructor.com/) (3M monthly downloads, 11K stars) for type-safe structured LLM output extraction. Replaces the manual `json.loads()` + isinstance checking pattern used at ~15 call sites across the codebase.

## Changes

- **New dependency**: `instructor>=1.7,<2` — MIT licensed, Pydantic-native
- **New module**: `src/tta/llm/structured.py` — `generate_structured()` helper with lazy litellm import
- **First integration**: genesis_v2.py `_infer_traits()` — character trait extraction now uses Pydantic model + auto-retries
- **Architecture Decision Records**: `docs/adr/README.md` with two ADRs:
  - ADR-001: Instructor for structured output (vs Outlines, PydanticAI, manual parsing)
  - ADR-002: Neo4j scale analysis (InMemoryWorldService viable for millions of nodes; Neo4j required for graph traversals)

## Why

Before:
```python
raw = await self._llm.generate(ModelRole.EXTRACTION, messages)
traits = json.loads(raw.content)
if isinstance(traits, list):
    state.inferred_traits = [str(t) for t in traits[:3]]
```

After:
```python
result = await generate_structured(self._llm, messages, CharacterTraits)
state.inferred_traits = result.traits[:3]
```

## Verification

- ruff: clean
- ruff format: clean
- Module imports cleanly from /tmp (avoids litellm import hang)