### PR TITLE
feat(arq): add run_playtester_session job + wire into eval pipeline

### DIFF
--- a/src/tta/eval/pipeline.py
+++ b/src/tta/eval/pipeline.py
@@ -39,11 +39,13 @@ class EvaluationPipeline:
         api_base_url: str = "",
         api_key: str | None = None,
         llm_client: Any = None,
+        arq_queue: Any = None,
     ) -> None:
         self._config = config or BatchConfig()
         self._api_base_url = api_base_url
         self._api_key = api_key
         self._llm = llm_client
+        self._arq_queue = arq_queue
 
     # ------------------------------------------------------------------
     # Step 1 — plan
@@ -72,7 +74,15 @@ class EvaluationPipeline:
     # Step 2 — execute LLM playtesters
 
     async def run_llm_playtesters(self, planned: list[PlannedRun]) -> list[RunResult]:
-        """Run all planned sessions in parallel (bounded by max_parallel_runs)."""
+        """Run all planned sessions, using arq workers when available.
+
+        With arq_queue: enqueue all sessions as jobs, wait for results.
+        Without arq_queue: run inline with asyncio.Semaphore (backward compat).
+        """
+        if self._arq_queue is not None:
+            return await self._run_via_arq(planned)
+
+        # Fallback: inline execution (existing behavior)
         from tta.playtest.agent import PlaytesterAgent
 
         sem = asyncio.Semaphore(self._config.max_parallel_runs)
@@ -131,6 +141,75 @@ class EvaluationPipeline:
                 )
 
         return list(await asyncio.gather(*[_run_one(p) for p in planned]))
+
+    async def _run_via_arq(self, planned: list[PlannedRun]) -> list[RunResult]:
+        """Enqueue playtester sessions as arq jobs and collect results."""
+        import asyncio
+
+        job_ids: dict[str, PlannedRun] = {}
+        for p in planned:
+            job_id = await self._arq_queue.enqueue(
+                "run_playtester_session",
+                api_base_url=self._api_base_url,
+                scenario_seed_id=p.scenario_seed_id,
+                persona_id=p.persona_id,
+                run_seed=p.run_seed,
+                persona_jitter_seed=p.persona_jitter_seed,
+                api_key=self._api_key or "",
+            )
+            job_ids[job_id] = p
+
+        # Poll for results
+        results: list[RunResult] = []
+        pending = dict(job_ids)
+        timeout = 600  # 10 min total wait
+        poll_interval = 2.0
+        elapsed = 0.0
+
+        while pending and elapsed < timeout:
+            for job_id, planned_run in list(pending.items()):
+                status = await self._arq_queue.job_status(job_id)
+                if status is None:
+                    continue
+                status_str = str(status) if not isinstance(status, str) else status
+                if status_str in ("complete", "success"):
+                    pending.pop(job_id)
+                    results.append(
+                        RunResult(
+                            run_id=planned_run.run_id,
+                            scenario_seed_id=planned_run.scenario_seed_id,
+                            persona_id=planned_run.persona_id,
+                            status="complete",
+                        )
+                    )
+                elif status_str in ("failed", "not_found"):
+                    pending.pop(job_id)
+                    results.append(
+                        RunResult(
+                            run_id=planned_run.run_id,
+                            scenario_seed_id=planned_run.scenario_seed_id,
+                            persona_id=planned_run.persona_id,
+                            status="error",
+                            error=f"arq job {status_str}",
+                        )
+                    )
+            if pending:
+                await asyncio.sleep(poll_interval)
+                elapsed += poll_interval
+
+        # Any still pending → timed out
+        for _job_id, planned_run in pending.items():
+            results.append(
+                RunResult(
+                    run_id=planned_run.run_id,
+                    scenario_seed_id=planned_run.scenario_seed_id,
+                    persona_id=planned_run.persona_id,
+                    status="error",
+                    error="arq job timed out",
+                )
+            )
+
+        return results
 
     # ------------------------------------------------------------------
     # Step 3 — load human feedback

--- a/src/tta/jobs/jobs.py
+++ b/src/tta/jobs/jobs.py
@@ -262,6 +262,79 @@ async def game_backfill(ctx: dict, game_id: str | None = None) -> dict:
         raise
 
 
+async def run_playtester_session(
+    ctx: dict,
+    api_base_url: str,
+    scenario_seed_id: str,
+    persona_id: str,
+    run_seed: int,
+    persona_jitter_seed: int = 0,
+    api_key: str = "",
+) -> dict:
+    """Run a single playtester session in an arq worker (Decision #6).
+
+    Creates a PlaytesterAgent, plays a full session against the TTA API,
+    and returns a serialized RunResult. Sessions are stateless and parallel.
+    """
+    start = time.monotonic()
+    job_fn = "run_playtester_session"
+    try:
+        from tta.llm.litellm_client import LiteLLMClient
+        from tta.playtest.agent import PlaytesterAgent
+
+        llm = LiteLLMClient()
+        agent = PlaytesterAgent(
+            api_base_url=api_base_url,
+            llm_client=llm,
+            api_key=api_key or None,
+        )
+        agent.setup(
+            scenario_seed_id=scenario_seed_id,
+            persona_id=persona_id,
+            run_seed=run_seed,
+            persona_jitter_seed=persona_jitter_seed,
+        )
+        report = await agent.run()
+
+        duration = time.monotonic() - start
+        JOB_DURATION.labels(job_fn=job_fn).observe(duration)
+        JOB_RUNS.labels(job_fn=job_fn, status="success").inc()
+        log.info(
+            "playtester_session_complete",
+            scenario_seed_id=scenario_seed_id,
+            persona_id=persona_id,
+            status=report.status,
+            turns=len(report.turns),
+            duration_ms=round(duration * 1000, 1),
+        )
+        return {
+            "scenario_seed_id": scenario_seed_id,
+            "persona_id": persona_id,
+            "run_seed": run_seed,
+            "status": report.status,
+            "run_id": report.run_id,
+            "turns_completed": len(report.turns),
+            "overall_rating": report.overall_agent_rating,
+            "report_json": report.model_dump_json(),  # type: ignore[attr-defined]
+        }
+
+    except Exception as exc:
+        duration = time.monotonic() - start
+        JOB_DURATION.labels(job_fn=job_fn).observe(duration)
+        job_try = ctx.get("job_try", 1)
+        if job_try >= 3:
+            JOB_RUNS.labels(job_fn=job_fn, status="failed").inc()
+            await _write_dead_letter(
+                ctx,
+                job_fn,
+                (api_base_url, scenario_seed_id, persona_id, run_seed),
+                str(exc),
+            )
+        else:
+            JOB_RUNS.labels(job_fn=job_fn, status="retry").inc()
+        raise
+
+
 async def run_npc_autonomy(ctx: dict, game_id: str, universe_id: str) -> dict:
     """Fire-and-forget NPC autonomy + consequence propagation (Decision #6).
 

--- a/src/tta/jobs/worker.py
+++ b/src/tta/jobs/worker.py
@@ -11,6 +11,7 @@ from tta.jobs.jobs import (
     gdpr_delete_player,
     retention_sweep,
     run_npc_autonomy,
+    run_playtester_session,
     session_cleanup,
 )
 
@@ -29,6 +30,7 @@ class WorkerSettings:
         session_cleanup,
         game_backfill,
         run_npc_autonomy,
+        run_playtester_session,
     ]
     redis_settings = RedisSettings.from_dsn(settings.redis_url)
     max_jobs = 10

--- a/tests/unit/jobs/test_s48_ac_compliance.py
+++ b/tests/unit/jobs/test_s48_ac_compliance.py
@@ -369,8 +369,8 @@ class TestWorkerSettings:
         assert self.WS.keep_result == 3600
 
     @pytest.mark.spec("AC-48.05")
-    def test_all_five_functions_registered(self) -> None:
-        """AC-48.05: All five job functions are registered with the worker."""
+    def test_all_six_functions_registered(self) -> None:
+        """AC-48.05: All six job functions are registered with the worker."""
         fn_names = {fn.__name__ for fn in self.WS.functions}
         assert fn_names == {
             "gdpr_delete_player",
@@ -378,6 +378,7 @@ class TestWorkerSettings:
             "session_cleanup",
             "game_backfill",
             "run_npc_autonomy",
+            "run_playtester_session",
         }
 
     @pytest.mark.spec("AC-48.05")


### PR DESCRIPTION
## Summary

Decision #6 Phase 1: playtester sessions now run in arq workers when arq_queue is configured, with inline fallback for backward compatibility.

## Changes
- `run_playtester_session` job: creates PlaytesterAgent, runs full session against TTA API
- `EvaluationPipeline`: new `arq_queue` param, `_run_via_arq()` method enqueues all sessions, polls for completion
- Each session: self-bootstrapping LiteLLMClient, Prometheus metrics, dead-letter handling
- `WorkerSettings`: 6th function registered (6 jobs total)
- `test_all_six_functions_registered` updated

## Design
When arq_queue is available: enqueue all sessions → poll for results → collect RunResults
When arq_queue is None: inline execution via asyncio.Semaphore (existing behavior)

Worker creates its own LiteLLMClient from env vars, same pattern as run_npc_autonomy.