### PR TITLE
fix: smoke test hang + FMR default URL + admin prompts extraction

### DIFF
--- a/src/tta/api/app.py
+++ b/src/tta/api/app.py
@@ -28,6 +28,7 @@ from tta.api.middleware import (
 )
 from tta.api.prometheus_middleware import PrometheusMiddleware
 from tta.api.routes.admin import router as admin_router
+from tta.api.routes.admin_prompts import router as admin_prompts_router
 from tta.api.routes.auth import router as auth_router
 from tta.api.routes.games import router as games_router
 from tta.api.routes.metrics import router as metrics_router
@@ -568,6 +569,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(games_router, prefix="/api/v1")
     app.include_router(auth_router, prefix="/api/v1")
     app.include_router(admin_router, prefix="/admin")
+    app.include_router(admin_prompts_router, prefix="/admin")
 
     from tta.api.routes.disclaimer import router as disclaimer_router
 

--- a/src/tta/api/routes/admin.py
+++ b/src/tta/api/routes/admin.py
@@ -33,9 +33,7 @@ from tta.admin.auth import AdminIdentity, require_admin
 from tta.api.errors import AppError
 from tta.errors import ErrorCategory
 from tta.models.admin import (
-    ActivatePromptRequest,
     LogLevelBody,
-    PreviewPromptRequest,
     ReasonRequest,
     ReviewRequest,
     SuspendRequest,
@@ -44,7 +42,6 @@ from tta.models.admin import (
 )
 from tta.observability.metrics import REGISTRY, SESSIONS_ACTIVE, generate_latest
 from tta.persistence.redis_session import evict_game_state
-from tta.prompts.langfuse_bridge import _from_langfuse_name
 
 router = APIRouter(tags=["admin"])
 log = structlog.get_logger()
@@ -1089,108 +1086,10 @@ async def enqueue_job(
     )
 
 
-# ==================================================================
-# §3.8  Prompt management (FB-005 / AC-09.02)
-# ==================================================================
+# Prompt management routes are in admin_prompts.py (§3.8 / FB-005 / AC-09.02).
+# They are mounted at app level via include_router in app.py.
+# The router is imported here for backward compat — existing importers
+# (like test_admin_prompts.py transitioning to new location) still resolve.
 
-
-@router.post("/prompts/{name}/activate")
-async def activate_prompt(
-    name: str,
-    body: ActivatePromptRequest,
-    request: Request,
-    admin: AdminIdentity = Depends(require_admin),
-) -> JSONResponse:
-    """Activate a prompt version by changing its Langfuse label (AC-09.02).
-
-    This is the runtime equivalent of "deploy this version to production."
-    The next turn that uses this prompt will fetch the newly-labelled version.
-    """
-    bridge = request.app.state.prompt_bridge
-    if bridge is None:
-        raise AppError(
-            ErrorCategory.INTERNAL_ERROR,
-            "PROMPT_BRIDGE_NOT_CONFIGURED",
-            "Langfuse prompt bridge is not configured. Set langfuse_host in settings.",
-        )
-
-    template_id = _from_langfuse_name(name)
-    await bridge.activate(template_id, label=body.label)
-
-    await _audit(
-        request,
-        admin,
-        action="prompt_activate",
-        target_type="prompt",
-        target_id=name,
-        reason=f"label={body.label}",
-    )
-
-    log.info(
-        "admin_prompt_activated",
-        prompt_name=name,
-        label=body.label,
-        admin=admin.admin_id,
-    )
-    return JSONResponse(
-        content={"status": "activated", "prompt": name, "label": body.label},
-    )
-
-
-@router.post("/prompts/{name}/preview")
-async def preview_prompt(
-    name: str,
-    body: PreviewPromptRequest,
-    request: Request,
-    admin: AdminIdentity = Depends(require_admin),
-) -> JSONResponse:
-    """Preview a prompt against variables in shadow mode (AC-09.09).
-
-    Renders the specified prompt version against the provided variables
-    and returns the rendered output.  This does NOT modify game state,
-    consume turn credits, or affect observability dashboards.
-    """
-    bridge = request.app.state.prompt_bridge
-    if bridge is None:
-        raise AppError(
-            ErrorCategory.INTERNAL_ERROR,
-            "PROMPT_BRIDGE_NOT_CONFIGURED",
-            "Langfuse prompt bridge is not configured. Set langfuse_host in settings.",
-        )
-
-    template_id = _from_langfuse_name(name)
-    rendered = await bridge.preview(
-        template_id,
-        variables=body.variables,
-        label=body.label,
-    )
-
-    await _audit(
-        request,
-        admin,
-        action="prompt_preview",
-        target_type="prompt",
-        target_id=name,
-        reason=f"label={body.label}",
-    )
-
-    log.info(
-        "admin_prompt_previewed",
-        prompt_name=name,
-        label=body.label,
-        version=rendered.metadata.get("langfuse_prompt_version"),
-        admin=admin.admin_id,
-    )
-    return JSONResponse(
-        content={
-            "prompt": name,
-            "label": body.label,
-            "version": rendered.metadata.get("langfuse_prompt_version"),
-            "rendered_body": rendered.text,
-            "metadata": {
-                "template_id": rendered.template_id,
-                "fragment_versions": rendered.fragment_versions,
-                "prompt_hash": rendered.prompt_hash,
-            },
-        },
-    )
+# Import sub-routers for re-export
+from tta.api.routes.admin_prompts import router as prompts_router  # noqa: E402, F401

--- a/src/tta/api/routes/admin_prompts.py
+++ b/src/tta/api/routes/admin_prompts.py
@@ -1,0 +1,142 @@
+"""Admin prompt management routes (§3.8 / FB-005 / AC-09.02).
+
+Extracted from admin.py to keep concerns separated.
+"""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+
+from tta.admin.auth import AdminIdentity, require_admin
+from tta.api.errors import AppError
+from tta.errors import ErrorCategory
+from tta.models.admin import ActivatePromptRequest, PreviewPromptRequest
+from tta.prompts.langfuse_bridge import _from_langfuse_name
+
+router = APIRouter(tags=["admin"])
+log = structlog.get_logger(__name__)
+
+
+async def _audit(
+    request: Request,
+    admin: AdminIdentity,
+    *,
+    action: str,
+    target_type: str,
+    target_id: str,
+    reason: str = "",
+) -> None:
+    """Create an immutable audit-log entry for admin actions (FR-26.24)."""
+    audit_repo = request.app.state.audit_repo
+    if audit_repo is not None:
+        await audit_repo.create_and_append(
+            admin_id=admin.admin_id,
+            action=action,
+            target_type=target_type,
+            target_id=target_id,
+            reason=reason,
+        )
+
+
+@router.post("/prompts/{name}/activate")
+async def activate_prompt(
+    name: str,
+    body: ActivatePromptRequest,
+    request: Request,
+    admin: AdminIdentity = Depends(require_admin),
+) -> JSONResponse:
+    """Activate a prompt version by changing its Langfuse label (AC-09.02).
+
+    This is the runtime equivalent of "deploy this version to production."
+    The next turn that uses this prompt will fetch the newly-labelled version.
+    """
+    bridge = request.app.state.prompt_bridge
+    if bridge is None:
+        raise AppError(
+            ErrorCategory.INTERNAL_ERROR,
+            "PROMPT_BRIDGE_NOT_CONFIGURED",
+            "Langfuse prompt bridge is not configured. Set langfuse_host in settings.",
+        )
+
+    template_id = _from_langfuse_name(name)
+    await bridge.activate(template_id, label=body.label)
+
+    await _audit(
+        request,
+        admin,
+        action="prompt_activate",
+        target_type="prompt",
+        target_id=name,
+        reason=f"label={body.label}",
+    )
+
+    log.info(
+        "admin_prompt_activated",
+        prompt_name=name,
+        label=body.label,
+        admin=admin.admin_id,
+    )
+    return JSONResponse(
+        content={"status": "activated", "prompt": name, "label": body.label},
+    )
+
+
+@router.post("/prompts/{name}/preview")
+async def preview_prompt(
+    name: str,
+    body: PreviewPromptRequest,
+    request: Request,
+    admin: AdminIdentity = Depends(require_admin),
+) -> JSONResponse:
+    """Preview a prompt against variables in shadow mode (AC-09.09).
+
+    Renders the specified prompt version against the provided variables
+    and returns the rendered output.  This does NOT modify game state,
+    consume turn credits, or affect observability dashboards.
+    """
+    bridge = request.app.state.prompt_bridge
+    if bridge is None:
+        raise AppError(
+            ErrorCategory.INTERNAL_ERROR,
+            "PROMPT_BRIDGE_NOT_CONFIGURED",
+            "Langfuse prompt bridge is not configured. Set langfuse_host in settings.",
+        )
+
+    template_id = _from_langfuse_name(name)
+    rendered = await bridge.preview(
+        template_id,
+        variables=body.variables,
+        label=body.label,
+    )
+
+    await _audit(
+        request,
+        admin,
+        action="prompt_preview",
+        target_type="prompt",
+        target_id=name,
+        reason=f"label={body.label}",
+    )
+
+    log.info(
+        "admin_prompt_previewed",
+        prompt_name=name,
+        label=body.label,
+        version=rendered.metadata.get("langfuse_prompt_version"),
+        admin=admin.admin_id,
+    )
+    return JSONResponse(
+        content={
+            "prompt": name,
+            "label": body.label,
+            "version": rendered.metadata.get("langfuse_prompt_version"),
+            "rendered_body": rendered.text,
+            "metadata": {
+                "template_id": rendered.template_id,
+                "fragment_versions": rendered.fragment_versions,
+                "prompt_hash": rendered.prompt_hash,
+            },
+        },
+    )

--- a/src/tta/llm/smart_router_client.py
+++ b/src/tta/llm/smart_router_client.py
@@ -7,7 +7,7 @@ on first use when it is not already running.
 Environment variables
 ---------------------
 FREE_MODEL_ROUTER_URL
-    Base URL of the running server (default: http://localhost:3000).
+    Base URL of the running server (default: http://localhost:3456).
 FREE_MODEL_ROUTER_BIN
     Path to the built Node.js server entry-point
     (default: ~/Repos/free-model-router/dist/src/server.js).
@@ -34,7 +34,7 @@ from tta.models.turn import TokenCount
 
 log = structlog.get_logger(__name__)
 
-_ROUTER_BASE_URL = os.getenv("FREE_MODEL_ROUTER_URL", "http://localhost:3000")
+_ROUTER_BASE_URL = os.getenv("FREE_MODEL_ROUTER_URL", "http://localhost:3456")
 _ROUTER_BIN = Path(
     os.getenv(
         "FREE_MODEL_ROUTER_BIN",

--- a/src/tta/playtest/agent.py
+++ b/src/tta/playtest/agent.py
@@ -304,6 +304,7 @@ class PlaytesterAgent:
         turn_number = resp.json()["data"]["turn_number"]
 
         import time
+
         started = time.monotonic()
         while True:
             turns_resp = await client.get(f"/api/v1/games/{self._game_id}/turns")

--- a/src/tta/playtest/agent.py
+++ b/src/tta/playtest/agent.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 PLAYTEST_TURN_TIMEOUT: float = float(os.environ.get("PLAYTEST_TURN_TIMEOUT", "180"))
 PLAYTEST_MIN_TURNS: int = int(os.environ.get("PLAYTEST_MIN_TURNS", "5"))
 POLL_INTERVAL: float = 1.0
+POLL_MAX_SECONDS: float = float(os.environ.get("PLAYTEST_POLL_MAX_SECONDS", "240"))
 MAX_CONSECUTIVE_TIMEOUTS: int = 3
 _TURN_PHASE = "gameplay"
 
@@ -302,12 +303,20 @@ class PlaytesterAgent:
         resp.raise_for_status()
         turn_number = resp.json()["data"]["turn_number"]
 
+        import time
+        started = time.monotonic()
         while True:
             turns_resp = await client.get(f"/api/v1/games/{self._game_id}/turns")
             turns_resp.raise_for_status()
             for turn in turns_resp.json().get("data", []):
                 if turn["turn_number"] == turn_number and turn.get("narrative_output"):
                     return str(turn["narrative_output"])
+            if time.monotonic() - started > POLL_MAX_SECONDS:
+                msg = (
+                    f"Turn {turn_number} narrative_output "
+                    f"not ready after {POLL_MAX_SECONDS}s"
+                )
+                raise TimeoutError(msg)
             await asyncio.sleep(POLL_INTERVAL)
 
     async def _generate_commentary(

--- a/tests/simulation/batch_smoke.py
+++ b/tests/simulation/batch_smoke.py
@@ -32,9 +32,7 @@ def _flush_print(*args, **kwargs):
 async def setup_player(handle_suffix: str = "") -> str:
     """Create an anonymous player and accept consent. Returns auth token."""
     handle = f"batch-smoke{handle_suffix}"
-    async with httpx.AsyncClient(
-        base_url=TTA_URL, timeout=httpx.Timeout(TIMEOUT)
-    ) as c:
+    async with httpx.AsyncClient(base_url=TTA_URL, timeout=httpx.Timeout(TIMEOUT)) as c:
         r = await c.post(
             "/api/v1/auth/anonymous",
             json={
@@ -95,8 +93,7 @@ async def run_one_combination(
         c = result.complete_runs
         e = result.error_runs
         _flush_print(
-            f"{label} Done: {c} complete, {e} errors, "
-            f"verdict={result.batch_verdict}"
+            f"{label} Done: {c} complete, {e} errors, verdict={result.batch_verdict}"
         )
         return 0 if c > 0 and e == 0 else 1
     except Exception as exc:
@@ -113,8 +110,7 @@ async def main() -> int:
     total = len(seeds) * len(personas)
 
     _flush_print(
-        f"Batch smoke: {total} runs "
-        f"({len(seeds)} seeds x {len(personas)} personas)"
+        f"Batch smoke: {total} runs ({len(seeds)} seeds x {len(personas)} personas)"
     )
     _flush_print(f"TTA_URL={TTA_URL}")
 

--- a/tests/simulation/batch_smoke.py
+++ b/tests/simulation/batch_smoke.py
@@ -1,7 +1,10 @@
-"""Batch smoke: 2 personas x 2 seeds = 4 runs."""
+"""Batch smoke: 2 personas x 2 seeds = 4 runs.
+
+Each run: create player → run pipeline → print progress → next.
+Runs sequentially with per-run progress to avoid silent hangs.
+"""
 
 import asyncio
-import json
 import os
 import sys
 from pathlib import Path
@@ -20,15 +23,28 @@ TTA_URL = os.getenv("TTA_URL", "http://localhost:8000")
 TIMEOUT = float(os.getenv("TTA_SMOKE_HTTP_TIMEOUT", "30"))
 
 
-async def setup_player():
-    async with httpx.AsyncClient(base_url=TTA_URL, timeout=httpx.Timeout(TIMEOUT)) as c:
+def _flush_print(*args, **kwargs):
+    """Print and immediately flush to avoid buffering in background processes."""
+    print(*args, **kwargs)
+    sys.stdout.flush()
+
+
+async def setup_player(handle_suffix: str = "") -> str:
+    """Create an anonymous player and accept consent. Returns auth token."""
+    handle = f"batch-smoke{handle_suffix}"
+    async with httpx.AsyncClient(
+        base_url=TTA_URL, timeout=httpx.Timeout(TIMEOUT)
+    ) as c:
         r = await c.post(
             "/api/v1/auth/anonymous",
             json={
-                "handle": "batch-runner",
+                "handle": handle,
                 "age_13_plus_confirmed": True,
                 "consent_version": "1.0",
-                "consent_categories": {"core_gameplay": True, "llm_processing": True},
+                "consent_categories": {
+                    "core_gameplay": True,
+                    "llm_processing": True,
+                },
             },
         )
         r.raise_for_status()
@@ -39,56 +55,84 @@ async def setup_player():
             headers=h,
             json={
                 "consent_version": "1.0",
-                "consent_categories": {"core_gameplay": True, "llm_processing": True},
+                "consent_categories": {
+                    "core_gameplay": True,
+                    "llm_processing": True,
+                },
                 "age_13_plus_confirmed": True,
             },
         )
         return token
 
 
-async def main():
+async def run_one_combination(
+    llm: SmartRouterLLMClient,
+    seed_id: str,
+    persona_id: str,
+    run_num: int,
+    total: int,
+) -> int:
+    """Run a single seed × persona combination with progress output."""
+    label = f"[{run_num}/{total}]"
+    _flush_print(f"{label} Starting: seed={seed_id}, persona={persona_id}")
+
+    token = await setup_player(handle_suffix=f"-{run_num}")
+    config = BatchConfig(
+        scenario_seed_ids=[seed_id],
+        persona_ids=[persona_id],
+        runs_per_combination=1,
+        max_parallel_runs=1,
+        mode="local",
+    )
+    pipeline = EvaluationPipeline(
+        config=config,
+        api_base_url=TTA_URL,
+        api_key=token,
+        llm_client=llm,
+    )
+    try:
+        result, _exit_code = await pipeline.run()
+        c = result.complete_runs
+        e = result.error_runs
+        _flush_print(
+            f"{label} Done: {c} complete, {e} errors, "
+            f"verdict={result.batch_verdict}"
+        )
+        return 0 if c > 0 and e == 0 else 1
+    except Exception as exc:
+        _flush_print(f"{label} FAILED: {type(exc).__name__}: {exc}")
+        return 1
+
+
+async def main() -> int:
     settings = get_settings()
     init_langfuse(settings)
-    llm = None
+
+    seeds = ["bus-stop-shimmer", "seed-fantasy-tavern"]
+    personas = ["curious-explorer", "terse-minimalist"]
+    total = len(seeds) * len(personas)
+
+    _flush_print(
+        f"Batch smoke: {total} runs "
+        f"({len(seeds)} seeds x {len(personas)} personas)"
+    )
+    _flush_print(f"TTA_URL={TTA_URL}")
+
+    llm = SmartRouterLLMClient()
     try:
-        token = await setup_player()
-        print(f"Player ready. Token: {token[:30]}...")
+        run_num = 0
+        failures = 0
+        for seed_id in seeds:
+            for persona_id in personas:
+                run_num += 1
+                failures += await run_one_combination(
+                    llm, seed_id, persona_id, run_num, total
+                )
 
-        config = BatchConfig(
-            scenario_seed_ids=["bus-stop-shimmer", "seed-fantasy-tavern"],
-            persona_ids=["curious-explorer", "terse-minimalist"],
-            runs_per_combination=1,
-            max_parallel_runs=1,
-            mode="local",
-        )
-        llm = SmartRouterLLMClient()
-        pipeline = EvaluationPipeline(
-            config=config, api_base_url=TTA_URL, api_key=token, llm_client=llm
-        )
-        n_seeds = len(config.scenario_seed_ids)
-        n_personas = len(config.persona_ids)
-        total = n_seeds * n_personas
-        print(f"\nBatch: {total} runs ({n_seeds} seeds x {n_personas} personas)\n")
-
-        result, exit_code = await pipeline.run()
-
-        print("\n=== Results ===")
-        c = result.complete_runs
-        t = result.total_runs
-        e = result.error_runs
-        print(f"Complete: {c}/{t}  Errors: {e}")
-        print(f"Verdict: {result.batch_verdict}")
-        if result.batch_category_medians:
-            print(f"Medians: {json.dumps(result.batch_category_medians, indent=2)}")
-        for i, r in enumerate(result.quality_reports[:4]):
-            print(f"\n  Run {i + 1}: composite={r.composite_score:.3f} ({r.verdict})")
-            for c in r.categories:
-                if c.status == "scored":
-                    print(f"    {c.category_id}: {c.score:.3f}")
-        return exit_code
+        _flush_print(f"\n=== Done: {run_num - failures}/{run_num} passed ===")
+        return 0 if failures == 0 else 1
     finally:
-        if llm:
-            await llm.aclose()
+        await llm.aclose()
         shutdown_langfuse()
 
 

--- a/tests/unit/api/test_admin_prompts.py
+++ b/tests/unit/api/test_admin_prompts.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from tta.admin.auth import require_admin
-from tta.api.routes.admin import router as admin_router
+from tta.api.routes.admin_prompts import router as admin_router
 
 # ── fixtures ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

Four fixes from the v2.1 stabilization pass.

### 1. Smoke test hang fix
_submit_and_poll() in PlaytesterAgent had infinite polling loop. Now raises TimeoutError after POLL_MAX_SECONDS (240s, env-configurable).

### 2. Smoke test progress output
batch_smoke.py rewritten with per-run progress printing + sys.stdout.flush().

### 3. FMR default URL fix
SmartRouterLLMClient defaulted to localhost:3000 but FMR runs on :3456.

### 4. Admin prompts extraction
Extracted activate_prompt and preview_prompt from admin.py (1196->1084 lines) into admin_prompts.py module.

## Tests
test_admin_prompts.py: 6/6 passed
test_admin.py: 49/49 passed