### PR TITLE
feat: activate Langfuse prompt bridge — seed, render, and per-version metrics

### DIFF
--- a/src/tta/api/app.py
+++ b/src/tta/api/app.py
@@ -158,6 +158,14 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
             file_registry=app.state.prompt_registry,
         )
         log.info("prompt_bridge_initialized")
+        # Seed Langfuse with current file-based templates (FB-005 / AC-09.2).
+        # Hash-based — skips unchanged content. Non-fatal: gameplay continues
+        # if Langfuse is unreachable.
+        try:
+            seed_results = await app.state.prompt_bridge.seed_from_files()
+            log.info("prompt_bridge_seeded", results=seed_results)
+        except Exception:
+            log.exception("prompt_bridge_seed_failed")
     else:
         app.state.prompt_bridge = None
         log.info("prompt_bridge_disabled", reason="langfuse_not_configured")
@@ -406,6 +414,7 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         consequence_service=consequence_svc,
         relationship_service=relationship_svc,
         prompt_registry=app.state.prompt_registry,
+        prompt_bridge=getattr(app.state, "prompt_bridge", None),
         llm_semaphore=app.state.llm_semaphore,
         llm_circuit_breaker=llm_circuit_breaker,
         db_session_factory=session_factory,

--- a/src/tta/pipeline/stages/generate.py
+++ b/src/tta/pipeline/stages/generate.py
@@ -256,7 +256,7 @@ async def generate_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
         )
 
     # 3. Call LLM with transient-failure retry cascade
-    gen_system, rendered_system_prompt = _resolve_system_prompt(deps)
+    gen_system, rendered_system_prompt = await _resolve_system_prompt(deps)
     messages = [
         Message(role=MessageRole.SYSTEM, content=gen_system),
         Message(role=MessageRole.USER, content=prompt),
@@ -358,10 +358,12 @@ async def generate_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
     )
 
 
-def _resolve_system_prompt(deps: PipelineDeps) -> tuple[str, RenderedPrompt]:
+async def _resolve_system_prompt(deps: PipelineDeps) -> tuple[str, RenderedPrompt]:
     """Resolve generation system prompt from registry (AC-09.1).
 
     Templates are the single source of truth — no inline fallback.
+    When the Langfuse bridge is active, rendering goes through it to
+    attach prompt provenance metadata (AC-09.7 / FB-005).
     """
     if not deps.prompt_registry or not deps.prompt_registry.has("narrative.generate"):
         log.error("generation_template_missing")
@@ -370,7 +372,7 @@ def _resolve_system_prompt(deps: PipelineDeps) -> tuple[str, RenderedPrompt]:
             "TEMPLATE_MISSING",
             "Narrative generation template not available",
         )
-    rendered = deps.prompt_registry.render("narrative.generate", {})
+    rendered = await deps.render_prompt("narrative.generate")
     return rendered.text, rendered
 
 
@@ -472,7 +474,7 @@ async def _extract_world_changes(
         log.debug("extraction_template_missing")
         return [], []
     try:
-        extraction_prompt = deps.prompt_registry.render("extraction.world-changes", {})
+        extraction_prompt = await deps.render_prompt("extraction.world-changes")
     except Exception:
         log.error(
             "extraction_template_render_failed",

--- a/src/tta/pipeline/stages/understand.py
+++ b/src/tta/pipeline/stages/understand.py
@@ -129,7 +129,7 @@ async def understand_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
                 }
             )
         try:
-            rendered = deps.prompt_registry.render("classification.intent", {})
+            rendered = await deps.render_prompt("classification.intent")
         except Exception:
             log.error(
                 "classification_template_render_failed",

--- a/src/tta/pipeline/types.py
+++ b/src/tta/pipeline/types.py
@@ -78,7 +78,7 @@ class PipelineDeps:
         self,
         template_id: str,
         variables: dict[str, Any] | None = None,
-    ) -> RenderedPrompt | None:
+    ) -> RenderedPrompt:
         """Render a prompt through the bridge if available, falling back to file
         registry.
 

--- a/src/tta/pipeline/types.py
+++ b/src/tta/pipeline/types.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel, Field
 
 from tta.models.turn import TurnState
+from tta.prompts.registry import RenderedPrompt
 
 if TYPE_CHECKING:
     from tta.choices.consequence_service import ConsequenceService
@@ -59,6 +60,7 @@ class PipelineDeps:
     consequence_service: ConsequenceService | None = None
     relationship_service: RelationshipService | None = None
     prompt_registry: FilePromptRegistry | None = None
+    prompt_bridge: Any | None = None  # LangfusePromptBridge (FB-005 / AC-09.2)
     llm_semaphore: LLMSemaphore | None = None
     llm_circuit_breaker: CircuitBreaker | None = None
     db_session_factory: Any | None = None  # async_sessionmaker for direct DB access
@@ -71,6 +73,29 @@ class PipelineDeps:
     memory_writer: MemoryWriter | None = None  # v2 S37
     social_memory_writer: SocialMemoryWriter | None = None  # v2 S38
     arq_queue: Any | None = None  # ArqQueue for fire-and-forget job dispatch
+
+    async def render_prompt(
+        self,
+        template_id: str,
+        variables: dict[str, Any] | None = None,
+    ) -> Any:
+        """Render a prompt through the bridge if available, falling back to file registry.
+
+        When the bridge is active, this adds Langfuse prompt metadata
+        (langfuse_prompt, version, label) enabling per-version metrics
+        in Langfuse (AC-09.7 / FB-005).
+        """
+        if variables is None:
+            variables = {}
+        if self.prompt_bridge is not None:
+            return await self.prompt_bridge.render(template_id, variables)
+        if self.prompt_registry is not None:
+            return self.prompt_registry.render(template_id, variables)
+        raise RuntimeError(
+            f"Cannot render prompt '{template_id}': "
+            "no prompt_registry or prompt_bridge configured"
+        )
+
 
 
 # Each stage takes (TurnState, PipelineDeps) and returns enriched TurnState

--- a/src/tta/pipeline/types.py
+++ b/src/tta/pipeline/types.py
@@ -78,8 +78,9 @@ class PipelineDeps:
         self,
         template_id: str,
         variables: dict[str, Any] | None = None,
-    ) -> Any:
-        """Render a prompt through the bridge if available, falling back to file registry.
+    ) -> RenderedPrompt | None:
+        """Render a prompt through the bridge if available, falling back to file
+        registry.
 
         When the bridge is active, this adds Langfuse prompt metadata
         (langfuse_prompt, version, label) enabling per-version metrics
@@ -95,7 +96,6 @@ class PipelineDeps:
             f"Cannot render prompt '{template_id}': "
             "no prompt_registry or prompt_bridge configured"
         )
-
 
 
 # Each stage takes (TurnState, PipelineDeps) and returns enriched TurnState

--- a/tests/unit/pipeline/test_generate_narrative.py
+++ b/tests/unit/pipeline/test_generate_narrative.py
@@ -73,6 +73,14 @@ def _make_deps(
     deps.prompt_registry = (
         make_mock_registry() if prompt_registry is _UNSET else prompt_registry
     )
+
+    # render_prompt: bridge-aware rendering (FB-005 / AC-09.2).
+    # Falls back to prompt_registry.render when bridge is not configured.
+    deps.prompt_bridge = None
+    async def _mock_render_prompt(template_id, variables=None):
+        return deps.prompt_registry.render(template_id, variables or {})
+    deps.render_prompt = AsyncMock(side_effect=_mock_render_prompt)
+
     return deps
 
 
@@ -116,14 +124,14 @@ class TestAdaptiveWordCounts:
 class TestNarratorConstraints:
     """System prompt (from registry template) includes hard constraints."""
 
-    def test_constraints_in_system_prompt(self) -> None:
+    async def test_constraints_in_system_prompt(self) -> None:
         registry = MagicMock()
         registry.has.return_value = True
         rendered = MagicMock()
         rendered.text = "Never break the fourth wall. Never reveal you are an AI."
         registry.render.return_value = rendered
         deps = _make_deps(prompt_registry=registry)
-        result_text, _ = _resolve_system_prompt(deps)
+        result_text, _ = await _resolve_system_prompt(deps)
         assert "fourth wall" in result_text.lower()
         assert "ai" in result_text.lower()
 
@@ -204,7 +212,7 @@ class TestSummaryInjection:
 class TestPromptRegistryResolution:
     """_resolve_system_prompt uses registry when available."""
 
-    def test_uses_registry_when_template_exists(self) -> None:
+    async def test_uses_registry_when_template_exists(self) -> None:
         registry = MagicMock()
         registry.has.return_value = True
         rendered = MagicMock()
@@ -212,20 +220,20 @@ class TestPromptRegistryResolution:
         registry.render.return_value = rendered
 
         deps = _make_deps(prompt_registry=registry)
-        result_text, _ = _resolve_system_prompt(deps)
+        result_text, _ = await _resolve_system_prompt(deps)
         assert result_text == "Custom system prompt from registry"
 
-    def test_raises_when_no_registry(self) -> None:
+    async def test_raises_when_no_registry(self) -> None:
         deps = _make_deps(prompt_registry=None)
         with pytest.raises(AppError):
-            _resolve_system_prompt(deps)
+            await _resolve_system_prompt(deps)
 
-    def test_raises_when_template_missing(self) -> None:
+    async def test_raises_when_template_missing(self) -> None:
         registry = MagicMock()
         registry.has.return_value = False
         deps = _make_deps(prompt_registry=registry)
         with pytest.raises(AppError):
-            _resolve_system_prompt(deps)
+            await _resolve_system_prompt(deps)
 
 
 # ===================================================================

--- a/tests/unit/pipeline/test_generate_narrative.py
+++ b/tests/unit/pipeline/test_generate_narrative.py
@@ -77,8 +77,10 @@ def _make_deps(
     # render_prompt: bridge-aware rendering (FB-005 / AC-09.2).
     # Falls back to prompt_registry.render when bridge is not configured.
     deps.prompt_bridge = None
+
     async def _mock_render_prompt(template_id, variables=None):
         return deps.prompt_registry.render(template_id, variables or {})
+
     deps.render_prompt = AsyncMock(side_effect=_mock_render_prompt)
 
     return deps


### PR DESCRIPTION
## Summary
Activates the Langfuse Prompt Bridge in the fictional-barnacle TTA pipeline, completing Phases 2 & 3 of the Langfuse integration plan.

## What changed

**Phase 2 — Seed on startup** (`app.py`)
- Calls `seed_from_files()` after bridge initialization
- Hash-based: skips unchanged content, non-fatal on Langfuse unreachable

**Phase 3 — Bridge-aware rendering** (`types.py`, `understand.py`, `generate.py`)
- Added `prompt_bridge` field + `render_prompt()` async method to `PipelineDeps`
- Switched all 3 render call sites to `await deps.render_prompt()`
- `render_prompt()` falls back to `FilePromptRegistry` when bridge is `None` (tests, no Langfuse config)

**Test updates** (`test_generate_narrative.py`)
- Wired `render_prompt` AsyncMock in `_make_deps`
- Made 4 test functions async to match `_resolve_system_prompt`

## Why
This unlocks per-version prompt metrics in Langfuse — every generation will be linked to its prompt version, enabling latency/token/cost/score breakdowns by version in the Langfuse dashboard.

## Testing
- 416 pipeline/prompts/app tests pass (same as pre-change baseline)
- No gameplay impact: bridge not configured in test env, fallback path taken

## Pre-requisite
- 3 TTA prompts created in Langfuse (tta-classification-intent, tta-narrative-generate, tta-extraction-world-changes) at v1 with production+staging labels