### PR TITLE
feat: harden pipeline extraction, LLM routing, and genesis degradation

### DIFF
--- a/plans/generation-serving-profiles.md
+++ b/plans/generation-serving-profiles.md
@@ -1,0 +1,614 @@
+# Generation Serving Profiles — Component Technical Plan
+
+> **Phase**: SDD Phase 2 — Component Plan
+> **Scope**: generation-serving-profile policy, LLM routing integration, evaluation/profile comparison, session preference plumbing
+> **Input specs**: S64 (Generation Serving Profiles), S07 (LLM Integration), S45 (Evaluation Pipeline), S50 (Rate-Limit Budget & Task Prioritization)
+> **Parent plans**: `plans/system.md`, `plans/llm-and-pipeline.md`, `plans/v2_1-evaluation-and-playtesting.md`
+> **Implementation wave**: v2.2
+> **Status**: 📝 Draft
+> **Last Updated**: 2026-05-25
+
+---
+
+## 0. Why This Plan Exists
+
+The current system has a real behavioral gap:
+- generation role means different things in different clients
+- batch playtesting can accidentally use interactive-serving assumptions
+- latency/quality tradeoffs are not first-class or measurable
+
+S64 defines the product contract. This plan defines the implementation that
+makes the contract real without leaking provider/model internals into the API or
+future UI.
+
+This is not just a router tweak. It is a cross-cutting policy layer spanning:
+- LLM client configuration
+- request/session metadata
+- playtester and evaluation orchestration
+- observability
+- FMR tenant/profile routing
+
+---
+
+## 1. Resolved Conflicts and Normative Decisions
+
+### 1.1 Canonical profiles are policy objects, not raw config flags
+
+`fast`, `balanced`, and `quality` are represented as a typed internal enum plus
+structured policy objects. Code must not scatter ad hoc string checks like:
+- `if quality:`
+- `task = "creative"`
+- `timeout = 90`
+
+All generation routing decisions must resolve through the same profile-policy
+lookup.
+
+### 1.2 Profile applies to narrative generation only in v2.2
+
+In v2.2, serving profile only affects generation-stage calls. Classification,
+extraction, summarization, and other correctness-sensitive stages continue using
+their existing role semantics.
+
+### 1.3 Separate traffic class from serving profile
+
+We need two independent dimensions:
+- **serving profile**: `fast`, `balanced`, `quality`
+- **traffic class**: `interactive_player`, `interactive_smoke`, `bulk_eval`, `quality_benchmark`
+
+This prevents the previous mistake where playtesting semantics were inferred from
+one overloaded task hint.
+
+### 1.4 FMR integration must use explicit metadata
+
+The LiteLLM/FMR boundary must receive explicit metadata for generation calls:
+- serving profile
+- traffic class
+- router task
+
+Do not rely on router-side guessing from prompt text or on client-specific enum
+names.
+
+### 1.5 Balanced is the system default everywhere
+
+If no profile is supplied, `balanced` is the default for:
+- gameplay sessions
+- playtester agents
+- evaluation runs
+
+Callers must opt into `fast` or `quality` explicitly.
+
+---
+
+## 2. Architecture Overview
+
+### 2.1 New concepts
+
+Add these shared types in `src/tta/llm/`:
+
+```python
+class GenerationServingProfile(str, Enum):
+    FAST = "fast"
+    BALANCED = "balanced"
+    QUALITY = "quality"
+
+
+class GenerationTrafficClass(str, Enum):
+    INTERACTIVE_PLAYER = "interactive_player"
+    INTERACTIVE_SMOKE = "interactive_smoke"
+    BULK_EVAL = "bulk_eval"
+    QUALITY_BENCHMARK = "quality_benchmark"
+
+
+class GenerationPolicy(BaseModel):
+    profile: GenerationServingProfile
+    router_task: str
+    latency_class: str
+    dispatch_preference: str
+    timeout_seconds: float
+    max_tokens: int
+    degradation_chain: list[GenerationServingProfile]
+```
+```
+
+These are implementation types, not API models yet.
+
+### 2.2 Central policy resolver
+
+Create a new module:
+
+```text
+src/tta/llm/serving_profiles.py
+```
+
+Responsibilities:
+- canonical enums
+- default profile lookup
+- policy lookup by `(profile, traffic_class)`
+- degradation rules
+- serialization helpers for logs/metrics
+
+Nothing else in the repo should hardcode generation routing policy.
+
+### 2.3 LLM call path integration
+
+Current generation call path:
+- caller specifies `ModelRole.GENERATION`
+- `LiteLLMClient` maps role -> router task
+- requests are sent to router-backed models
+
+New path:
+- caller optionally specifies generation profile + traffic class
+- `LiteLLMClient` resolves a `GenerationPolicy`
+- generation request includes explicit routing metadata
+- fallback/degradation happens through policy-aware logic
+
+---
+
+## 3. File-Level Changes
+
+### 3.1 New files
+
+Create:
+
+- `specs/64-generation-serving-profiles.md`
+- `plans/generation-serving-profiles.md`
+- `src/tta/llm/serving_profiles.py`
+- `tests/unit/llm/test_serving_profiles.py`
+- `tests/unit/llm/test_litellm_serving_profiles.py`
+- `tests/unit/eval/test_profile_matrix_planning.py`
+
+### 3.2 Existing files to modify
+
+#### LLM layer
+- `src/tta/llm/client.py`
+  - extend generation call interface to accept optional profile metadata
+- `src/tta/llm/litellm_client.py`
+  - replace hardcoded generation->creative mapping with policy resolution
+- `src/tta/llm/roles.py`
+  - keep role model mapping, but stop using it as the sole generation-policy layer
+- `src/tta/llm/testing.py`
+  - support profile-aware test doubles
+
+#### Gameplay / API
+- `src/tta/api/routes/games.py`
+  - accept optional generation profile at session creation if exposed in v2.2
+- `src/tta/models/game.py`
+  - store canonical generation profile on session/game model if persisted in v2.2
+- `src/tta/api/routes/games_lifecycle.py`
+  - ensure restore/resume preserves stored profile
+
+#### Pipeline / generation callers
+- `src/tta/pipeline/stages/generate.py`
+- `src/tta/genesis/genesis_lite.py`
+- `src/tta/genesis/genesis_v2.py`
+- `src/tta/quality/evaluator.py`
+- `src/tta/playtest/agent.py`
+
+These callers must explicitly pass traffic class, and generation profile where
+relevant.
+
+#### Eval layer
+- `src/tta/eval/models.py`
+  - extend batch config with serving-profile matrix support
+- `src/tta/eval/pipeline.py`
+  - plan and report by profile
+
+#### Observability
+- `src/tta/observability/langfuse.py`
+- metric helpers / logging call sites in LLM path
+
+Add labels/fields:
+- requested_profile
+- effective_profile
+- degraded
+- degradation_reason
+- traffic_class
+
+---
+
+## 4. Data Model and API Contract
+
+### 4.1 Internal client contract
+
+Extend the generation interface in `src/tta/llm/client.py`.
+
+Current shape is roughly:
+
+```python
+async def generate(role, messages, params=None) -> LLMResponse
+```
+
+Proposed shape:
+
+```python
+async def generate(
+    role: ModelRole,
+    messages: list[Message],
+    params: GenerationParams | None = None,
+    *,
+    generation_profile: GenerationServingProfile | None = None,
+    traffic_class: GenerationTrafficClass | None = None,
+) -> LLMResponse
+```
+
+Rules:
+- extra kwargs are only meaningful for `ModelRole.GENERATION`
+- non-generation roles ignore them or reject them explicitly
+- if omitted for generation, defaults are resolved centrally
+
+### 4.2 LLMResponse extension
+
+Extend `LLMResponse` with optional policy metadata:
+
+```python
+requested_profile: str = ""
+effective_profile: str = ""
+traffic_class: str = ""
+degraded: bool = False
+degradation_reason: str = ""
+```
+
+This keeps downstream logging and eval code simple.
+
+### 4.3 Gameplay API surface
+
+For v2.2, the safest public API step is session-level support on create/resume,
+not per-turn slider churn.
+
+Recommended request field on game/session creation:
+
+```json
+{
+  "generation_profile": "balanced"
+}
+```
+
+Validation:
+- only `fast`, `balanced`, `quality`
+- default omitted -> `balanced`
+
+Persist on the session/game row if the repo’s current schema makes that easy.
+If persistence is too invasive for the first slice, store it in session state
+with an explicit follow-up task — but do not bury it in transient request-only
+logic if you want resume to stay honest.
+
+---
+
+## 5. Policy Resolution Design
+
+### 5.1 Canonical policy table
+
+Initial v2.2 policy table:
+
+| Profile | Traffic Class | router_task | latency_class | dispatch_preference | timeout | max_tokens |
+|---|---|---|---|---|---:|---:|
+| fast | interactive_player | generation | interactive | sync | 20s | 512 |
+| balanced | interactive_player | generation | interactive | sync | 35s | 768 |
+| quality | interactive_player | creative | relaxed | sync_or_compare | 60s | 1024 |
+| fast | bulk_eval | generation | batch | queue_tolerant | 30s | 512 |
+| balanced | bulk_eval | generation | batch | queue_tolerant | 45s | 768 |
+| quality | quality_benchmark | creative | benchmark | queue_tolerant_or_compare | 90s | 1024 |
+
+These values are starting points, not eternal truths. They should live in one
+resolver module and be easy to retune.
+
+### 5.2 Degradation algorithm
+
+Pseudo-logic:
+
+```python
+def degradation_chain(profile):
+    if profile == QUALITY:
+        return [QUALITY, BALANCED, FAST]
+    if profile == BALANCED:
+        return [BALANCED, FAST]
+    return [FAST]
+```
+
+When generation fails for supply/policy reasons that warrant profile degradation:
+1. try requested profile policy
+2. if exhausted and degradation allowed, try next profile
+3. record requested/effective profile and reason
+4. if all profiles fail, raise the existing LLM failure
+
+Important: this is not a replacement for normal primary/fallback within a single
+profile. The nesting is:
+- profile policy resolution
+- within profile: normal model fallback chain
+- across profiles: explicit degradation only when justified
+
+### 5.3 What counts as degradable
+
+Allow profile degradation on:
+- router/provider exhaustion
+- 503 no providers available
+- explicit policy envelope unavailable
+- queue timeout for a higher profile
+
+Do not degrade on:
+- caller validation errors
+- malformed prompts
+- schema violations in non-generation tasks
+- persistence failures
+
+---
+
+## 6. FMR / Router Integration
+
+### 6.1 Explicit request metadata
+
+At the LiteLLM call boundary, generation requests should include:
+
+```python
+call_kwargs["task"] = policy.router_task
+call_kwargs["generation_profile"] = policy.profile.value
+call_kwargs["traffic_class"] = traffic_class.value
+```
+
+If LiteLLM/OpenAI compatibility rejects unknown fields for the current path,
+fallback to `extra_body={...}` rather than losing metadata.
+
+### 6.2 Tenant strategy
+
+Near-term recommendation: do not create one tenant per profile immediately if a
+profile header/body field is enough.
+
+But do create profile-aware routing/pinned pools in FMR terms, likely using:
+- explicit task hints
+- traffic_class awareness
+- optional alias/tenant split for bulk evaluation lanes
+
+Recommended rollout:
+1. phase 1: metadata only, current tenant intact
+2. phase 2: split bulk-eval / quality-benchmark routing into dedicated FMR lanes
+3. phase 3: optional player-profile-aware pinning if frontier data justifies it
+
+### 6.3 No more implicit generation->creative default
+
+The current hardcoded behavior in `litellm_client.py` is the main bug vector.
+After this change:
+- `creative` should only be chosen by profile policy
+- not by every generation call automatically
+
+---
+
+## 7. Playtester and Evaluation Changes
+
+### 7.1 BatchConfig extension
+
+Extend `BatchConfig` in `src/tta/eval/models.py`:
+
+```python
+serving_profiles: list[GenerationServingProfile] = field(
+    default_factory=lambda: [GenerationServingProfile.BALANCED]
+)
+traffic_class: GenerationTrafficClass = GenerationTrafficClass.BULK_EVAL
+```
+
+This changes planning semantics from:
+- seeds × personas × reps
+
+to:
+- profiles × seeds × personas × reps
+
+### 7.2 PlannedRun extension
+
+Add to `PlannedRun`:
+
+```python
+generation_profile: str
+traffic_class: str
+```
+
+### 7.3 RunResult / BatchEvalResult extension
+
+Add per-run and per-batch profile visibility:
+- profile on `RunResult`
+- grouped medians by profile in `BatchEvalResult`
+- frontier-friendly artifact output
+
+### 7.4 Playtester agent defaults
+
+`PlaytesterAgent` should default to:
+- profile = `balanced`
+- traffic_class = `bulk_eval` when run from eval pipeline
+- traffic_class = `interactive_smoke` when used in smoke validation mode
+
+That distinction must be explicit at construction time, not inferred from URL or
+call stack.
+
+---
+
+## 8. Observability Design
+
+### 8.1 Structured logs
+
+For every generation call completion/failure, log:
+
+```python
+log.info(
+    "llm_generation_call_complete",
+    requested_profile=...,
+    effective_profile=...,
+    degraded=...,
+    degradation_reason=...,
+    traffic_class=...,
+    router_task=...,
+    model=...,
+    latency_ms=...,
+)
+```
+
+### 8.2 Metrics
+
+Add labels or new metrics for:
+- generation_calls_total{requested_profile,effective_profile,traffic_class,status}
+- generation_latency_seconds{effective_profile,traffic_class}
+- generation_degradations_total{from_profile,to_profile,reason}
+
+### 8.3 Langfuse
+
+Attach serving profile metadata to traces/scores so profile-based trend analysis
+is possible in Langfuse without custom joins.
+
+---
+
+## 9. Testing Strategy
+
+### 9.1 Unit tests
+
+#### `tests/unit/llm/test_serving_profiles.py`
+Cover:
+- default profile resolution
+- policy lookup by `(profile, traffic_class)`
+- degradation chain correctness
+- invalid-profile rejection
+
+#### `tests/unit/llm/test_litellm_serving_profiles.py`
+Cover:
+- generation calls inject explicit profile metadata
+- generation does not default to `creative` blindly
+- degradation updates effective profile fields correctly
+- non-generation roles ignore or reject profile extras correctly
+
+#### `tests/unit/eval/test_profile_matrix_planning.py`
+Cover:
+- planning runs across multiple profiles
+- artifact grouping by profile
+- defaulting to balanced when omitted
+
+### 9.2 Integration tests
+
+Add/extend tests for:
+- session create with `generation_profile`
+- resume/restore preserving profile
+- live smoke running under `fast` vs `balanced`
+
+### 9.3 Evaluation validation
+
+Add one smoke-friendly comparison mode:
+- same seed/persona under `fast` and `balanced`
+- verify outputs are emitted with distinct profile labels
+- do not assert one profile is always “better”; assert metrics are recorded
+
+---
+
+## 10. Rollout Phases
+
+### Phase 1 — Tactical isolation + central policy layer
+
+Goal: stop the current routing ambiguity.
+
+Steps:
+1. add serving profile enums and resolver module
+2. patch `LiteLLMClient` to use central policy instead of hardcoded creative mapping
+3. make bulk playtester/eval traffic explicit with `balanced + bulk_eval`
+4. add observability fields
+
+Outcome:
+- current bug class is eliminated
+- no UI required yet
+
+### Phase 2 — Profile-aware evaluation frontier
+
+Goal: learn the latency/quality frontier.
+
+Steps:
+1. extend BatchConfig to support profile matrices
+2. emit profile-aware artifacts
+3. run repeated seed/persona comparisons
+4. establish provisional latency targets and preferred defaults
+
+Outcome:
+- empirical frontier data for future product/UI work
+
+### Phase 3 — Session/player preference plumbing
+
+Goal: make profile selectable in actual sessions.
+
+Steps:
+1. add API/session field
+2. persist and restore profile
+3. expose profile in admin/debug views
+
+Outcome:
+- real player/session policy support
+
+### Phase 4 — UI slider / labels
+
+Goal: expose the feature in a player-facing way.
+
+Steps:
+1. map user-facing labels to canonical profiles
+2. instrument usage and preference
+3. tune labels from research
+
+Outcome:
+- productized control backed by measured data
+
+---
+
+## 11. Risks and Mitigations
+
+| Risk | Why it matters | Mitigation |
+|---|---|---|
+| Profile semantics drift over time | Slider becomes meaningless | Centralize policy + track requested/effective profile in artifacts |
+| Too many profile-specific code paths | Logic becomes unmaintainable | Keep profile handling in one resolver module |
+| Bulk eval still competes with interactive traffic | Old problem survives under new names | Make traffic_class explicit and route-aware |
+| Numeric latency targets are unrealistic | Product promise breaks | Learn targets from Phase 2 eval frontier data |
+| Persistence work is bigger than expected | Delays useful fix | Ship Phase 1 without player-persisted preference if needed |
+
+---
+
+## 12. Recommended Immediate Implementation Sequence
+
+1. Create `src/tta/llm/serving_profiles.py`
+2. Extend `LLMClient` interface for optional profile metadata
+3. Patch `LiteLLMClient` to resolve generation policy centrally
+4. Remove hardcoded generation -> creative behavior
+5. Mark playtester/eval traffic as `balanced + bulk_eval`
+6. Add observability fields to generation calls
+7. Extend eval models for multi-profile planning
+8. Add tests
+
+That gets the architecture onto the right rails before any player-facing UI or
+bigger API changes.
+
+---
+
+## 13. Verification Checklist
+
+Before considering S64 implementation complete:
+
+- [ ] No generation caller relies on ad hoc `creative` defaults
+- [ ] Generation serving profile is centrally resolved
+- [ ] Bulk evaluation traffic carries explicit profile + traffic class metadata
+- [ ] Requested/effective profile is visible in logs/traces
+- [ ] Eval artifacts can compare multiple profiles on the same matrix
+- [ ] Session/profile defaults are explicit and tested
+- [ ] Resume/restore behavior is defined for persisted profile state
+
+---
+
+## 14. Open Implementation Decisions
+
+1. Should unknown OpenAI-compatible request fields go into top-level body or
+   `extra_body` for LiteLLM/FMR compatibility?
+2. Is session-level persistence for `generation_profile` cheap enough for Phase 1,
+   or should it wait for Phase 3?
+3. Do we need a distinct FMR tenant for `bulk_eval` immediately, or is metadata
+   enough until Phase 2 data arrives?
+4. Should `quality` ever use comparison dispatch for live gameplay, or only for
+   explicit benchmark traffic?
+
+---
+
+## 15. Notes for the Current Hotfix Context
+
+This plan intentionally preserves the immediate tactical direction:
+- do not fix the current playtesting issue by prompt trimming
+- do not treat all generation as `creative`
+- do separate batch evaluation semantics from interactive player semantics
+
+The first code change should therefore be the central policy resolver and the
+removal of the current hardcoded generation->creative mapping.

--- a/scripts/run_tta_experiment.py
+++ b/scripts/run_tta_experiment.py
@@ -18,7 +18,11 @@ Usage:
 
 from __future__ import annotations
 
-import argparse, json, os, sys, time
+import argparse
+import json
+import os
+import sys
+import time
 from typing import Any
 
 os.environ.setdefault("OTEL_TRACES_EXPORTER", "none")
@@ -35,8 +39,14 @@ TTA_URL = os.environ.get("TTA_URL", "http://localhost:8010")
 
 def tta_task(*, item: Any, **kwargs: Any) -> str:
     """Send a player input to TTA and return the narrative response."""
-    player_input = item.input.get("player_input", "") if isinstance(item.input, dict) else str(item.input)
-    dimension = item.metadata.get("dimension", "unknown") if item.metadata else "unknown"
+    player_input = (
+        item.input.get("player_input", "")
+        if isinstance(item.input, dict)
+        else str(item.input)
+    )
+    dimension = (
+        item.metadata.get("dimension", "unknown") if item.metadata else "unknown"
+    )
 
     try:
         start = time.monotonic()
@@ -92,7 +102,6 @@ def narrative_coherence(*, output: str, **kwargs: Any) -> float:
     """Check for basic coherence markers in narrative text."""
     if not output or output.startswith("ERROR"):
         return 0.0
-    output_lower = output.lower()
     # Coherence heuristics: has sentences, no excessive repetition, logical connectors
     sentences = [s.strip() for s in output.replace("\n", ". ").split(".") if s.strip()]
     if len(sentences) < 1:
@@ -100,12 +109,18 @@ def narrative_coherence(*, output: str, **kwargs: Any) -> float:
     if len(sentences) < 2:
         return 0.4
     # Check for variety
-    unique_sentences = len(set(s[:30] for s in sentences))
+    unique_sentences = len({s[:30] for s in sentences})
     variety = min(1.0, unique_sentences / len(sentences))
     return 0.5 + variety * 0.5
 
 
-def dimension_match(*, output: str, metadata: dict | None = None, expected_output: Any = None, **kwargs: Any) -> float:
+def dimension_match(
+    *,
+    output: str,
+    metadata: dict | None = None,
+    expected_output: Any = None,
+    **kwargs: Any,
+) -> float:
     """Check if output addresses the evaluation dimension."""
     if not output or not metadata:
         return 0.0
@@ -122,14 +137,27 @@ def dimension_match(*, output: str, metadata: dict | None = None, expected_outpu
         return 1.0 if len(output) > 20 and "error" not in output.lower() else 0.3
 
     if dimension == "persona_curious":
-        return 0.8 if any(w in output.lower() for w in ["examine", "curious", "study", "observe", "careful"]) else 0.4
+        curious_words = ["examine", "curious", "study", "observe", "careful"]
+        return 0.8 if any(w in output.lower() for w in curious_words) else 0.4
 
     if dimension == "persona_warrior":
-        return 0.8 if any(w in output.lower() for w in ["attack", "strike", "charge", "slash", "blade", "axe", "weapon"]) else 0.4
+        warrior_words = [
+            "attack",
+            "strike",
+            "charge",
+            "slash",
+            "blade",
+            "axe",
+            "weapon",
+        ]
+        return 0.8 if any(w in output.lower() for w in warrior_words) else 0.4
 
     if dimension == "choice_quality":
         # Choice quality: response should present options
-        return 0.8 if "?" in output or "choice" in output.lower() or "decide" in output.lower() else 0.4
+        has_choice_markers = (
+            "?" in output or "choice" in output.lower() or "decide" in output.lower()
+        )
+        return 0.8 if has_choice_markers else 0.4
 
     # Default: check criteria keywords
     keywords = criteria.lower().split(",") if criteria else []
@@ -202,7 +230,12 @@ def run(args: argparse.Namespace) -> None:
         name=args.name or "tta-narrative-baseline",
         description="Baseline TTA narrative quality evaluation",
         task=tta_task,
-        evaluators=[narrative_length, narrative_coherence, dimension_match, latency_quality],
+        evaluators=[
+            narrative_length,
+            narrative_coherence,
+            dimension_match,
+            latency_quality,
+        ],
         run_evaluators=[composite_score],
         max_concurrency=1,
         include_item_results=True,

--- a/scripts/run_tta_experiment.py
+++ b/scripts/run_tta_experiment.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""TTA Narrative Quality Experiment Runner.
+
+Runs Langfuse dataset experiments against the TTA API for narrative
+quality evaluation. Tests narrative coherence, world consistency,
+choice quality, engagement, persona fidelity, and error handling.
+
+Pattern from the article: dataset.run_experiment(task=fn, evaluators=[...])
+
+Usage:
+  LANGFUSE_PUBLIC_KEY=pk-lf-... LANGFUSE_SECRET_KEY=sk-lf-... \\
+  TTA_URL=http://localhost:8010 \\
+  python3 scripts/run_tta_experiment.py
+
+  # Dry run (no Langfuse, no TTA — just print what would happen):
+  python3 scripts/run_tta_experiment.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse, json, os, sys, time
+from typing import Any
+
+os.environ.setdefault("OTEL_TRACES_EXPORTER", "none")
+
+import httpx
+from langfuse import Langfuse
+
+DATASET_NAME = "tta-narrative-quality"
+TTA_URL = os.environ.get("TTA_URL", "http://localhost:8010")
+
+
+# ── Task function ─────────────────────────────────────────────────────────
+
+
+def tta_task(*, item: Any, **kwargs: Any) -> str:
+    """Send a player input to TTA and return the narrative response."""
+    player_input = item.input.get("player_input", "") if isinstance(item.input, dict) else str(item.input)
+    dimension = item.metadata.get("dimension", "unknown") if item.metadata else "unknown"
+
+    try:
+        start = time.monotonic()
+        resp = httpx.post(
+            f"{TTA_URL}/api/v1/turns",
+            json={"player_input": player_input},
+            timeout=60.0,
+        )
+        elapsed = (time.monotonic() - start) * 1000
+
+        if resp.status_code != 200:
+            kwargs["metadata"] = {
+                "error": f"HTTP {resp.status_code}",
+                "dimension": dimension,
+                "latency_ms": round(elapsed, 1),
+            }
+            return f"ERROR: HTTP {resp.status_code}"
+
+        data = resp.json()
+        narrative = data.get("narrative", "") or data.get("content", "")
+        kwargs["metadata"] = {
+            "dimension": dimension,
+            "latency_ms": round(elapsed, 1),
+            "turn_id": data.get("turn_id", ""),
+            "model_used": data.get("model", ""),
+            "tokens": data.get("token_count", {}),
+        }
+        return narrative
+
+    except Exception as exc:
+        kwargs["metadata"] = {"error": str(exc)[:200], "dimension": dimension}
+        return f"ERROR: {exc}"
+
+
+# ── Evaluators ────────────────────────────────────────────────────────────
+
+
+def narrative_length(*, output: str, **kwargs: Any) -> float:
+    """Narrative should be substantive (100-2000 chars)."""
+    if not output or output.startswith("ERROR"):
+        return 0.0
+    length = len(output)
+    if 100 <= length <= 2000:
+        return 1.0
+    if length < 50:
+        return 0.2
+    if length < 100:
+        return 0.5 + (length - 50) / 100
+    return max(0.3, 1.0 - (length - 2000) / 3000)
+
+
+def narrative_coherence(*, output: str, **kwargs: Any) -> float:
+    """Check for basic coherence markers in narrative text."""
+    if not output or output.startswith("ERROR"):
+        return 0.0
+    output_lower = output.lower()
+    # Coherence heuristics: has sentences, no excessive repetition, logical connectors
+    sentences = [s.strip() for s in output.replace("\n", ". ").split(".") if s.strip()]
+    if len(sentences) < 1:
+        return 0.1
+    if len(sentences) < 2:
+        return 0.4
+    # Check for variety
+    unique_sentences = len(set(s[:30] for s in sentences))
+    variety = min(1.0, unique_sentences / len(sentences))
+    return 0.5 + variety * 0.5
+
+
+def dimension_match(*, output: str, metadata: dict | None = None, expected_output: Any = None, **kwargs: Any) -> float:
+    """Check if output addresses the evaluation dimension."""
+    if not output or not metadata:
+        return 0.0
+    dimension = metadata.get("dimension", "")
+    criteria = (
+        expected_output.get("criteria", "")
+        if isinstance(expected_output, dict)
+        else str(expected_output or "")
+    )
+
+    # Dimension-specific checks
+    if dimension == "error_handling":
+        # Error handling: response should NOT be an error/empty
+        return 1.0 if len(output) > 20 and "error" not in output.lower() else 0.3
+
+    if dimension == "persona_curious":
+        return 0.8 if any(w in output.lower() for w in ["examine", "curious", "study", "observe", "careful"]) else 0.4
+
+    if dimension == "persona_warrior":
+        return 0.8 if any(w in output.lower() for w in ["attack", "strike", "charge", "slash", "blade", "axe", "weapon"]) else 0.4
+
+    if dimension == "choice_quality":
+        # Choice quality: response should present options
+        return 0.8 if "?" in output or "choice" in output.lower() or "decide" in output.lower() else 0.4
+
+    # Default: check criteria keywords
+    keywords = criteria.lower().split(",") if criteria else []
+    if not keywords:
+        return 0.5
+    hits = sum(1 for kw in keywords if kw.strip() in output.lower())
+    return min(1.0, hits / max(len(keywords) * 0.5, 1))
+
+
+def latency_quality(*, metadata: dict | None = None, **kwargs: Any) -> float:
+    """Score latency (faster = better, but not too fast)."""
+    if not metadata or "latency_ms" not in metadata:
+        return 0.0
+    ms = metadata["latency_ms"]
+    if ms < 100:
+        return 0.4  # Suspiciously fast — likely error
+    if ms < 500:
+        return 1.0
+    if ms < 5000:
+        return 1.0 - (ms - 500) / 4500
+    return 0.0
+
+
+def composite_score(*, item_results: list, **kwargs: Any) -> float:
+    """Aggregate evaluator — averages all per-item scores across the run."""
+    if not item_results:
+        return 0.0
+    all_scores: list[float] = []
+    for result in item_results:
+        evals = getattr(result, "evaluations", []) or []
+        for e in evals:
+            val = getattr(e, "value", None)
+            if isinstance(val, (int, float)):
+                all_scores.append(float(val))
+    return round(sum(all_scores) / len(all_scores), 3) if all_scores else 0.0
+
+
+# ── Main ──────────────────────────────────────────────────────────────────
+
+
+def run(args: argparse.Namespace) -> None:
+    if args.dry_run:
+        print("DRY RUN — no Langfuse, no TTA calls\n")
+        _dry_run()
+        return
+
+    pk = os.environ.get("LANGFUSE_PUBLIC_KEY", "")
+    sk = os.environ.get("LANGFUSE_SECRET_KEY", "")
+    if not pk:
+        print("ERROR: LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY required")
+        sys.exit(1)
+
+    client = Langfuse(public_key=pk, secret_key=sk, base_url="http://localhost:3001")
+    dataset = client.get_dataset(DATASET_NAME)
+    items = dataset.items if hasattr(dataset, "items") else []
+    print(f"Dataset: {DATASET_NAME} ({len(items)} items)")
+    if not items:
+        print("No items — seed first: scripts/seed_tta_dataset.py")
+        sys.exit(1)
+
+    # Dimension distribution
+    dims: dict[str, int] = {}
+    for it in items:
+        d = (it.metadata or {}).get("dimension", "unknown")
+        dims[d] = dims.get(d, 0) + 1
+    print(f"Dimensions: {json.dumps(dims)}")
+    print(f"TTA URL: {TTA_URL}")
+
+    result = dataset.run_experiment(
+        name=args.name or "tta-narrative-baseline",
+        description="Baseline TTA narrative quality evaluation",
+        task=tta_task,
+        evaluators=[narrative_length, narrative_coherence, dimension_match, latency_quality],
+        run_evaluators=[composite_score],
+        max_concurrency=1,
+        include_item_results=True,
+    )
+    print(result.format())
+
+
+def _dry_run() -> None:
+    samples = [
+        ("narrative_coherence", "You enter a misty forest clearing. What do you do?"),
+        ("world_consistency", "I draw my sword and charge the shadow."),
+        ("error_handling", "asdfghjkl"),
+    ]
+    for dimension, player_input in samples:
+        print(f"  [{dimension}] {player_input}")
+    print("\n  12 items would be sent to TTA at", TTA_URL)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--name", default="tta-narrative-baseline")
+    args = parser.parse_args()
+    run(args)

--- a/specs/64-generation-serving-profiles.md
+++ b/specs/64-generation-serving-profiles.md
@@ -1,0 +1,519 @@
+# S64 — Generation Serving Profiles
+
+> **Status**: 📝 Draft
+> **Release Baseline**: 🆕 v2.2
+> **Implementation Fit**: ❌ Not Started
+> **Level**: 2 — AI & Content
+> **Dependencies**: S07 (LLM Integration), S10 (API & Streaming), S11 (Player Identity & Sessions), S15 (Observability), S23 (Error Handling & Resilience), S42 (LLM Playtester Agent Harness), S45 (Evaluation Pipeline), S50 (Rate-Limit Budget & Task Prioritization)
+> **Related**: `plans/llm-and-pipeline.md`, `plans/v2_1-evaluation-and-playtesting.md`
+> **Last Updated**: 2026-05-25
+
+---
+
+## 1. Purpose
+
+TTA needs an explicit, user-meaningful way to trade response speed against
+narrative richness. Today that tradeoff is implicit and inconsistent: some
+callers route narrative generation through latency-sensitive paths, others use
+creative-quality paths, and batch evaluation traffic can accidentally compete
+with player-facing sessions.
+
+S64 defines **generation serving profiles** as a product-level contract for that
+tradeoff. A serving profile expresses what kind of generation experience is
+being requested — `fast`, `balanced`, or `quality` — and the system uses that
+profile to choose routing policy, latency budget, fallback behavior, and
+observability.
+
+This spec is deliberately about **policy**, not model IDs. Players and internal
+callers choose a profile; the router and operator configuration choose specific
+models within that profile's envelope.
+
+---
+
+## 2. Design Principles
+
+### 2.1 Correctness Is Not Adjustable
+
+Serving profiles affect narrative-generation policy only. They MUST NOT change
+world-state correctness, persistence semantics, moderation behavior, extraction
+correctness, or save/resume integrity.
+
+### 2.2 Profiles Are Product Promises
+
+`fast`, `balanced`, and `quality` are not internal implementation details. They
+are stable promises about the expected latency/quality tradeoff of narrative
+output. The internal routing stack may change over time, but the behavioral
+meaning of each profile must stay legible.
+
+### 2.3 The Frontier Must Be Measured, Not Assumed
+
+The system MUST support empirical comparison of serving profiles on the same
+seeds, personas, and inputs. Operators should be able to answer: "What latency
+increase bought what quality gain?"
+
+### 2.4 Degradation Must Be Explicit
+
+When the requested profile cannot be satisfied, the system MAY degrade to a
+lower profile according to explicit rules. Silent policy drift is not allowed.
+Requested profile, effective profile, and degradation reason must be recorded.
+
+### 2.5 Interactive and Batch Work Are Different Products
+
+A human or live smoke test validating player experience is not the same thing as
+bulk automated playtesting. The system MUST support profile-aware evaluation so
+that bulk runs do not inherit interactive serving assumptions by accident.
+
+---
+
+## 3. User Stories
+
+### US-64.1 — Player prefers quick responses
+
+As a player, I want a quick-response mode so that the story keeps moving even if
+prose quality is slightly less rich.
+
+### US-64.2 — Player prefers richer narration
+
+As a player, I want a richer-narration mode so that I can accept longer waits
+when I care more about style and depth.
+
+### US-64.3 — Operator compares the tradeoff frontier
+
+As an operator, I want to compare `fast`, `balanced`, and `quality` on the same
+scenarios so that I can make routing decisions using evidence instead of taste.
+
+### US-64.4 — Developer isolates batch evaluation traffic
+
+As a developer, I want bulk automated playtests to use an explicit serving
+profile so that evaluation traffic does not distort player-facing latency paths.
+
+### US-64.5 — Future UI slider has stable semantics
+
+As a product designer, I want the eventual player slider to map to stable serving
+profiles so that the UI does not expose raw model or routing internals.
+
+---
+
+## 4. Canonical Serving Profiles
+
+The system defines three canonical generation serving profiles:
+
+| Profile | Player-facing meaning | Primary promise |
+|---|---|---|
+| `fast` | "Respond quickly" | Lowest latency and highest completion resilience |
+| `balanced` | "Default experience" | Good narrative quality without large latency spikes |
+| `quality` | "Take more time for richer prose" | Higher narrative richness with more tolerance for latency |
+
+These names are normative internal identifiers. User-facing labels MAY differ
+(e.g. "Quick", "Balanced", "Rich"), but must map cleanly to these three
+profiles.
+
+### FR-64.01 — Canonical profile enum
+
+The system SHALL define `fast`, `balanced`, and `quality` as the only canonical
+v2.2 generation serving profiles.
+
+### FR-64.02 — Default profile
+
+If a caller does not specify a generation serving profile, the system SHALL use
+`balanced` as the default.
+
+### FR-64.03 — Future slider compatibility
+
+Any future continuous UI control SHALL map onto these canonical profiles or a
+forward-compatible extension of them. The UI SHALL NOT bind directly to model
+IDs or provider names.
+
+---
+
+## 5. Behavioral Scope and Invariants
+
+### FR-64.04 — Scope of profile influence
+
+Generation serving profiles SHALL govern the policy used for narrative
+generation tasks, including:
+- router task hints for generation calls
+- latency and timeout budgets for generation calls
+- dispatch preference (e.g. sync vs queue-tolerant)
+- fallback/degradation policy for generation calls
+- token/output budgets for generation calls
+- observability labels and evaluation reporting for generation calls
+
+### FR-64.05 — Correctness invariants
+
+Generation serving profiles SHALL NOT alter:
+- game rules or state-transition logic
+- extraction/classification correctness requirements
+- moderation and safety decisions
+- persistence, save, restore, or resume semantics
+- error taxonomy between permanent and transient failures
+
+### FR-64.06 — Non-generation tasks remain explicit
+
+If a non-generation stage is ever allowed to vary by serving profile, that
+behavior MUST be specified explicitly in a future revision. It is not implied by
+v2.2.
+
+---
+
+## 6. Routing and Degradation Contract
+
+### FR-64.07 — Policy envelope, not model selection
+
+Serving profiles SHALL resolve to a **policy envelope** rather than a concrete
+model ID. The policy envelope defines the routing semantics that FMR and the
+LLM client use to select a model.
+
+### FR-64.08 — Profile-specific routing semantics
+
+Each profile SHALL define, at minimum:
+- router task hint for narrative generation
+- latency sensitivity / latency class
+- dispatch preference
+- timeout budget
+- output token budget
+- allowed fallback/degradation targets
+
+The exact values are implementation-defined in the technical plan.
+
+### FR-64.09 — Explicit degradation rules
+
+If a requested profile cannot be satisfied, the system MAY degrade only along
+an explicit path:
+- `quality -> balanced -> fast`
+- `balanced -> fast`
+- `fast` has no lower profile
+
+Any degradation SHALL be recorded in logs and observability fields with:
+- requested profile
+- effective profile
+- degradation reason
+
+### FR-64.10 — No silent premium escalation
+
+A `fast` request SHALL NOT be silently treated as `quality` if doing so would
+materially violate the `fast` latency envelope. Opportunistic model upgrades are
+allowed only if they stay within the requested profile's latency contract.
+
+### FR-64.11 — Graceful failure after profile exhaustion
+
+If the requested profile and all allowed degradation targets are unavailable,
+the system SHALL fail using the existing LLM/resilience contract from S07 and
+S23 rather than fabricating placeholder narrative.
+
+---
+
+## 7. API, Session, and Preference Semantics
+
+### FR-64.12 — Session-scoped preference
+
+The system SHALL support an optional generation serving profile at session scope
+for player-facing gameplay sessions.
+
+### FR-64.13 — Request override
+
+The system MAY support a per-request override for operator and evaluation tools,
+but the override SHALL be explicit and validated against the canonical profile
+enum.
+
+### FR-64.14 — Persisted preference fields
+
+If a gameplay session or player preference stores a generation serving profile,
+the stored value SHALL use the canonical internal identifier (`fast`,
+`balanced`, `quality`).
+
+### FR-64.15 — Unavailable profile handling
+
+If a caller requests an invalid or unsupported profile, the system SHALL reject
+the request with a validation error rather than silently coercing it.
+
+---
+
+## 8. Playtesting and Evaluation Semantics
+
+### FR-64.16 — Profile-aware batch planning
+
+The evaluation pipeline SHALL support planning and reporting batches by serving
+profile. Operators MUST be able to run the same seed/persona matrix under
+multiple profiles.
+
+### FR-64.17 — Distinct evaluation run classes
+
+The system SHALL support at least these run classes:
+- interactive smoke runs validating player-facing behavior
+- bulk evaluation runs measuring throughput, stability, and quality at scale
+- premium narrative benchmark runs focused on richer-prose policies
+
+These run classes MAY reuse the same game API, but MUST carry explicit serving
+profile and run-class metadata.
+
+### FR-64.18 — Frontier-comparison outputs
+
+Evaluation artifacts SHALL make it possible to compare profiles on the same
+input set for:
+- latency distribution
+- completion/error rate
+- fallback/degradation rate
+- quality scores
+- human preference data when available
+
+### FR-64.19 — Batch traffic isolation
+
+Bulk automated playtesting SHALL NOT rely on the same implicit routing policy as
+interactive player traffic. It MUST use an explicit generation serving profile.
+
+---
+
+## 9. Observability and Analytics
+
+### FR-64.20 — Per-call observability fields
+
+Every generation call SHALL record:
+- requested serving profile
+- effective serving profile
+- whether degradation occurred
+- degradation reason (if any)
+- requested run class / traffic class if available
+- model actually used
+- latency and token counts
+
+### FR-64.21 — Batch/profile aggregates
+
+The system SHALL expose aggregate metrics by serving profile for:
+- call count
+- completion rate
+- fallback rate
+- degradation rate
+- latency percentiles
+- quality-report medians where applicable
+
+### FR-64.22 — Evaluation trace labels
+
+Langfuse traces and exported evaluation artifacts SHALL include serving-profile
+labels so that long-term comparison by profile is possible.
+
+---
+
+## 10. Non-Functional Requirements
+
+### NFR-64.01 — Profile stability
+
+The semantic meaning of `fast`, `balanced`, and `quality` MUST remain stable
+across releases. Operators may retune internals, but the perceived product
+contract must not drift arbitrarily.
+
+### NFR-64.02 — Healthy-supply latency targets
+
+Under healthy model supply and absent system overload, default profile targets
+SHALL be measurable and operator-visible. Suggested defaults for v2.2:
+- `fast`: optimized for lowest turn latency
+- `balanced`: optimized for stable default play
+- `quality`: optimized for richer prose with relaxed latency tolerance
+
+Exact numeric targets are defined in the technical plan and may evolve with
+empirical data.
+
+### NFR-64.03 — No hidden coupling to provider names
+
+No user-facing profile semantics SHALL depend on a specific provider or model
+family being available.
+
+### NFR-64.04 — Comparison reproducibility
+
+Evaluation runs comparing multiple profiles SHALL be reproducible on the same
+scenario seeds, personas, and input scripts so that frontier analysis is valid.
+
+---
+
+## 11. User Journeys
+
+### Journey 1 — Player starts a session with the default profile
+
+Trigger: a player creates a new game without specifying a serving profile.
+
+1. Player starts a new session.
+2. System applies the default profile `balanced`.
+3. Narrative generation requests carry `requested_profile=balanced`.
+4. The turn completes normally.
+5. Observability records the requested and effective profile.
+
+Happy path: the player receives the standard experience without needing to think
+about routing internals.
+
+Alternative path: if `balanced` is temporarily unavailable, the system degrades
+to `fast`, logs the degradation, and still completes the turn if possible.
+
+### Journey 2 — Operator runs a profile comparison batch
+
+Trigger: an operator runs evaluation across `fast`, `balanced`, and `quality`.
+
+1. Operator configures a shared seed/persona matrix.
+2. Pipeline runs the same matrix under each profile.
+3. Results are exported with profile labels.
+4. Operator compares latency, completion rate, and quality medians.
+5. Operator updates serving policy based on measured tradeoffs.
+
+Happy path: the operator obtains a comparable latency/quality frontier rather
+than anecdotal impressions.
+
+### Journey 3 — Quality request degrades gracefully under supply pressure
+
+Trigger: a player or benchmark requests `quality` while the quality envelope is
+unavailable.
+
+1. Caller requests `quality`.
+2. System determines the `quality` envelope is not currently satisfiable.
+3. System degrades to `balanced` per allowed degradation path.
+4. The turn completes under `effective_profile=balanced`.
+5. Logs, traces, and metrics record the degradation reason.
+
+Happy path: the session continues with a documented downgrade rather than an
+opaque failure.
+
+Alternative path: if `balanced` and `fast` are also unavailable, the request
+fails under the normal resilience contract.
+
+---
+
+## 12. Edge Cases & Failure Modes
+
+| # | Scenario | Expected Behavior |
+|---|----------|-------------------|
+| E1 | Caller submits unknown profile `ultra` | Validation error; request is rejected |
+| E2 | `quality` profile unavailable mid-session | Degrade to `balanced` or `fast` per policy; record reason |
+| E3 | `fast` profile has a stronger model available | Allowed only if latency contract is preserved; effective profile remains `fast` |
+| E4 | Bulk eval forgets to specify a profile | Pipeline defaults to `balanced` and logs the defaulting decision |
+| E5 | Different clients use different implicit task mappings | Forbidden by this spec; profile contract must be centralized |
+| E6 | Resume/save path restores a session with stored profile | Restored session resumes with the same canonical profile unless explicitly overridden |
+| E7 | Quality benchmark and interactive smoke share the same transport path | Allowed if run-class/profile metadata remain explicit and routing policies stay distinct |
+| E8 | Provider/model pool changes across releases | Allowed as long as profile semantics and observability remain stable |
+
+---
+
+## 13. Acceptance Criteria (Gherkin)
+
+```gherkin
+Feature: Generation Serving Profiles
+
+  Scenario: AC-64.01 — Default generation profile is balanced
+    Given a gameplay session is created without a generation serving profile
+    When the first narrative generation request is issued
+    Then the requested serving profile is "balanced"
+
+  Scenario: AC-64.02 — Invalid profile is rejected
+    Given a caller submits generation_profile = "ultra"
+    When the request is validated
+    Then the system returns a validation error
+    And no generation request is dispatched
+
+  Scenario: AC-64.03 — Quality can degrade to balanced
+    Given a caller requests generation_profile = "quality"
+    And the quality policy envelope is unavailable
+    When generation is dispatched
+    Then the effective serving profile is "balanced"
+    And the degradation reason is recorded
+
+  Scenario: AC-64.04 — Fast does not silently become quality
+    Given a caller requests generation_profile = "fast"
+    When generation is dispatched
+    Then the effective serving profile is never set to "quality"
+    Unless the request still satisfies the fast latency contract
+
+  Scenario: AC-64.05 — Serving profile does not change correctness stages
+    Given the same player input and world state
+    When generation is run under fast, balanced, and quality
+    Then extraction and persistence semantics remain unchanged
+    And only generation-policy behavior may differ
+
+  Scenario: AC-64.06 — Evaluation pipeline can compare profiles on the same matrix
+    Given a batch config with a fixed seed and persona matrix
+    When the evaluation pipeline runs that matrix for fast, balanced, and quality
+    Then the output artifacts include per-profile results for the same inputs
+
+  Scenario: AC-64.07 — Bulk playtesting uses an explicit profile
+    Given an automated bulk playtest batch
+    When generation requests are dispatched
+    Then each request includes an explicit serving profile
+    And batch traffic does not depend on an implicit interactive routing policy
+
+  Scenario: AC-64.08 — Observability records requested and effective profiles
+    Given any narrative generation call
+    When the call completes or fails
+    Then logs and traces include requested_profile and effective_profile
+```
+
+### Criteria Checklist
+- [ ] **AC-64.01**: Default profile is `balanced`
+- [ ] **AC-64.02**: Invalid profiles are rejected
+- [ ] **AC-64.03**: Explicit degradation path is enforced
+- [ ] **AC-64.04**: `fast` is not silently treated as `quality`
+- [ ] **AC-64.05**: Correctness semantics are invariant across profiles
+- [ ] **AC-64.06**: Evaluation can compare profiles on the same matrix
+- [ ] **AC-64.07**: Bulk playtesting uses explicit profile metadata
+- [ ] **AC-64.08**: Observability records requested/effective profile
+
+---
+
+## 14. Dependencies & Integration Boundaries
+
+| Spec | Relationship | Contract |
+|------|-------------|----------|
+| S07 | Extends LLM role-based routing with profile-aware generation policy | S64 constrains how `generation` role requests are routed and observed |
+| S10 | Defines how profile metadata enters request/response APIs | Session/request fields and validation must be API-visible where exposed |
+| S11 | Governs any persisted player/session preference | Canonical profile IDs may be stored with session/player state |
+| S15 | Provides metrics and traces | Requested/effective profile labels must be observable |
+| S23 | Supplies failure taxonomy and graceful-failure behavior | Profile exhaustion still uses existing resilience semantics |
+| S42 | Playtester agent uses profile-aware generation requests | Automated playtester traffic must carry explicit profile metadata |
+| S45 | Evaluation pipeline compares profiles | Batch outputs and Langfuse export must be profile-aware |
+| S50 | Coordinates concurrency and traffic priority | Serving profiles coexist with task-priority tiers; neither replaces the other |
+
+---
+
+## 15. Open Questions
+
+| ID | Question | Impact | Owner |
+|---|----------|--------|-------|
+| OQ-64.01 | Should player-facing sessions expose profile selection at create-time, resume-time, or both in v2.2? | High | Product + API |
+| OQ-64.02 | Should `quality` be allowed to use comparison dispatch by default, or only in benchmarks? | High | Routing / Ops |
+| OQ-64.03 | Do we want a fourth internal profile later (e.g. `ultra_quality` or `economy`), or should v2.2 stay fixed at three? | Moderate | Product |
+| OQ-64.04 | Which numeric latency targets are realistic for each profile on the current free-model pool? | High | Ops / Eval |
+| OQ-64.05 | Should profile preference be stored at player scope, session scope, or both? | Moderate | Product + API |
+
+---
+
+## 16. Out of Scope
+
+- Direct user-facing slider UI — deferred until profile semantics and frontier data are validated.
+- Arbitrary user selection of specific model IDs or providers — hidden behind policy envelopes by design.
+- Retuning extraction/classification/summarization by profile — unchanged in v2.2 unless separately specified.
+- Commercial pricing or monetization tied to profiles — not part of this spec.
+- Non-generation personalization knobs such as tone or verbosity sliders — separate product features.
+
+---
+
+## Appendix
+
+### A. Glossary
+
+- **Serving profile**: a stable generation policy contract (`fast`, `balanced`,
+  `quality`) chosen by a caller or user.
+- **Requested profile**: the profile asked for by the caller.
+- **Effective profile**: the profile actually used after any allowed degradation.
+- **Policy envelope**: the routing/timeout/fallback semantics associated with a
+  profile.
+- **Frontier**: the measured tradeoff curve between latency, completion
+  resilience, and narrative quality.
+
+### B. References
+
+- `specs/07-llm-integration.md`
+- `specs/45-evaluation-pipeline.md`
+- `specs/50-rate-limit-budget.md`
+- `plans/llm-and-pipeline.md`
+- `plans/v2_1-evaluation-and-playtesting.md`
+
+### C. Structural Notes
+
+This spec intentionally defines the product contract for generation serving
+profiles without locking implementation details such as exact tenant names,
+provider pools, or token budgets. Those are specified in the technical plan.

--- a/src/tta/api/app.py
+++ b/src/tta/api/app.py
@@ -179,8 +179,8 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # 4. LLM client
     if settings.llm_mock:
-        from tta.llm.testing import MockLLMClient
         from tta.llm.roles import DEFAULT_ROLE_CONFIGS
+        from tta.llm.testing import MockLLMClient
 
         app.state.llm_client = MockLLMClient()
         app.state.llm_role_configs = DEFAULT_ROLE_CONFIGS

--- a/src/tta/api/app.py
+++ b/src/tta/api/app.py
@@ -180,8 +180,10 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     # 4. LLM client
     if settings.llm_mock:
         from tta.llm.testing import MockLLMClient
+        from tta.llm.roles import DEFAULT_ROLE_CONFIGS
 
         app.state.llm_client = MockLLMClient()
+        app.state.llm_role_configs = DEFAULT_ROLE_CONFIGS
         log.info("llm_client_mock_enabled")
     else:
         import os
@@ -233,6 +235,7 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
             _effective_role_configs = _overridden
 
         app.state.llm_client = LiteLLMClient(role_configs=_effective_role_configs)
+        app.state.llm_role_configs = _effective_role_configs
 
         # S17 FR-17.30: log configured LLM provider on startup for audit trail
         log.info(
@@ -415,6 +418,7 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         relationship_service=relationship_svc,
         prompt_registry=app.state.prompt_registry,
         prompt_bridge=getattr(app.state, "prompt_bridge", None),
+        llm_role_configs=app.state.llm_role_configs,
         llm_semaphore=app.state.llm_semaphore,
         llm_circuit_breaker=llm_circuit_breaker,
         db_session_factory=session_factory,

--- a/src/tta/api/routes/games.py
+++ b/src/tta/api/routes/games.py
@@ -178,7 +178,9 @@ async def create_game(
     genesis_error_code: str | None = None
     genesis_error_message: str | None = None
     try:
-        registry = request.app.state.template_registry
+        registry = getattr(request.app.state, "template_registry", None)
+        if registry is None:
+            raise NotImplementedError("template_registry not configured on app state")
 
         # Select template: explicit key or best-match by preferences
         if body.world_id:

--- a/src/tta/api/routes/games.py
+++ b/src/tta/api/routes/games.py
@@ -33,6 +33,7 @@ from tta.models.game import (
     GameData,
     GameStatus,
     GameSummary,
+    GenesisStatus,
     PaginationMeta,
 )
 from tta.models.player import Player
@@ -75,6 +76,11 @@ _PUBLIC_STATE_MAP: dict[str, str] = {
     "abandoned": "abandoned",
 }
 
+_GENESIS_TIMEOUT_CODE = "GENESIS_TIMEOUT"
+_GENESIS_CANCELLED_CODE = "GENESIS_CANCELLED"
+_GENESIS_FAILED_CODE = "GENESIS_FAILED"
+_GENESIS_UNAVAILABLE_CODE = "GENESIS_UNAVAILABLE"
+
 
 def _string_pref(preferences: dict[str, str | list[str]], key: str) -> str | None:
     value = preferences.get(key)
@@ -88,6 +94,29 @@ def _traits_pref(preferences: dict[str, str | list[str]]) -> list[str]:
     if isinstance(raw, str) and raw.strip():
         return [raw]
     return []
+
+
+async def _persist_genesis_metadata(
+    pg: AsyncSession,
+    *,
+    game_id: UUID,
+    world_seed_json: dict,
+) -> None:
+    """Persist the latest genesis metadata into the stored world seed."""
+    await pg.execute(
+        sa.text(
+            "UPDATE game_sessions "
+            "SET world_seed = cast(:seed AS jsonb), "
+            "updated_at = :now "
+            "WHERE id = :gid"
+        ),
+        {
+            "seed": json.dumps(world_seed_json),
+            "now": datetime.now(UTC),
+            "gid": game_id,
+        },
+    )
+    await pg.commit()
 
 
 # --- Routes ---
@@ -145,6 +174,9 @@ async def create_game(
 
     # --- Genesis (best-effort) ---
     narrative_intro: str | None = None
+    genesis_status = GenesisStatus.complete
+    genesis_error_code: str | None = None
+    genesis_error_message: str | None = None
     try:
         registry = request.app.state.template_registry
 
@@ -192,36 +224,100 @@ async def create_game(
 
         # Persist genesis result alongside original seed
         world_seed_json["genesis"] = {
+            "status": GenesisStatus.complete.value,
             "world_id": result.world_id,
             "player_location_id": result.player_location_id,
             "template_key": result.template_key,
             "narrative_intro": result.narrative_intro,
             "genesis_elements": result.genesis_elements,
         }
-        await pg.execute(
-            sa.text(
-                "UPDATE game_sessions "
-                "SET world_seed = cast(:seed AS jsonb), "
-                "updated_at = :now "
-                "WHERE id = :gid"
-            ),
-            {
-                "seed": json.dumps(world_seed_json),
-                "now": datetime.now(UTC),
-                "gid": game_id,
-            },
+        await _persist_genesis_metadata(
+            pg,
+            game_id=game_id,
+            world_seed_json=world_seed_json,
         )
-        await pg.commit()
         log.info("genesis_complete", game_id=str(game_id))
+    except TimeoutError:
+        genesis_status = GenesisStatus.degraded
+        genesis_error_code = _GENESIS_TIMEOUT_CODE
+        genesis_error_message = (
+            "World generation timed out before the narrative intro was ready."
+        )
+        world_seed_json["genesis"] = {
+            "status": genesis_status.value,
+            "error_code": genesis_error_code,
+            "error_message": genesis_error_message,
+        }
+        await _persist_genesis_metadata(
+            pg,
+            game_id=game_id,
+            world_seed_json=world_seed_json,
+        )
+        log.warning(
+            "genesis_timeout_graceful_degradation",
+            game_id=str(game_id),
+            genesis_error_code=genesis_error_code,
+        )
     except asyncio.CancelledError:
+        genesis_status = GenesisStatus.degraded
+        genesis_error_code = _GENESIS_CANCELLED_CODE
+        genesis_error_message = (
+            "World generation was interrupted before the narrative intro was ready."
+        )
+        world_seed_json["genesis"] = {
+            "status": genesis_status.value,
+            "error_code": genesis_error_code,
+            "error_message": genesis_error_message,
+        }
+        await _persist_genesis_metadata(
+            pg,
+            game_id=game_id,
+            world_seed_json=world_seed_json,
+        )
         log.warning(
             "genesis_cancelled_graceful_degradation",
             game_id=str(game_id),
+            genesis_error_code=genesis_error_code,
+        )
+    except NotImplementedError:
+        genesis_status = GenesisStatus.degraded
+        genesis_error_code = _GENESIS_UNAVAILABLE_CODE
+        genesis_error_message = "World generation is not available in this environment."
+        world_seed_json["genesis"] = {
+            "status": genesis_status.value,
+            "error_code": genesis_error_code,
+            "error_message": genesis_error_message,
+        }
+        await _persist_genesis_metadata(
+            pg,
+            game_id=game_id,
+            world_seed_json=world_seed_json,
+        )
+        log.warning(
+            "genesis_unavailable_graceful_degradation",
+            game_id=str(game_id),
+            genesis_error_code=genesis_error_code,
         )
     except Exception:
+        genesis_status = GenesisStatus.degraded
+        genesis_error_code = _GENESIS_FAILED_CODE
+        genesis_error_message = (
+            "World generation failed before the narrative intro was ready."
+        )
+        world_seed_json["genesis"] = {
+            "status": genesis_status.value,
+            "error_code": genesis_error_code,
+            "error_message": genesis_error_message,
+        }
+        await _persist_genesis_metadata(
+            pg,
+            game_id=game_id,
+            world_seed_json=world_seed_json,
+        )
         log.warning(
             "genesis_failed_graceful_degradation",
             game_id=str(game_id),
+            genesis_error_code=genesis_error_code,
             exc_info=True,
         )
 
@@ -232,6 +328,9 @@ async def create_game(
             status=GameStatus.active.value,
             turn_count=0,
             narrative_intro=narrative_intro,
+            genesis_status=genesis_status,
+            genesis_error_code=genesis_error_code,
+            genesis_error_message=genesis_error_message,
             character_name=_string_pref(pref, "character_name"),
             character_traits=_traits_pref(pref),
             created_at=now,

--- a/src/tta/api/routes/games.py
+++ b/src/tta/api/routes/games.py
@@ -170,12 +170,23 @@ async def create_game(
 
         from tta.genesis.genesis_lite import run_genesis_lite
 
-        result = await run_genesis_lite(
-            session_id=game_id,
-            player_id=player.id,
-            world_seed=seed,
-            llm=request.app.state.llm_client,
-            world_service=request.app.state.world_service,
+        abort_seconds = settings.latency_budget_abort_ms / 1000.0
+        genesis_budget_seconds = max(
+            0.05,
+            min(
+                settings.pipeline_timeout_seconds,
+                abort_seconds * 0.8,
+            ),
+        )
+        result = await asyncio.wait_for(
+            run_genesis_lite(
+                session_id=game_id,
+                player_id=player.id,
+                world_seed=seed,
+                llm=request.app.state.llm_client,
+                world_service=request.app.state.world_service,
+            ),
+            timeout=genesis_budget_seconds,
         )
         narrative_intro = result.narrative_intro
 
@@ -203,7 +214,10 @@ async def create_game(
         await pg.commit()
         log.info("genesis_complete", game_id=str(game_id))
     except asyncio.CancelledError:
-        raise
+        log.warning(
+            "genesis_cancelled_graceful_degradation",
+            game_id=str(game_id),
+        )
     except Exception:
         log.warning(
             "genesis_failed_graceful_degradation",

--- a/src/tta/api/routes/games.py
+++ b/src/tta/api/routes/games.py
@@ -103,20 +103,27 @@ async def _persist_genesis_metadata(
     world_seed_json: dict,
 ) -> None:
     """Persist the latest genesis metadata into the stored world seed."""
-    await pg.execute(
-        sa.text(
-            "UPDATE game_sessions "
-            "SET world_seed = cast(:seed AS jsonb), "
-            "updated_at = :now "
-            "WHERE id = :gid"
-        ),
-        {
-            "seed": json.dumps(world_seed_json),
-            "now": datetime.now(UTC),
-            "gid": game_id,
-        },
-    )
-    await pg.commit()
+    try:
+        await pg.execute(
+            sa.text(
+                "UPDATE game_sessions "
+                "SET world_seed = cast(:seed AS jsonb), "
+                "updated_at = :now "
+                "WHERE id = :gid"
+            ),
+            {
+                "seed": json.dumps(world_seed_json),
+                "now": datetime.now(UTC),
+                "gid": game_id,
+            },
+        )
+        await pg.commit()
+    except Exception:
+        log.warning(
+            "genesis_metadata_persist_failed",
+            game_id=str(game_id),
+            exc_info=True,
+        )
 
 
 # --- Routes ---

--- a/src/tta/api/routes/games_turns.py
+++ b/src/tta/api/routes/games_turns.py
@@ -334,8 +334,12 @@ async def submit_turn(
         turn_id=str(turn_id),
         turn_number=turn_number,
         input_len=len(normalized),
-        game_state_keys=sorted(game_state.keys()) if isinstance(game_state, dict) else [],
-        game_state_size=len(json.dumps(game_state, default=str)) if game_state is not None else 0,
+        game_state_keys=(
+            sorted(game_state.keys()) if isinstance(game_state, dict) else []
+        ),
+        game_state_size=(
+            len(json.dumps(game_state, default=str)) if game_state is not None else 0
+        ),
     )
     asyncio.create_task(
         dispatch_pipeline(

--- a/src/tta/api/routes/games_turns.py
+++ b/src/tta/api/routes/games_turns.py
@@ -328,6 +328,15 @@ async def submit_turn(
     game_state = row.world_seed if row.world_seed else {}
     if isinstance(game_state, str):
         game_state = json.loads(game_state)
+    log.info(
+        "turn_dispatch_task_created",
+        game_id=str(game_id),
+        turn_id=str(turn_id),
+        turn_number=turn_number,
+        input_len=len(normalized),
+        game_state_keys=sorted(game_state.keys()) if isinstance(game_state, dict) else [],
+        game_state_size=len(json.dumps(game_state, default=str)) if game_state is not None else 0,
+    )
     asyncio.create_task(
         dispatch_pipeline(
             app_state=request.app.state,

--- a/src/tta/eval/pipeline.py
+++ b/src/tta/eval/pipeline.py
@@ -8,6 +8,7 @@ import json
 import os
 import statistics
 import uuid
+from pathlib import Path
 from typing import Any
 
 import structlog
@@ -272,9 +273,12 @@ class EvaluationPipeline:
         """Run NarrativeQualityEvaluator on each completed session."""
         from tta.quality.evaluator import NarrativeQualityEvaluator
         from tta.quality.feedback import FeedbackRecord
+        from tta.seeds import SeedRegistry
 
         evaluator = NarrativeQualityEvaluator(llm_client=self._llm)
         reports: list[NarrativeQualityReport] = []
+        seeds_dir = Path(__file__).resolve().parents[3] / "data" / "seeds"
+        seed_registry = SeedRegistry(seeds_dir)
 
         for result in run_results:
             if result.status != "complete" or result.playtest_report is None:
@@ -286,6 +290,8 @@ class EvaluationPipeline:
                     result.playtest_report.run_id
                 ].to_feedback_record()
 
+            seed_manifest = seed_registry.get(result.scenario_seed_id)
+
             try:
                 # QC-06 consequence_count: not available from the playtest
                 # report alone (requires ConsequenceRecord data from the
@@ -295,7 +301,7 @@ class EvaluationPipeline:
                 quality_report = await evaluator.evaluate(
                     result.playtest_report,
                     feedback=feedback,
-                    seed=None,
+                    seed=seed_manifest,
                     genesis_character_name=(
                         result.playtest_report.genesis_character_name
                     ),
@@ -354,7 +360,9 @@ class EvaluationPipeline:
         """Flag categories where batch median is more than 0.10 below baseline."""
         regressions: list[RegressionResult] = []
         for cat, base_score in baseline.items():
-            batch_score = batch_medians.get(cat, 0.0)
+            if cat not in batch_medians:
+                continue
+            batch_score = batch_medians[cat]
             delta = round(batch_score - base_score, 10)
             if delta < -_REGRESSION_DELTA:
                 regressions.append(

--- a/src/tta/genesis/genesis_lite.py
+++ b/src/tta/genesis/genesis_lite.py
@@ -16,7 +16,7 @@ from tta.genesis.prompts import (
     INTRO_SYSTEM_PROMPT,
     INTRO_USER_PROMPT,
 )
-from tta.llm.client import LLMClient, Message, MessageRole
+from tta.llm.client import GenerationParams, LLMClient, Message, MessageRole
 from tta.llm.roles import ModelRole
 from tta.models.world import WorldSeed, WorldTemplate
 from tta.world.service import WorldService
@@ -77,6 +77,18 @@ class GenesisResult(BaseModel):
         ),
     )
     created_at: datetime
+
+
+def _enrichment_response_format() -> dict[str, object]:
+    """Structured output contract for enrichment calls via FMR."""
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "enriched_template",
+            "schema": EnrichedTemplate.model_json_schema(),
+            "strict": True,
+        },
+    }
 
 
 # -- Public API --------------------------------------------------
@@ -243,6 +255,11 @@ async def enrich_template(
     response = await llm.generate(
         ModelRole.EXTRACTION,
         messages,
+        GenerationParams(
+            temperature=0.0,
+            max_tokens=2048,
+            response_format=_enrichment_response_format(),
+        ),
     )
     first_error_msg: str | None = None
     try:
@@ -274,6 +291,11 @@ async def enrich_template(
     response = await llm.generate(
         ModelRole.EXTRACTION,
         retry_messages,
+        GenerationParams(
+            temperature=0.0,
+            max_tokens=2048,
+            response_format=_enrichment_response_format(),
+        ),
     )
     try:
         return _parse_enrichment(response.content)

--- a/src/tta/llm/client.py
+++ b/src/tta/llm/client.py
@@ -1,11 +1,17 @@
 """LLM client protocol and supporting types."""
 
+from __future__ import annotations
+
 from enum import StrEnum
-from typing import Literal, Protocol
+from typing import Any, Literal, Protocol
 
 from pydantic import BaseModel, Field
 
 from tta.llm.roles import ModelRole
+from tta.llm.serving_profiles import (
+    GenerationServingProfile,
+    GenerationTrafficClass,
+)
 from tta.models.turn import TokenCount
 
 
@@ -30,6 +36,7 @@ class GenerationParams(BaseModel):
     temperature: float = 0.7
     max_tokens: int = 1024
     stop: list[str] = Field(default_factory=list)
+    response_format: dict[str, Any] | None = None
 
 
 class LLMResponse(BaseModel):
@@ -47,6 +54,11 @@ class LLMResponse(BaseModel):
     tier_used: Literal["primary", "fallback"] = "primary"
     trace_id: str = ""
     cost_usd: float = 0.0
+    requested_profile: str = ""
+    effective_profile: str = ""
+    traffic_class: str = ""
+    degraded: bool = False
+    degradation_reason: str = ""
 
 
 class LLMClient(Protocol):
@@ -62,6 +74,9 @@ class LLMClient(Protocol):
         role: ModelRole,
         messages: list[Message],
         params: GenerationParams | None = None,
+        *,
+        generation_profile: GenerationServingProfile | None = None,
+        traffic_class: GenerationTrafficClass | None = None,
     ) -> LLMResponse: ...
 
     async def stream(
@@ -69,4 +84,7 @@ class LLMClient(Protocol):
         role: ModelRole,
         messages: list[Message],
         params: GenerationParams | None = None,
+        *,
+        generation_profile: GenerationServingProfile | None = None,
+        traffic_class: GenerationTrafficClass | None = None,
     ) -> LLMResponse: ...

--- a/src/tta/llm/litellm_client.py
+++ b/src/tta/llm/litellm_client.py
@@ -135,7 +135,7 @@ class LiteLLMClient:
 
         policy = (
             resolve_generation_policy(generation_profile, traffic_class)
-            if role == ModelRole.GENERATION
+            if role == ModelRole.GENERATION and generation_profile is not None
             else None
         )
 

--- a/src/tta/llm/litellm_client.py
+++ b/src/tta/llm/litellm_client.py
@@ -298,8 +298,8 @@ class LiteLLMClient:
                 if response_format is not None:
                     call_kwargs["response_format"] = response_format
                 raw = await litellm.acompletion(**call_kwargs)
-                content = raw.choices[0].message.content or ""
-                usage = raw.usage
+                content = raw.choices[0].message.content or ""  # pyright: ignore[reportAttributeAccessIssue]
+                usage = raw.usage  # pyright: ignore[reportAttributeAccessIssue]
         except (TransientLLMError, PermanentLLMError):
             raise
         except Exception as exc:
@@ -394,7 +394,7 @@ class LiteLLMClient:
             }
         if response_format is not None:
             call_kwargs["response_format"] = response_format
-        response = await litellm.acompletion(**call_kwargs)
+        response: Any = await litellm.acompletion(**call_kwargs)
 
         content_parts: list[str] = []
         usage: Any = None

--- a/src/tta/llm/litellm_client.py
+++ b/src/tta/llm/litellm_client.py
@@ -34,6 +34,12 @@ from tta.llm.roles import (
     ModelRole,
     ModelRoleConfig,
 )
+from tta.llm.serving_profiles import (
+    GenerationPolicy,
+    GenerationServingProfile,
+    GenerationTrafficClass,
+    resolve_generation_policy,
+)
 from tta.models.turn import TokenCount
 from tta.observability.metrics import (
     TURN_LLM_CALLS,
@@ -44,6 +50,19 @@ from tta.observability.metrics import (
 log = structlog.get_logger(__name__)
 
 TierName = Literal["primary", "fallback"]
+
+
+def _router_task_for_model(
+    model: str,
+    role: ModelRole,
+    policy: GenerationPolicy | None = None,
+) -> str | None:
+    """Return FMR task hint for OpenAI-compatible router-backed models."""
+    if not model.startswith("openai/"):
+        return None
+    if role == ModelRole.GENERATION and policy is not None:
+        return policy.router_task
+    return role.value
 
 
 class LiteLLMClient:
@@ -66,22 +85,38 @@ class LiteLLMClient:
         role: ModelRole,
         messages: list[Message],
         params: GenerationParams | None = None,
+        *,
+        generation_profile: GenerationServingProfile | None = None,
+        traffic_class: GenerationTrafficClass | None = None,
     ) -> LLMResponse:
         """Generate a complete response (non-streaming)."""
-        return await self._call_with_fallback(role, messages, params, stream=False)
+        return await self._call_with_fallback(
+            role,
+            messages,
+            params,
+            stream=False,
+            generation_profile=generation_profile,
+            traffic_class=traffic_class,
+        )
 
     async def stream(
         self,
         role: ModelRole,
         messages: list[Message],
         params: GenerationParams | None = None,
+        *,
+        generation_profile: GenerationServingProfile | None = None,
+        traffic_class: GenerationTrafficClass | None = None,
     ) -> LLMResponse:
         """Buffer-then-stream: streams internally, returns LLMResponse."""
-        return await self._call_with_fallback(role, messages, params, stream=True)
-
-    # ------------------------------------------------------------------
-    # Internal: fallback chain
-    # ------------------------------------------------------------------
+        return await self._call_with_fallback(
+            role,
+            messages,
+            params,
+            stream=True,
+            generation_profile=generation_profile,
+            traffic_class=traffic_class,
+        )
 
     async def _call_with_fallback(
         self,
@@ -90,16 +125,32 @@ class LiteLLMClient:
         params: GenerationParams | None,
         *,
         stream: bool,
+        generation_profile: GenerationServingProfile | None,
+        traffic_class: GenerationTrafficClass | None,
     ) -> LLMResponse:
         config = self._role_configs.get(role)
         if config is None:
             msg = f"No model config for role={role}"
             raise PermanentLLMError(msg)
 
+        policy = (
+            resolve_generation_policy(generation_profile, traffic_class)
+            if role == ModelRole.GENERATION
+            else None
+        )
+
         effective_params = params or GenerationParams(
             temperature=config.temperature,
-            max_tokens=config.max_tokens,
+            max_tokens=(policy.max_tokens if policy is not None else config.max_tokens),
         )
+        if (
+            policy is not None
+            and params is not None
+            and params.max_tokens == GenerationParams().max_tokens
+        ):
+            effective_params = params.model_copy(
+                update={"max_tokens": policy.max_tokens}
+            )
 
         tiers: list[tuple[str, TierName]] = [
             (config.primary, "primary"),
@@ -110,7 +161,7 @@ class LiteLLMClient:
         errors: list[Exception] = []
         for model, tier_name in tiers:
             try:
-                return await self._call_with_retries(
+                response = await self._call_with_retries(
                     model=model,
                     messages=messages,
                     params=effective_params,
@@ -118,7 +169,26 @@ class LiteLLMClient:
                     stream=stream,
                     tier=tier_name,
                     role=role,
+                    policy=policy,
                 )
+                if policy is not None:
+                    requested_profile = policy.profile.value
+                    effective_profile = policy.profile.value
+                    traffic_value = policy.traffic_class.value
+                    degraded = tier_name != "primary"
+                    degradation_reason = (
+                        "router_primary_tier_unavailable" if degraded else ""
+                    )
+                    return response.model_copy(
+                        update={
+                            "requested_profile": requested_profile,
+                            "effective_profile": effective_profile,
+                            "traffic_class": traffic_value,
+                            "degraded": degraded,
+                            "degradation_reason": degradation_reason,
+                        }
+                    )
+                return response
             except PermanentLLMError:
                 raise
             except TransientLLMError as exc:
@@ -129,13 +199,16 @@ class LiteLLMClient:
                     model=model,
                     tier=tier_name,
                     error=str(exc),
+                    requested_profile=(policy.profile.value if policy else ""),
+                    traffic_class=(policy.traffic_class.value if policy else ""),
                 )
 
+        if role == ModelRole.GENERATION and policy is not None:
+            raise AllTiersFailedError(
+                role=str(role),
+                errors=errors,
+            )
         raise AllTiersFailedError(role=str(role), errors=errors)
-
-    # ------------------------------------------------------------------
-    # Internal: per-tier retries (tenacity)
-    # ------------------------------------------------------------------
 
     @retry(
         retry=retry_if_exception_type(TransientLLMError),
@@ -153,6 +226,7 @@ class LiteLLMClient:
         stream: bool,
         tier: TierName,
         role: ModelRole,
+        policy: GenerationPolicy | None,
     ) -> LLMResponse:
         """Single-tier call wrapped with tenacity retries."""
         return await self._call_llm(
@@ -163,11 +237,8 @@ class LiteLLMClient:
             stream=stream,
             tier=tier,
             role=role,
+            policy=policy,
         )
-
-    # ------------------------------------------------------------------
-    # Internal: raw litellm call
-    # ------------------------------------------------------------------
 
     async def _call_llm(
         self,
@@ -179,29 +250,56 @@ class LiteLLMClient:
         stream: bool,
         tier: TierName,
         role: ModelRole,
+        policy: GenerationPolicy | None,
     ) -> LLMResponse:
         msg_dicts: list[dict[str, str]] = [
             {"role": m.role.value, "content": m.content} for m in messages
         ]
         stop = params.stop if params.stop else None
+        response_format = params.response_format
         start = time.monotonic()
 
         try:
             if stream:
                 content, usage = await self._stream_and_buffer(
-                    model, msg_dicts, params, config, stop
+                    model,
+                    msg_dicts,
+                    params,
+                    config,
+                    stop,
+                    response_format,
+                    role,
+                    policy,
                 )
             else:
-                raw = await litellm.acompletion(  # type: ignore[reportUnknownMemberType]
-                    model=model,
-                    messages=msg_dicts,  # type: ignore[reportArgumentType]
-                    temperature=params.temperature,
-                    max_tokens=params.max_tokens,
-                    stop=stop,
-                    timeout=config.timeout_seconds,
-                )
-                content = raw.choices[0].message.content or ""  # type: ignore[reportUnknownMemberType]
-                usage = raw.usage  # type: ignore[reportUnknownMemberType]
+                call_kwargs: dict[str, Any] = {
+                    "model": model,
+                    "messages": msg_dicts,
+                    "temperature": params.temperature,
+                    "max_tokens": params.max_tokens,
+                    "stop": stop,
+                    "timeout": (
+                        policy.timeout_seconds
+                        if policy is not None
+                        else config.timeout_seconds
+                    ),
+                }
+                router_task = _router_task_for_model(model, role, policy)
+                if router_task is not None:
+                    call_kwargs["task"] = router_task
+                if policy is not None:
+                    call_kwargs["metadata"] = {
+                        "generation_profile": policy.profile.value,
+                        "traffic_class": policy.traffic_class.value,
+                        "router_task": policy.router_task,
+                        "latency_class": policy.latency_class,
+                        "dispatch_preference": policy.dispatch_preference,
+                    }
+                if response_format is not None:
+                    call_kwargs["response_format"] = response_format
+                raw = await litellm.acompletion(**call_kwargs)
+                content = raw.choices[0].message.content or ""
+                usage = raw.usage
         except (TransientLLMError, PermanentLLMError):
             raise
         except Exception as exc:
@@ -231,9 +329,17 @@ class LiteLLMClient:
             prompt_tokens=token_count.prompt_tokens,
             completion_tokens=token_count.completion_tokens,
             cost_usd=cost_usd,
+            requested_profile=(policy.profile.value if policy else ""),
+            effective_profile=(policy.profile.value if policy else ""),
+            traffic_class=(policy.traffic_class.value if policy else ""),
+            degraded=(tier != "primary" if policy else False),
+            degradation_reason=(
+                "router_primary_tier_unavailable"
+                if policy and tier != "primary"
+                else ""
+            ),
         )
 
-        # Prometheus instrumentation (S15 FR-15.6/7/8)
         provider = model.split("/", 1)[0] if "/" in model else "unknown"
         TURN_LLM_CALLS.labels(model=model, provider=provider).inc()
         TURN_LLM_DURATION.labels(model=model).observe(elapsed_ms / 1000)
@@ -256,25 +362,44 @@ class LiteLLMClient:
         params: GenerationParams,
         config: ModelRoleConfig,
         stop: list[str] | None,
+        response_format: dict[str, Any] | None,
+        role: ModelRole,
+        policy: GenerationPolicy | None,
     ) -> tuple[str, Any]:
         """Stream from litellm and buffer all chunks.
 
         Returns (content, usage_or_None).
         """
-        response = await litellm.acompletion(  # type: ignore[reportUnknownMemberType]
-            model=model,
-            messages=msg_dicts,  # type: ignore[reportArgumentType]
-            temperature=params.temperature,
-            max_tokens=params.max_tokens,
-            stop=stop,
-            timeout=config.timeout_seconds,
-            stream=True,
-        )
+        call_kwargs: dict[str, Any] = {
+            "model": model,
+            "messages": msg_dicts,
+            "temperature": params.temperature,
+            "max_tokens": params.max_tokens,
+            "stop": stop,
+            "timeout": (
+                policy.timeout_seconds if policy is not None else config.timeout_seconds
+            ),
+            "stream": True,
+        }
+        router_task = _router_task_for_model(model, role, policy)
+        if router_task is not None:
+            call_kwargs["task"] = router_task
+        if policy is not None:
+            call_kwargs["metadata"] = {
+                "generation_profile": policy.profile.value,
+                "traffic_class": policy.traffic_class.value,
+                "router_task": policy.router_task,
+                "latency_class": policy.latency_class,
+                "dispatch_preference": policy.dispatch_preference,
+            }
+        if response_format is not None:
+            call_kwargs["response_format"] = response_format
+        response = await litellm.acompletion(**call_kwargs)
 
         content_parts: list[str] = []
         usage: Any = None
 
-        async for chunk in response:  # type: ignore[reportUnknownVariableType]
+        async for chunk in response:
             choices = getattr(chunk, "choices", None)
             if choices:
                 delta = getattr(choices[0], "delta", None)
@@ -287,16 +412,12 @@ class LiteLLMClient:
 
         return "".join(content_parts), usage
 
-    # ------------------------------------------------------------------
-    # Internal: cost calculation
-    # ------------------------------------------------------------------
-
     @staticmethod
     def _calculate_cost(model: str, token_count: TokenCount) -> float:
         """Best-effort cost via litellm's cost tables."""
         try:
             return float(
-                litellm.completion_cost(  # type: ignore[reportUnknownMemberType]
+                litellm.completion_cost(
                     model=model,
                     prompt_tokens=token_count.prompt_tokens,
                     completion_tokens=token_count.completion_tokens,

--- a/src/tta/llm/semaphore.py
+++ b/src/tta/llm/semaphore.py
@@ -71,12 +71,14 @@ class LLMSemaphore:
         self,
         fn: Callable[..., Awaitable[T]],
         *args: object,
+        timeout: float | None = None,
         **kwargs: object,
     ) -> T:
         """Execute *fn* under semaphore with queue and timeout.
 
         Raises 503 if queue is full, cancels on timeout.
         """
+        effective_timeout = self._timeout if timeout is None else timeout
         async with self._lock:
             if self._waiting >= self._queue_size:
                 log.warning(
@@ -93,10 +95,10 @@ class LLMSemaphore:
             LLM_SEMAPHORE_WAITING.set(self._waiting)
 
         try:
-            async with asyncio.timeout(self._timeout):
+            async with asyncio.timeout(effective_timeout):
                 await self._semaphore.acquire()
         except TimeoutError:
-            log.warning("llm_queue_timeout", timeout=self._timeout)
+            log.warning("llm_queue_timeout", timeout=effective_timeout)
             raise AppError(
                 ErrorCategory.SERVICE_UNAVAILABLE,
                 "LLM_TIMEOUT",
@@ -109,10 +111,10 @@ class LLMSemaphore:
         self._active += 1
         LLM_SEMAPHORE_ACTIVE.set(self._active)
         try:
-            async with asyncio.timeout(self._timeout):
+            async with asyncio.timeout(effective_timeout):
                 return await fn(*args, **kwargs)  # type: ignore[return-value]
         except TimeoutError:
-            log.warning("llm_call_timeout", timeout=self._timeout)
+            log.warning("llm_call_timeout", timeout=effective_timeout)
             raise AppError(
                 ErrorCategory.SERVICE_UNAVAILABLE,
                 "LLM_CALL_TIMEOUT",

--- a/src/tta/llm/serving_profiles.py
+++ b/src/tta/llm/serving_profiles.py
@@ -1,0 +1,157 @@
+"""Canonical generation serving-profile policy resolution (S64 Phase 1)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class GenerationServingProfile(StrEnum):
+    FAST = "fast"
+    BALANCED = "balanced"
+    QUALITY = "quality"
+
+
+class GenerationTrafficClass(StrEnum):
+    INTERACTIVE_PLAYER = "interactive_player"
+    INTERACTIVE_SMOKE = "interactive_smoke"
+    BULK_EVAL = "bulk_eval"
+    QUALITY_BENCHMARK = "quality_benchmark"
+
+
+@dataclass(frozen=True)
+class GenerationPolicy:
+    profile: GenerationServingProfile
+    traffic_class: GenerationTrafficClass
+    router_task: str
+    latency_class: str
+    dispatch_preference: str
+    timeout_seconds: float
+    max_tokens: int
+    degradation_chain: tuple[GenerationServingProfile, ...]
+
+
+_DEFAULT_PROFILE = GenerationServingProfile.BALANCED
+_DEFAULT_TRAFFIC_CLASS = GenerationTrafficClass.INTERACTIVE_PLAYER
+
+
+def default_generation_profile() -> GenerationServingProfile:
+    return _DEFAULT_PROFILE
+
+
+def default_generation_traffic_class() -> GenerationTrafficClass:
+    return _DEFAULT_TRAFFIC_CLASS
+
+
+def coerce_generation_profile(
+    profile: GenerationServingProfile | str | None,
+) -> GenerationServingProfile:
+    if profile is None:
+        return default_generation_profile()
+    if isinstance(profile, GenerationServingProfile):
+        return profile
+    return GenerationServingProfile(profile)
+
+
+def coerce_generation_traffic_class(
+    traffic_class: GenerationTrafficClass | str | None,
+) -> GenerationTrafficClass:
+    if traffic_class is None:
+        return default_generation_traffic_class()
+    if isinstance(traffic_class, GenerationTrafficClass):
+        return traffic_class
+    return GenerationTrafficClass(traffic_class)
+
+
+def degradation_chain_for(
+    profile: GenerationServingProfile | str | None,
+) -> tuple[GenerationServingProfile, ...]:
+    resolved = coerce_generation_profile(profile)
+    if resolved == GenerationServingProfile.QUALITY:
+        return (
+            GenerationServingProfile.BALANCED,
+            GenerationServingProfile.FAST,
+        )
+    if resolved == GenerationServingProfile.BALANCED:
+        return (GenerationServingProfile.FAST,)
+    return ()
+
+
+def resolve_generation_policy(
+    profile: GenerationServingProfile | str | None = None,
+    traffic_class: GenerationTrafficClass | str | None = None,
+) -> GenerationPolicy:
+    resolved_profile = coerce_generation_profile(profile)
+    resolved_traffic = coerce_generation_traffic_class(traffic_class)
+
+    if resolved_traffic in {
+        GenerationTrafficClass.INTERACTIVE_PLAYER,
+        GenerationTrafficClass.INTERACTIVE_SMOKE,
+    }:
+        if resolved_profile == GenerationServingProfile.FAST:
+            router_task = "generation"
+            latency_class = "interactive"
+            dispatch_preference = "sync"
+            timeout_seconds = 20.0
+            max_tokens = 512
+        elif resolved_profile == GenerationServingProfile.BALANCED:
+            router_task = "generation"
+            latency_class = "interactive"
+            dispatch_preference = "sync"
+            timeout_seconds = 35.0
+            max_tokens = 768
+        else:
+            router_task = "creative"
+            latency_class = "relaxed"
+            dispatch_preference = "sync_or_compare"
+            timeout_seconds = 60.0
+            max_tokens = 1024
+    elif resolved_traffic == GenerationTrafficClass.BULK_EVAL:
+        if resolved_profile == GenerationServingProfile.FAST:
+            router_task = "generation"
+            latency_class = "batch"
+            dispatch_preference = "queue_tolerant"
+            timeout_seconds = 30.0
+            max_tokens = 512
+        elif resolved_profile == GenerationServingProfile.BALANCED:
+            router_task = "generation"
+            latency_class = "batch"
+            dispatch_preference = "queue_tolerant"
+            timeout_seconds = 45.0
+            max_tokens = 768
+        else:
+            router_task = "creative"
+            latency_class = "batch"
+            dispatch_preference = "queue_tolerant_or_compare"
+            timeout_seconds = 90.0
+            max_tokens = 1024
+    else:
+        if resolved_profile == GenerationServingProfile.FAST:
+            router_task = "generation"
+            latency_class = "benchmark"
+            dispatch_preference = "queue_tolerant"
+            timeout_seconds = 45.0
+            max_tokens = 512
+        elif resolved_profile == GenerationServingProfile.BALANCED:
+            router_task = "generation"
+            latency_class = "benchmark"
+            dispatch_preference = "queue_tolerant_or_compare"
+            timeout_seconds = 75.0
+            max_tokens = 768
+        else:
+            router_task = "creative"
+            latency_class = "benchmark"
+            dispatch_preference = "queue_tolerant_or_compare"
+            timeout_seconds = 90.0
+            max_tokens = 1024
+
+    return GenerationPolicy(
+        profile=resolved_profile,
+        traffic_class=resolved_traffic,
+        router_task=router_task,
+        latency_class=latency_class,
+        dispatch_preference=dispatch_preference,
+        timeout_seconds=timeout_seconds,
+        max_tokens=max_tokens,
+        degradation_chain=degradation_chain_for(resolved_profile),
+    )

--- a/src/tta/llm/smart_router_client.py
+++ b/src/tta/llm/smart_router_client.py
@@ -29,6 +29,7 @@ import httpx
 import structlog
 
 from tta.llm.client import GenerationParams, LLMResponse, Message
+from tta.llm.errors import PermanentLLMError, TransientLLMError
 from tta.llm.roles import ModelRole
 from tta.models.turn import TokenCount
 
@@ -45,7 +46,7 @@ _STARTUP_TIMEOUT = float(os.getenv("FREE_MODEL_ROUTER_STARTUP_TIMEOUT", "15"))
 _ROUTER_API_KEY = os.getenv("FREE_MODEL_ROUTER_API_KEY", "free-model-router")
 
 _ROLE_TO_TASK: dict[ModelRole, str] = {
-    ModelRole.GENERATION: "creative",
+    ModelRole.GENERATION: "generation",
     ModelRole.CLASSIFICATION: "classification",
     ModelRole.EXTRACTION: "extraction",
     ModelRole.SUMMARIZATION: "summarization",
@@ -95,15 +96,27 @@ class SmartRouterLLMClient:
             resp = await self._client.post("/v1/chat/completions", json=payload)
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
             log.warning(
                 "free_model_router.http_error",
-                status=exc.response.status_code,
+                status=status,
                 body=exc.response.text[:200],
             )
-            return self._error_response(messages, str(exc))
+            if status in {400, 401, 403, 404, 422}:
+                raise PermanentLLMError(
+                    f"free-model-router HTTP {status}: {exc.response.text[:200]}",
+                    model="free-model-router",
+                ) from exc
+            raise TransientLLMError(
+                f"free-model-router HTTP {status}: {exc.response.text[:200]}",
+                model="free-model-router",
+            ) from exc
         except httpx.TransportError as exc:
             log.warning("free_model_router.transport_error", error=str(exc))
-            return self._error_response(messages, str(exc))
+            raise TransientLLMError(
+                f"free-model-router transport error: {exc}",
+                model="free-model-router",
+            ) from exc
 
         elapsed_ms = (time.monotonic() - t0) * 1000.0
         data = resp.json()

--- a/src/tta/llm/testing.py
+++ b/src/tta/llm/testing.py
@@ -72,6 +72,9 @@ class MockLLMClient:
         role: ModelRole,
         messages: list[Message],
         params: GenerationParams | None = None,
+        *,
+        generation_profile: GenerationServingProfile | None = None,
+        traffic_class: GenerationTrafficClass | None = None,
     ) -> LLMResponse:
         """Buffer-then-stream: returns complete LLMResponse like generate()."""
         self.call_history.append(

--- a/src/tta/llm/testing.py
+++ b/src/tta/llm/testing.py
@@ -51,7 +51,12 @@ class MockLLMClient:
         params: GenerationParams | None = None,
     ) -> LLMResponse:
         self.call_history.append(
-            {"method": "generate", "role": role, "messages": messages}
+            {
+                "method": "generate",
+                "role": role,
+                "messages": messages,
+                "params": params,
+            }
         )
         return self._build_response(messages, role)
 
@@ -63,6 +68,11 @@ class MockLLMClient:
     ) -> LLMResponse:
         """Buffer-then-stream: returns complete LLMResponse like generate()."""
         self.call_history.append(
-            {"method": "stream", "role": role, "messages": messages}
+            {
+                "method": "stream",
+                "role": role,
+                "messages": messages,
+                "params": params,
+            }
         )
         return self._build_response(messages, role)

--- a/src/tta/llm/testing.py
+++ b/src/tta/llm/testing.py
@@ -6,6 +6,10 @@ from tta.llm.client import (
     Message,
 )
 from tta.llm.roles import ModelRole
+from tta.llm.serving_profiles import (
+    GenerationServingProfile,
+    GenerationTrafficClass,
+)
 from tta.models.turn import TokenCount
 
 MOCK_RESPONSE = "You enter a dimly lit chamber."
@@ -49,6 +53,9 @@ class MockLLMClient:
         role: ModelRole,
         messages: list[Message],
         params: GenerationParams | None = None,
+        *,
+        generation_profile: GenerationServingProfile | None = None,
+        traffic_class: GenerationTrafficClass | None = None,
     ) -> LLMResponse:
         self.call_history.append(
             {

--- a/src/tta/models/game.py
+++ b/src/tta/models/game.py
@@ -21,6 +21,13 @@ class GameStatus(StrEnum):
     abandoned = "abandoned"
 
 
+class GenesisStatus(StrEnum):
+    """Outcome of synchronous genesis during game creation."""
+
+    complete = "complete"
+    degraded = "degraded"
+
+
 class GameSession(BaseModel):
     """Top-level container for a single play-through."""
 
@@ -118,6 +125,9 @@ class GameData(BaseModel):
     title: str | None = None
     summary: str | None = None
     narrative_intro: str | None = None
+    genesis_status: GenesisStatus = GenesisStatus.complete
+    genesis_error_code: str | None = None
+    genesis_error_message: str | None = None
     character_name: str | None = None
     character_traits: list[str] = []
     created_at: datetime

--- a/src/tta/observability/langfuse.py
+++ b/src/tta/observability/langfuse.py
@@ -142,6 +142,41 @@ def shutdown_langfuse() -> None:
         _langfuse_client.flush()
 
 
+def _score_generation(
+    obs: Any,
+    *,
+    name: str,
+    role: str,
+    latency_ms: int,
+    cost_usd: float,
+    model: str | None,
+    turn_id: str | None,
+) -> None:
+    """Attach per-generation quality scores for Langfuse UI (FB-005, AC-09.8).
+
+    Fire-and-forget — scoring failures are silently swallowed.
+    """
+    if obs is None or _langfuse_client is None:
+        return
+    try:
+        scores: list[dict[str, Any]] = [
+            {"name": "llm_role", "value": role},
+            {"name": "llm_latency_ms", "value": float(latency_ms)},
+            {"name": "llm_cost_usd", "value": cost_usd},
+        ]
+        if model:
+            scores.append({"name": "llm_model", "value": model})
+        if turn_id:
+            scores.append({"name": "llm_turn_id", "value": turn_id})
+
+        # Score on the generation observation (SDK infers data_type from value)
+        for s in scores:
+            if hasattr(obs, "score"):
+                obs.score(name=s["name"], value=s["value"])
+    except Exception:
+        _warn_langfuse_error("langfuse_scoring_failed", name=name)
+
+
 def record_llm_generation(
     *,
     name: str,
@@ -258,7 +293,7 @@ def record_llm_generation(
 
     try:
         if _langfuse_uses_v4_sdk(_langfuse_client):
-            _start_generation_observation(
+            obs = _start_generation_observation(
                 _langfuse_client,
                 trace_id=_to_langfuse_id(turn_id) if turn_id else None,
                 name=name,
@@ -275,10 +310,20 @@ def record_llm_generation(
             )
         else:
             trace_obj = _langfuse_client.trace(**trace_kwargs)
-            trace_obj.generation(**gen)
+            obs = trace_obj.generation(**gen)
     except Exception:
         _warn_langfuse_error("langfuse_generation_failed", name=name)
     else:
+        # Inline scoring — per-generation quality signals (FB-005, AC-09.8)
+        _score_generation(
+            obs,
+            name=name,
+            role=role,
+            latency_ms=latency_ms,
+            cost_usd=cost_usd,
+            model=gen.get("model"),
+            turn_id=turn_id,
+        )
         # Flush immediately so traces appear without waiting for the
         # SDK background flush interval. Best-effort only.
         try:

--- a/src/tta/pipeline/llm_guard.py
+++ b/src/tta/pipeline/llm_guard.py
@@ -104,7 +104,18 @@ async def guarded_llm_call(
         attributes={"llm.role": role_name},
     ) as llm_span:
         if deps.llm_semaphore:
-            response = await deps.llm_semaphore.execute(_call)
+            timeout_seconds: float | None = None
+            if deps.llm_role_configs is not None:
+                role_config = deps.llm_role_configs.get(role)
+                if role_config is not None:
+                    timeout_seconds = role_config.timeout_seconds
+            if timeout_seconds is not None:
+                response = await deps.llm_semaphore.execute(
+                    _call,
+                    timeout=timeout_seconds,
+                )
+            else:
+                response = await deps.llm_semaphore.execute(_call)
         else:
             response = await _call()
 

--- a/src/tta/pipeline/orchestrator.py
+++ b/src/tta/pipeline/orchestrator.py
@@ -96,6 +96,12 @@ async def run_pipeline(
                 for stage_config in config.stages:
                     stage_fn = STAGE_MAP[stage_config.name]
                     stage_name = stage_config.name.value
+                    log.debug(
+                        "stage_start",
+                        stage=stage_name,
+                        timeout=stage_config.timeout_seconds,
+                        status=state.status,
+                    )
 
                     with tracer.start_as_current_span(
                         f"stage_{stage_name}",
@@ -154,6 +160,10 @@ async def run_pipeline(
                             "stage_complete",
                             stage=stage_name,
                             duration_ms=round(stage_elapsed * 1000, 1),
+                            status=state.status,
+                            context_partial=state.context_partial,
+                            narrative_len=len(state.narrative_output or ""),
+                            world_updates_count=len(state.world_state_updates or []),
                         )
 
                     # Early return if stage marked turn as failed
@@ -243,15 +253,50 @@ async def dispatch_pipeline(
         game_state=game_state,
     )
 
+    log.info(
+        "pipeline_dispatch_start",
+        game_id=str(game_id),
+        turn_id=str(turn_id),
+        turn_number=turn_number,
+        player_input_len=len(player_input or ""),
+        game_state_keys=(
+            sorted(game_state.keys()) if isinstance(game_state, dict) else []
+        ),
+        game_state_size=len(str(game_state)) if game_state is not None else 0,
+        session_cost_usd=session_cost_usd,
+    )
+
+    dispatch_exception: Exception | None = None
+    failure_persist_succeeded = False
+
     start = time.monotonic()
     try:
         result = await run_pipeline(state, deps)
-    except Exception:
-        log.error("pipeline_dispatch_failed", game_id=str(game_id), exc_info=True)
+    except Exception as exc:
+        dispatch_exception = exc
+        log.error(
+            "pipeline_dispatch_failed",
+            game_id=str(game_id),
+            turn_id=str(turn_id),
+            exception_type=type(exc).__name__,
+            exc_info=True,
+        )
         result = state.model_copy(update={"status": TurnStatus.failed})
 
     elapsed_ms = (time.monotonic() - start) * 1000
     result = result.model_copy(update={"latency_ms": elapsed_ms})
+    log.info(
+        "pipeline_dispatch_result",
+        game_id=str(game_id),
+        turn_id=str(turn_id),
+        status=result.status,
+        latency_ms=round(elapsed_ms, 1),
+        context_partial=result.context_partial,
+        model_used=result.model_used,
+        narrative_len=len(result.narrative_output or ""),
+        world_updates_count=len(result.world_state_updates or []),
+        suggested_actions_count=len(result.suggested_actions or []),
+    )
 
     # Persist turn result via repository
     turn_persisted = False
@@ -272,6 +317,14 @@ async def dispatch_pipeline(
                 latency_ms=elapsed_ms,
                 token_count=token_dict,
             )
+            log.info(
+                "turn_persist_complete",
+                turn_id=str(turn_id),
+                status=result.status,
+                model_used=result.model_used or "unknown",
+                narrative_len=len(result.narrative_output or ""),
+                token_count=token_dict,
+            )
             # FR-24.06 item 5: mark moderated turns distinctly
             if result.status == TurnStatus.moderated:
                 await turn_repo.update_status(turn_id, "moderated")
@@ -279,8 +332,33 @@ async def dispatch_pipeline(
         else:
             # FR-23.18: preserve partial narrative on failure
             await turn_repo.fail_turn(turn_id, narrative_output=result.narrative_output)
+            failure_persist_succeeded = True
+            log.info(
+                "turn_persist_failed_status",
+                turn_id=str(turn_id),
+                status=result.status,
+                narrative_len=len(result.narrative_output or ""),
+            )
+            if dispatch_exception is not None:
+                log.error(
+                    "pipeline_dispatch_exception_persisted_failure",
+                    game_id=str(game_id),
+                    turn_id=str(turn_id),
+                    exception_type=type(dispatch_exception).__name__,
+                    failure_persist_succeeded=failure_persist_succeeded,
+                )
     except Exception:
-        log.error("turn_persist_failed", turn_id=str(turn_id), exc_info=True)
+        log.error(
+            "turn_persist_failed",
+            turn_id=str(turn_id),
+            failure_persist_succeeded=failure_persist_succeeded,
+            dispatch_exception_type=(
+                type(dispatch_exception).__name__
+                if dispatch_exception is not None
+                else None
+            ),
+            exc_info=True,
+        )
         # Last-resort: ensure turn exits processing state to prevent
         # permanent concurrent-turn lock (critique finding #5).
         try:
@@ -472,6 +550,13 @@ async def dispatch_pipeline(
     try:
         store = app_state.turn_result_store  # type: ignore[attr-defined]
         await store.publish(str(turn_id), result)
+        log.info(
+            "turn_result_published",
+            turn_id=str(turn_id),
+            status=result.status,
+            narrative_len=len(result.narrative_output or ""),
+            world_updates_count=len(result.world_state_updates or []),
+        )
     except Exception:
         log.error(
             "turn_result_publish_failed",

--- a/src/tta/pipeline/stages/context.py
+++ b/src/tta/pipeline/stages/context.py
@@ -7,6 +7,8 @@ with graceful fallback to a basic context dict from game_state.
 
 from __future__ import annotations
 
+import json
+
 import structlog
 
 from tta.models.turn import TurnState
@@ -41,6 +43,13 @@ async def context_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
         world_context["intent"] = intent
         world_context["turn_number"] = state.turn_number
         context_partial = False
+        log.debug(
+            "context_live_world_loaded",
+            session_id=str(state.session_id),
+            turn_number=state.turn_number,
+            world_context_keys=sorted(world_context.keys()),
+            world_context_size=len(json.dumps(world_context, default=str)),
+        )
     except Exception as exc:
         # Fallback: still try to get recent events from Postgres
         log.warning(
@@ -68,6 +77,18 @@ async def context_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
             "recent_events": recent_events,
         }
         context_partial = True
+        log.warning(
+            "context_fallback_summary",
+            session_id=str(state.session_id),
+            turn_number=state.turn_number,
+            recent_events_count=len(recent_events),
+            fallback_game_state_keys=(
+                sorted(state.game_state.keys())
+                if isinstance(state.game_state, dict)
+                else []
+            ),
+            fallback_game_state_size=len(json.dumps(state.game_state, default=str)),
+        )
 
     # v2.1 Decision #6: NPC autonomy + consequence propagation moved to arq worker.
     # Fire-and-forget via ArqQueue — NPC state changes visible on NEXT turn.
@@ -158,6 +179,8 @@ async def context_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
         intent=intent,
         turn_number=state.turn_number,
         partial=context_partial,
+        world_context_keys=sorted(world_context.keys()),
+        world_context_size=len(json.dumps(world_context, default=str)),
     )
 
     update: dict = {

--- a/src/tta/pipeline/stages/generate.py
+++ b/src/tta/pipeline/stages/generate.py
@@ -8,6 +8,8 @@ hooks, calls the LLM for narrative, then extracts world changes.
 from __future__ import annotations
 
 import json
+import re
+import time
 from typing import Any
 
 import structlog
@@ -68,6 +70,46 @@ _CONTEXT_META_KEYS = {
     "npc_dialogue_contexts",
     "active_companions",
 }
+
+
+def _parse_extraction_response(content: str) -> dict[str, Any] | list[Any] | None:
+    """Extract JSON payload from extraction-model output.
+
+    Handles raw JSON, fenced JSON, and JSON objects/lists embedded in prose.
+    Returns None when no parseable JSON payload is found.
+    """
+    stripped = content.strip()
+    if not stripped:
+        return None
+
+    decoder = json.JSONDecoder()
+    candidates = [stripped]
+
+    fence_match = re.search(r"```(?:json)?\s*\n?(.*?)\n?\s*```", content, re.DOTALL)
+    if fence_match:
+        candidates.append(fence_match.group(1).strip())
+
+    for candidate in candidates:
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            pass
+        else:
+            if isinstance(parsed, (dict, list)):
+                return parsed
+
+    start_positions = sorted(
+        {idx for idx in (content.find("{"), content.find("[")) if idx != -1}
+    )
+    for start in start_positions:
+        try:
+            parsed, _ = decoder.raw_decode(content[start:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, (dict, list)):
+            return parsed
+
+    return None
 
 
 def _build_npc_section(npc_contexts: list[dict]) -> str:
@@ -235,6 +277,21 @@ async def generate_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
     """
     # 1. Build generation prompt
     prompt = _build_generation_prompt(state)
+    wc = state.world_context or {}
+    context_data = {k: v for k, v in wc.items() if k not in _CONTEXT_META_KEYS}
+    log.info(
+        "generation_prompt_built",
+        session_id=str(state.session_id),
+        turn_number=state.turn_number,
+        context_partial=state.context_partial,
+        prompt_len=len(prompt),
+        world_context_keys=sorted(wc.keys()),
+        world_context_size=len(json.dumps(wc, default=str)),
+        context_data_size=len(json.dumps(context_data, default=str)),
+        active_consequences_count=len(state.active_consequences or []),
+        consequence_hints_count=len(state.consequence_hints or []),
+        pruned_chain_closures_count=len(state.pruned_chain_closures or []),
+    )
     state = state.model_copy(update={"generation_prompt": prompt})
 
     # Observe-only injection signal scan on USER content (AC-09.8)
@@ -267,6 +324,7 @@ async def generate_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
     response: LLMResponse | None = None
 
     try:
+        llm_start = time.monotonic()
         response = await _llm_with_retries(
             messages,
             deps,
@@ -277,7 +335,19 @@ async def generate_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
             prompt_hash=rendered_system_prompt.prompt_hash,
             langfuse_prompt=rendered_system_prompt.metadata.get("langfuse_prompt"),
         )
+        llm_elapsed_ms = (time.monotonic() - llm_start) * 1000
         narrative = response.content
+        log.info(
+            "generation_llm_succeeded",
+            session_id=str(state.session_id),
+            turn_number=state.turn_number,
+            model_used=response.model_used,
+            llm_elapsed_ms=round(llm_elapsed_ms, 1),
+            narrative_len=len(narrative or ""),
+            token_count=(
+                response.token_count.model_dump() if response.token_count else None
+            ),
+        )
     except (BudgetExceededError, AppError, PermanentLLMError):
         raise  # Non-transient — propagate immediately
     except (TransientLLMError, AllTiersFailedError):
@@ -340,9 +410,34 @@ async def generate_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
             }
         )
 
-    world_updates, suggestions = await _extract_world_changes(
-        narrative, state.player_input, deps
-    )
+    extract_start = time.monotonic()
+    try:
+        world_updates, suggestions = await _extract_world_changes(
+            narrative, state.player_input, deps
+        )
+    except TimeoutError:
+        extract_elapsed_ms = (time.monotonic() - extract_start) * 1000
+        log.warning(
+            "generation_extraction_timeout",
+            session_id=str(state.session_id),
+            turn_number=state.turn_number,
+            extraction_elapsed_ms=round(extract_elapsed_ms, 1),
+            model_used=response.model_used if response else "fallback",
+            narrative_len=len(narrative),
+            exc_info=True,
+        )
+        world_updates = []
+        suggestions = []
+    else:
+        extract_elapsed_ms = (time.monotonic() - extract_start) * 1000
+        log.info(
+            "generation_extraction_complete",
+            session_id=str(state.session_id),
+            turn_number=state.turn_number,
+            extraction_elapsed_ms=round(extract_elapsed_ms, 1),
+            world_updates_count=len(world_updates or []),
+            suggested_actions_count=len(suggestions or []),
+        )
 
     prior = list(state.world_state_updates or [])
     merged = prior + (world_updates or [])
@@ -500,7 +595,9 @@ async def _extract_world_changes(
             prompt_hash=extraction_prompt.prompt_hash,
             langfuse_prompt=extraction_prompt.metadata.get("langfuse_prompt"),
         )
-        parsed = json.loads(response.content)
+        parsed = _parse_extraction_response(response.content)
+        if parsed is None:
+            return [], []
 
         # New format: {"world_changes": [...], "suggested_actions": [...]}
         if isinstance(parsed, dict):

--- a/src/tta/pipeline/types.py
+++ b/src/tta/pipeline/types.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from tta.choices.consequence_service import ConsequenceService
     from tta.config import Settings
     from tta.llm.client import LLMClient
+    from tta.llm.roles import ModelRole, ModelRoleConfig
     from tta.llm.semaphore import LLMSemaphore
     from tta.persistence.repositories import (
         SessionRepository,
@@ -61,6 +62,7 @@ class PipelineDeps:
     relationship_service: RelationshipService | None = None
     prompt_registry: FilePromptRegistry | None = None
     prompt_bridge: Any | None = None  # LangfusePromptBridge (FB-005 / AC-09.2)
+    llm_role_configs: dict[ModelRole, ModelRoleConfig] | None = None
     llm_semaphore: LLMSemaphore | None = None
     llm_circuit_breaker: CircuitBreaker | None = None
     db_session_factory: Any | None = None  # async_sessionmaker for direct DB access

--- a/src/tta/playtest/agent.py
+++ b/src/tta/playtest/agent.py
@@ -159,20 +159,46 @@ class PlaytesterAgent:
                         raise RuntimeError(
                             "ANON_GAME_LIMIT but no existing games found"
                         )
-                    # Use the most recently created game, then resume
-                    # to get the genesis narrative_intro (GameSummary
-                    # does not include it; only POST /{id}/resume does).
-                    existing = games[0]
-                    self._game_id = existing["game_id"]
-                    resume_resp = await self._request_with_backoff(
-                        client,
-                        "POST",
-                        f"/api/v1/games/{self._game_id}/resume",
-                    )
-                    resume_data = resume_resp.json()["data"]
-                    current_narrative = resume_data.get("recap", "")
-                    self._genesis_phases_completed = 7  # genesis is done
-                    # Skip the game creation block below
+
+                    reusable_found = False
+                    for existing in games:
+                        candidate_game_id = existing["game_id"]
+                        detail_resp = await client.get(
+                            f"/api/v1/games/{candidate_game_id}"
+                        )
+                        detail_resp.raise_for_status()
+                        detail_data = detail_resp.json().get("data", {})
+                        detail_status = detail_data.get("status")
+
+                        if detail_status == "created":
+                            self._game_id = candidate_game_id
+                            recent_turns = detail_data.get("recent_turns", [])
+                            current_narrative = (
+                                recent_turns[-1].get("narrative_output", "")
+                                if recent_turns
+                                else ""
+                            )
+                            self._genesis_phases_completed = 0
+                            reusable_found = True
+                            break
+
+                        if detail_status in {"active", "paused", "expired"}:
+                            self._game_id = candidate_game_id
+                            resume_resp = await self._request_with_backoff(
+                                client,
+                                "POST",
+                                f"/api/v1/games/{self._game_id}/resume",
+                            )
+                            resume_data = resume_resp.json()["data"]
+                            current_narrative = resume_data.get("recap", "")
+                            self._genesis_phases_completed = 7
+                            reusable_found = True
+                            break
+
+                    if not reusable_found:
+                        raise RuntimeError(
+                            "ANON_GAME_LIMIT but no reusable existing games found"
+                        )
                 else:
                     resp.raise_for_status()
             else:

--- a/src/tta/quality/evaluator.py
+++ b/src/tta/quality/evaluator.py
@@ -254,6 +254,15 @@ class NarrativeQualityEvaluator:
             report, genesis_character_name, traits
         )
 
+        if not genesis_character_name.strip():
+            return CategoryScore(
+                category_id=QC_CHARACTER_DEPTH,
+                score=None,
+                status="not_evaluated",
+                sources=["automated"],
+                notes="QC-04 not evaluated: missing genesis character metadata.",
+            )
+
         if feedback is not None:
             human_score = feedback.character_normalized
             score = 0.5 * auto_score + 0.5 * human_score

--- a/tests/simulation/smoke_eval_pipeline.py
+++ b/tests/simulation/smoke_eval_pipeline.py
@@ -126,6 +126,13 @@ async def run_live_preflight(token: str) -> None:
         create_data = create_resp.json()["data"]
         game_id = str(create_data["game_id"])
         intro = str(create_data.get("narrative_intro") or "").strip()
+        genesis_status = str(create_data.get("genesis_status") or "").strip()
+        if genesis_status == "degraded":
+            raise RuntimeError(
+                "Preflight create_game degraded: "
+                f"{create_data.get('genesis_error_code')}: "
+                f"{create_data.get('genesis_error_message')}"
+            )
         if not intro:
             raise RuntimeError("Preflight create_game returned empty narrative_intro")
         print(f"Preflight game ready: {game_id}")

--- a/tests/unit/api/test_games.py
+++ b/tests/unit/api/test_games.py
@@ -129,6 +129,7 @@ class TestCreateGame:
             side_effect=[
                 _make_result(scalar=0),  # count active games
                 _make_result(),  # INSERT
+                _make_result(),  # UPDATE world_seed (genesis persist)
             ]
         )
         pg.commit = AsyncMock()
@@ -160,6 +161,7 @@ class TestCreateGame:
             side_effect=[
                 _make_result(scalar=0),  # count active games
                 _make_result(),  # INSERT
+                _make_result(),  # UPDATE world_seed (genesis persist)
             ]
         )
         pg.commit = AsyncMock()
@@ -182,10 +184,12 @@ class TestCreateGame:
         )
         pg.execute = AsyncMock(
             side_effect=[
-                _make_result(scalar=0),
-                _make_result(),
-                _make_result(scalar=1),
-                _make_result(),
+                _make_result(scalar=0),  # count active games (game 1)
+                _make_result(),  # INSERT (game 1)
+                _make_result(),  # UPDATE world_seed (game 1)
+                _make_result(scalar=1),  # count active games (game 2)
+                _make_result(),  # INSERT (game 2)
+                _make_result(),  # UPDATE world_seed (game 2)
             ]
         )
         pg.commit = AsyncMock()
@@ -241,6 +245,7 @@ class TestCreateGame:
             side_effect=[
                 _make_result(scalar=0),  # count active games (create)
                 _make_result(),  # INSERT game (create)
+                _make_result(),  # UPDATE world_seed (create genesis persist)
                 _make_result([game_row]),  # SELECT games (list)
             ]
         )

--- a/tests/unit/api/test_genesis_integration.py
+++ b/tests/unit/api/test_genesis_integration.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Generator
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
@@ -9,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+import structlog
 
 from tta.models.turn import TurnState, TurnStatus
 from tta.models.world import TemplateMetadata, WorldChangeType, WorldTemplate
@@ -468,6 +471,57 @@ class TestCreateGameGenesis:
         assert resp.status_code == 201
         assert resp.json()["data"]["narrative_intro"] is None
 
+    @patch("tta.genesis.genesis_lite.run_genesis_lite", new_callable=AsyncMock)
+    def test_genesis_timeout_degrades_before_latency_abort(
+        self,
+        mock_genesis: AsyncMock,
+        _app_for_genesis: tuple,
+    ) -> None:
+        """Slow genesis degrades gracefully before middleware returns 503."""
+        app, client, pg = _app_for_genesis
+        app.state.settings.latency_budget_abort_ms = 200
+        app.state.settings.latency_budget_warn_ms = 0
+
+        async def _slow_genesis(*args: Any, **kwargs: Any) -> None:
+            del args, kwargs
+            await asyncio.sleep(0.35)
+
+        mock_genesis.side_effect = _slow_genesis
+        pg.execute = AsyncMock(
+            side_effect=[
+                _make_result(scalar=0),
+                _make_result(),
+            ]
+        )
+        pg.commit = AsyncMock()
+
+        resp = client.post("/api/v1/games", json={})
+
+        assert resp.status_code == 201
+        assert resp.json()["data"]["narrative_intro"] is None
+
+    @patch("tta.genesis.genesis_lite.run_genesis_lite", new_callable=AsyncMock)
+    def test_genesis_cancellation_degrades_gracefully(
+        self,
+        mock_genesis: AsyncMock,
+        _app_for_genesis: tuple,
+    ) -> None:
+        """Cancelled genesis still returns the created game instead of 503."""
+        _, client, pg = _app_for_genesis
+        mock_genesis.side_effect = asyncio.CancelledError()
+        pg.execute = AsyncMock(
+            side_effect=[
+                _make_result(scalar=0),
+                _make_result(),
+            ]
+        )
+        pg.commit = AsyncMock()
+
+        resp = client.post("/api/v1/games", json={})
+
+        assert resp.status_code == 201
+        assert resp.json()["data"]["narrative_intro"] is None
+
 
 # ------------------------------------------------------------------
 # _dispatch_pipeline world changes (isolated unit tests)
@@ -476,6 +530,106 @@ class TestCreateGameGenesis:
 
 class TestDispatchPipelineWorldChanges:
     """Tests that _dispatch_pipeline applies world changes correctly."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_structlog(self) -> Generator[None, None, None]:
+        structlog.reset_defaults()
+        from tta.pipeline import orchestrator as orchestrator_module
+
+        if "bind" in orchestrator_module.log.__dict__:
+            del orchestrator_module.log.bind
+        yield
+        structlog.reset_defaults()
+
+    @pytest.mark.asyncio
+    @patch("tta.world.changes.apply_changes", new_callable=AsyncMock)
+    @patch("tta.pipeline.orchestrator.run_pipeline", new_callable=AsyncMock)
+    async def test_dispatch_exception_logs_persistence_outcome(
+        self,
+        mock_pipeline: AsyncMock,
+        mock_apply: AsyncMock,
+    ) -> None:
+        """Dispatch exceptions log type and failed-turn persist success."""
+        from tta.pipeline.orchestrator import dispatch_pipeline
+
+        game_id = uuid4()
+        turn_id = uuid4()
+
+        mock_pipeline.side_effect = RuntimeError("boom")
+        turn_repo = AsyncMock()
+        store = AsyncMock()
+
+        app_state = SimpleNamespace(
+            pipeline_deps=SimpleNamespace(
+                turn_repo=turn_repo,
+                world=AsyncMock(),
+                llm=MagicMock(),
+                prompt_registry=MagicMock(),
+                relationship_service=None,
+            ),
+            settings=_settings(),
+            turn_result_store=store,
+        )
+
+        with structlog.testing.capture_logs() as logs:
+            await dispatch_pipeline(app_state, game_id, turn_id, 1, "go north", {})
+
+        mock_apply.assert_not_awaited()
+        turn_repo.fail_turn.assert_awaited_once_with(turn_id, narrative_output=None)
+        dispatch_failed = [
+            e for e in logs if e.get("event") == "pipeline_dispatch_failed"
+        ]
+        persisted = [
+            e
+            for e in logs
+            if e.get("event") == "pipeline_dispatch_exception_persisted_failure"
+        ]
+        assert dispatch_failed
+        assert dispatch_failed[0]["exception_type"] == "RuntimeError"
+        assert persisted
+        assert persisted[0]["exception_type"] == "RuntimeError"
+        assert persisted[0]["failure_persist_succeeded"] is True
+
+    @pytest.mark.asyncio
+    @patch("tta.world.changes.apply_changes", new_callable=AsyncMock)
+    @patch("tta.pipeline.orchestrator.run_pipeline", new_callable=AsyncMock)
+    async def test_dispatch_exception_log_marks_failed_persist_when_fail_turn_raises(
+        self,
+        mock_pipeline: AsyncMock,
+        mock_apply: AsyncMock,
+    ) -> None:
+        """Persist failure log includes dispatch exception type and outcome."""
+        from tta.pipeline.orchestrator import dispatch_pipeline
+
+        game_id = uuid4()
+        turn_id = uuid4()
+
+        mock_pipeline.side_effect = RuntimeError("boom")
+        turn_repo = AsyncMock()
+        turn_repo.fail_turn.side_effect = RuntimeError("db write failed")
+        store = AsyncMock()
+
+        app_state = SimpleNamespace(
+            pipeline_deps=SimpleNamespace(
+                turn_repo=turn_repo,
+                world=AsyncMock(),
+                llm=MagicMock(),
+                prompt_registry=MagicMock(),
+                relationship_service=None,
+            ),
+            settings=_settings(),
+            turn_result_store=store,
+        )
+
+        with structlog.testing.capture_logs() as logs:
+            await dispatch_pipeline(app_state, game_id, turn_id, 1, "go north", {})
+
+        mock_apply.assert_not_awaited()
+        turn_repo.update_status.assert_awaited_once_with(turn_id, "failed")
+        persist_failed = [e for e in logs if e.get("event") == "turn_persist_failed"]
+        assert persist_failed
+        assert persist_failed[0]["dispatch_exception_type"] == "RuntimeError"
+        assert persist_failed[0]["failure_persist_succeeded"] is False
 
     @pytest.mark.asyncio
     @patch("tta.world.changes.apply_changes", new_callable=AsyncMock)

--- a/tests/unit/api/test_genesis_integration.py
+++ b/tests/unit/api/test_genesis_integration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import Generator
 from datetime import UTC, datetime
 from types import SimpleNamespace
@@ -303,6 +304,7 @@ def _genesis_result_mock() -> MagicMock:
     result.player_location_id = "loc_1"
     result.template_key = "fantasy"
     result.narrative_intro = "You awaken in a dark forest..."
+    result.genesis_elements = []
     return result
 
 
@@ -377,6 +379,9 @@ class TestCreateGameGenesis:
         assert resp.status_code == 201
         data = resp.json()["data"]
         assert data["narrative_intro"] == "You awaken in a dark forest..."
+        assert data["genesis_status"] == "complete"
+        assert data["genesis_error_code"] is None
+        assert data["genesis_error_message"] is None
         mock_genesis.assert_awaited_once()
 
     @patch("tta.genesis.genesis_lite.run_genesis_lite", new_callable=AsyncMock)
@@ -392,6 +397,7 @@ class TestCreateGameGenesis:
             side_effect=[
                 _make_result(scalar=0),  # count active games
                 _make_result(),  # INSERT game
+                _make_result(),  # UPDATE degraded genesis metadata
             ]
         )
         pg.commit = AsyncMock()
@@ -401,6 +407,9 @@ class TestCreateGameGenesis:
         assert resp.status_code == 201
         data = resp.json()["data"]
         assert data["narrative_intro"] is None
+        assert data["genesis_status"] == "degraded"
+        assert data["genesis_error_code"] == "GENESIS_FAILED"
+        assert data["genesis_error_message"]
 
     @patch("tta.genesis.genesis_lite.run_genesis_lite", new_callable=AsyncMock)
     def test_genesis_uses_world_id_for_template_lookup(
@@ -462,6 +471,7 @@ class TestCreateGameGenesis:
             side_effect=[
                 _make_result(scalar=0),
                 _make_result(),
+                _make_result(),
             ]
         )
         pg.commit = AsyncMock()
@@ -469,7 +479,10 @@ class TestCreateGameGenesis:
         resp = client.post("/api/v1/games", json={})
 
         assert resp.status_code == 201
-        assert resp.json()["data"]["narrative_intro"] is None
+        data = resp.json()["data"]
+        assert data["narrative_intro"] is None
+        assert data["genesis_status"] == "degraded"
+        assert data["genesis_error_code"] == "GENESIS_UNAVAILABLE"
 
     @patch("tta.genesis.genesis_lite.run_genesis_lite", new_callable=AsyncMock)
     def test_genesis_timeout_degrades_before_latency_abort(
@@ -491,6 +504,7 @@ class TestCreateGameGenesis:
             side_effect=[
                 _make_result(scalar=0),
                 _make_result(),
+                _make_result(),
             ]
         )
         pg.commit = AsyncMock()
@@ -498,7 +512,10 @@ class TestCreateGameGenesis:
         resp = client.post("/api/v1/games", json={})
 
         assert resp.status_code == 201
-        assert resp.json()["data"]["narrative_intro"] is None
+        data = resp.json()["data"]
+        assert data["narrative_intro"] is None
+        assert data["genesis_status"] == "degraded"
+        assert data["genesis_error_code"] == "GENESIS_TIMEOUT"
 
     @patch("tta.genesis.genesis_lite.run_genesis_lite", new_callable=AsyncMock)
     def test_genesis_cancellation_degrades_gracefully(
@@ -513,6 +530,7 @@ class TestCreateGameGenesis:
             side_effect=[
                 _make_result(scalar=0),
                 _make_result(),
+                _make_result(),
             ]
         )
         pg.commit = AsyncMock()
@@ -520,7 +538,36 @@ class TestCreateGameGenesis:
         resp = client.post("/api/v1/games", json={})
 
         assert resp.status_code == 201
-        assert resp.json()["data"]["narrative_intro"] is None
+        data = resp.json()["data"]
+        assert data["narrative_intro"] is None
+        assert data["genesis_status"] == "degraded"
+        assert data["genesis_error_code"] == "GENESIS_CANCELLED"
+
+    @patch("tta.genesis.genesis_lite.run_genesis_lite", new_callable=AsyncMock)
+    def test_genesis_degradation_persists_explicit_metadata(
+        self,
+        mock_genesis: AsyncMock,
+        _app_for_genesis: tuple,
+    ) -> None:
+        """Degraded genesis persists status/code into the stored world seed."""
+        _, client, pg = _app_for_genesis
+        mock_genesis.side_effect = RuntimeError("router offline")
+        pg.execute = AsyncMock(
+            side_effect=[
+                _make_result(scalar=0),
+                _make_result(),
+                _make_result(),
+            ]
+        )
+        pg.commit = AsyncMock()
+
+        resp = client.post("/api/v1/games", json={})
+
+        assert resp.status_code == 201
+        update_params = pg.execute.await_args_list[-1].args[1]
+        persisted_seed = json.loads(update_params["seed"])
+        assert persisted_seed["genesis"]["status"] == "degraded"
+        assert persisted_seed["genesis"]["error_code"] == "GENESIS_FAILED"
 
 
 # ------------------------------------------------------------------

--- a/tests/unit/api/test_s01_ac_compliance.py
+++ b/tests/unit/api/test_s01_ac_compliance.py
@@ -416,8 +416,10 @@ class TestAC108SecondPlaythrough:
                 side_effect=[
                     _make_result(scalar=0),  # count active games (first)
                     _make_result(),  # INSERT game (first)
+                    _make_result(),  # UPDATE world_seed (first genesis persist)
                     _make_result(scalar=0),  # count active games (second)
                     _make_result(),  # INSERT game (second)
+                    _make_result(),  # UPDATE world_seed (second genesis persist)
                 ]
             )
             pg.commit = AsyncMock()

--- a/tests/unit/api/test_s10_ac_compliance.py
+++ b/tests/unit/api/test_s10_ac_compliance.py
@@ -188,6 +188,7 @@ class TestAC1001GameplayFlow:
             side_effect=[
                 _make_result(scalar=0),  # count active games
                 _make_result(),  # INSERT game
+                _make_result(),  # UPDATE world_seed (genesis persist)
                 _make_result([_game_row()]),  # _get_owned_game (for turn)
                 _make_result(),  # advisory lock
                 _make_result(),  # in-flight check

--- a/tests/unit/auth/test_jwt.py
+++ b/tests/unit/auth/test_jwt.py
@@ -254,3 +254,145 @@ class TestDenyList:
     async def test_no_redis_non_prod_not_denied(self) -> None:
         """Without Redis in dev, is_token_denied returns False."""
         assert await is_token_denied(None, "some-jti") is False
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Swarm-generated edge case tests — 2026-05-24
+# Workers: hermes-pipeline (qwen3-coder-480b → kimi-k2 → gemma-31b)
+# Reviewer: hermes-reasoning (mistral-large)
+# Recomposed by: orchestrator (deepseek-v4-pro)
+# Git trailer: Swarm: 2026-05-24-run-1/jwt-edge-cases
+# ═══════════════════════════════════════════════════════════════════
+
+
+# ── JTI uniqueness ───────────────────────────────────────────────
+
+
+class TestJtiUniqueness:
+    """JTI values must be unique across calls — verified by swarm worker C."""
+
+    def test_access_token_jtis_are_unique(self) -> None:
+        t1 = create_access_token(_PID)
+        t2 = create_access_token(_PID)
+        c1 = pyjwt.decode(
+            t1, "test-secret-key-minimum-32-bytes-long!!", algorithms=["HS256"]
+        )
+        c2 = pyjwt.decode(
+            t2, "test-secret-key-minimum-32-bytes-long!!", algorithms=["HS256"]
+        )
+        assert c1["jti"] != c2["jti"]
+
+    def test_refresh_token_jtis_are_unique(self) -> None:
+        _, jti1 = create_refresh_token(_PID, session_family_id=_SFID)
+        _, jti2 = create_refresh_token(_PID, session_family_id=_SFID)
+        assert jti1 != jti2
+
+
+# ── decode_token — wrong algorithm ───────────────────────────────
+
+
+class TestDecodeTokenWrongAlgorithm:
+    """Verified by swarm worker A — tokens signed with wrong key must fail."""
+
+    def test_rejects_token_signed_with_different_secret(self) -> None:
+        """Token signed with a different secret must be rejected."""
+        different_secret = "a-different-secret-key-32-bytes-xx"
+        now = datetime.now(UTC)
+        claims = {
+            "sub": str(_PID),
+            "typ": "access",
+            "iat": now,
+            "exp": now + timedelta(hours=1),
+            "jti": "test-jti",
+        }
+        token = pyjwt.encode(claims, different_secret, algorithm="HS256")
+        with pytest.raises(TokenError, match="Invalid token"):
+            decode_token(token)
+
+
+# ── deny-list — PRODUCTION-mode error paths ──────────────────────
+
+
+@pytest.fixture
+def _prod_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Override environment to PRODUCTION for deny-list error tests."""
+    from tta.config import Environment
+
+    s = Settings(
+        database_url="postgresql://test@localhost/test",
+        neo4j_password="test",
+        jwt_secret="test-secret-key-minimum-32-bytes-long!!",
+        jwt_algorithm="HS256",
+        access_token_ttl=3600,
+        anon_access_token_ttl=86400,
+        refresh_token_ttl=2592000,
+        anon_refresh_token_ttl=604800,
+        environment=Environment.PRODUCTION,
+    )
+    monkeypatch.setattr("tta.auth.jwt.get_settings", lambda: s)
+
+
+class TestDenyListProdErrors:
+    """Verified by swarm worker B — PRODUCTION-mode error handling."""
+
+    @pytest.mark.anyio
+    async def test_deny_without_redis_in_prod_raises(
+        self, _prod_settings: None
+    ) -> None:
+        exp = datetime.now(UTC) + timedelta(hours=1)
+        with pytest.raises(RuntimeError, match="Redis is required"):
+            await deny_token(None, "jti-001", exp)
+
+    @pytest.mark.anyio
+    async def test_check_without_redis_in_prod_raises(
+        self, _prod_settings: None
+    ) -> None:
+        with pytest.raises(RuntimeError, match="Redis is required"):
+            await is_token_denied(None, "jti-001")
+
+    @pytest.mark.anyio
+    async def test_deny_redis_connection_error_in_prod_raises(
+        self, _prod_settings: None
+    ) -> None:
+        redis = AsyncMock()
+        redis.setex = AsyncMock(side_effect=ConnectionError("down"))
+        exp = datetime.now(UTC) + timedelta(hours=1)
+        with pytest.raises(RuntimeError, match="Redis connection failed"):
+            await deny_token(redis, "jti-001", exp)
+
+    @pytest.mark.anyio
+    async def test_check_redis_connection_error_in_prod_raises(
+        self, _prod_settings: None
+    ) -> None:
+        redis = AsyncMock()
+        redis.exists = AsyncMock(side_effect=ConnectionError("down"))
+        with pytest.raises(RuntimeError, match="Redis connection failed"):
+            await is_token_denied(redis, "jti-001")
+
+
+# ── deny-list — non-PROD error resilience ────────────────────────
+
+
+class TestDenyListNonProdResilience:
+    """Verified by swarm worker B — non-PROD must degrade gracefully."""
+
+    @pytest.mark.anyio
+    async def test_deny_redis_connection_error_non_prod_warns(
+        self,
+    ) -> None:
+        redis = AsyncMock()
+        redis.setex = AsyncMock(side_effect=ConnectionError("down"))
+        exp = datetime.now(UTC) + timedelta(hours=1)
+        # Should NOT raise — the warning goes to structlog stdout, not caplog
+        await deny_token(redis, "jti-001", exp)
+        # No exception = pass
+
+    @pytest.mark.anyio
+    async def test_check_redis_connection_error_non_prod_warns(
+        self,
+    ) -> None:
+        redis = AsyncMock()
+        redis.exists = AsyncMock(side_effect=ConnectionError("down"))
+        result = await is_token_denied(redis, "jti-001")
+        assert result is False
+        # No exception = pass

--- a/tests/unit/eval/test_s45_ac_compliance.py
+++ b/tests/unit/eval/test_s45_ac_compliance.py
@@ -144,6 +144,16 @@ def test_regression_result_contains_correct_delta():
     assert regressions[0].batch_median == pytest.approx(0.50)
 
 
+@pytest.mark.spec("AC-45.02")
+def test_detect_regressions_skips_categories_absent_from_batch_medians():
+    pipeline = _make_pipeline()
+    baseline = {"QC-03": 0.78}
+
+    regressions = pipeline.detect_regressions(batch_medians={}, baseline=baseline)
+
+    assert regressions == []
+
+
 # ---------------------------------------------------------------------------
 # AC-45.03 — Langfuse logging
 
@@ -270,6 +280,51 @@ async def test_eval_cli_initializes_and_shuts_down_langfuse() -> None:
     init_langfuse.assert_called_once()
     shutdown_langfuse.assert_called_once()
     pipeline.run.assert_awaited_once()
+
+
+@pytest.mark.spec("AC-45.02")
+@pytest.mark.asyncio
+async def test_evaluate_sessions_passes_seed_manifest_to_evaluator() -> None:
+    pipeline = _make_pipeline()
+
+    playtest_report = MagicMock()
+    playtest_report.run_id = "run-123"
+    playtest_report.genesis_character_name = "Mira"
+    playtest_report.genesis_traits = ["cautious", "curious"]
+
+    run_result = MagicMock()
+    run_result.status = "complete"
+    run_result.run_id = "run-123"
+    run_result.scenario_seed_id = "bus-stop-shimmer"
+    run_result.playtest_report = playtest_report
+
+    fake_manifest = MagicMock()
+    fake_report = MagicMock()
+
+    evaluator = MagicMock()
+    evaluator.evaluate = AsyncMock(return_value=fake_report)
+
+    registry = MagicMock()
+    registry.get.return_value = fake_manifest
+
+    with (
+        patch(
+            "tta.quality.evaluator.NarrativeQualityEvaluator",
+            return_value=evaluator,
+        ),
+        patch("tta.seeds.SeedRegistry", return_value=registry),
+    ):
+        reports = await pipeline.evaluate_sessions([run_result])
+
+    assert reports == [fake_report]
+    registry.get.assert_called_once_with("bus-stop-shimmer")
+    evaluator.evaluate.assert_awaited_once_with(
+        playtest_report,
+        feedback=None,
+        seed=fake_manifest,
+        genesis_character_name="Mira",
+        genesis_traits=["cautious", "curious"],
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/genesis/test_genesis_lite.py
+++ b/tests/unit/genesis/test_genesis_lite.py
@@ -183,6 +183,7 @@ class _SequenceMockLLM:
                 "method": "generate",
                 "role": role,
                 "messages": messages,
+                "params": params,
             }
         )
         prompt_tokens = sum(len(m.content.split()) for m in messages)
@@ -409,6 +410,27 @@ class TestEnrichTemplate:
         assert len(result.locations) == 2
         assert result.locations[0].key == "tavern"
         assert "cozy tavern" in (result.locations[0].name.lower())
+
+    async def test_uses_structured_output_schema(self) -> None:
+        """Enrichment requests FMR structured output with the model schema."""
+        template = _make_test_template()
+        seed = _make_world_seed(template)
+        enrichment_json = _make_enrichment_json(template)
+        llm = MockLLMClient(response=enrichment_json)
+
+        await enrich_template(
+            template,
+            seed,
+            llm,
+        )
+
+        params = llm.call_history[0]["params"]
+        assert params is not None
+        assert params.response_format is not None
+        assert params.response_format["type"] == "json_schema"
+        json_schema = params.response_format["json_schema"]
+        assert json_schema["name"] == "enriched_template"
+        assert json_schema["strict"] is True
 
 
 # -- Tests: _default_enrichment ----------------------------------

--- a/tests/unit/llm/test_litellm_client.py
+++ b/tests/unit/llm/test_litellm_client.py
@@ -39,6 +39,13 @@ def _role_configs(
             max_tokens=100,
             timeout_seconds=5.0,
         ),
+        ModelRole.EXTRACTION: ModelRoleConfig(
+            primary=primary,
+            fallback=fallback,
+            temperature=0.0,
+            max_tokens=200,
+            timeout_seconds=5.0,
+        ),
     }
 
 
@@ -148,6 +155,43 @@ class TestGenerate:
         assert call_kwargs["temperature"] == 0.7
         assert call_kwargs["max_tokens"] == 100
 
+    @pytest.mark.asyncio
+    @patch(_COST, return_value=0.0)
+    @patch(_ACOMPLETION)
+    async def test_openai_models_pass_task_hint(
+        self, mock_ac: AsyncMock, mock_cost: MagicMock
+    ) -> None:
+        mock_ac.return_value = _mock_response()
+        client = LiteLLMClient(role_configs=_role_configs(primary="openai/tta"))
+
+        await client.generate(ModelRole.EXTRACTION, MESSAGES, PARAMS)
+
+        call_kwargs = mock_ac.call_args.kwargs
+        assert call_kwargs["task"] == "extraction"
+
+    @pytest.mark.asyncio
+    @patch(_COST, return_value=0.0)
+    @patch(_ACOMPLETION)
+    async def test_response_format_passed_through(
+        self, mock_ac: AsyncMock, mock_cost: MagicMock
+    ) -> None:
+        mock_ac.return_value = _mock_response(content='{"ok": true}')
+        client = LiteLLMClient(role_configs=_role_configs())
+        response_format = {"type": "json_object"}
+
+        await client.generate(
+            ModelRole.GENERATION,
+            MESSAGES,
+            GenerationParams(
+                temperature=0.0,
+                max_tokens=64,
+                response_format=response_format,
+            ),
+        )
+
+        call_kwargs = mock_ac.call_args.kwargs
+        assert call_kwargs["response_format"] == response_format
+
 
 # ── stream() tests ──────────────────────────────────────────────────
 
@@ -156,7 +200,9 @@ class TestStream:
     @pytest.mark.asyncio
     @patch(_COST, return_value=0.0)
     @patch(_ACOMPLETION)
-    async def test_happy_path(self, mock_ac: AsyncMock, mock_cost: MagicMock) -> None:
+    async def test_stream_happy_path(
+        self, mock_ac: AsyncMock, mock_cost: MagicMock
+    ) -> None:
         chunks = _mock_stream_chunks("Hello world")
         mock_ac.return_value = _async_iter(chunks)
         client = LiteLLMClient(role_configs=_role_configs())
@@ -168,6 +214,20 @@ class TestStream:
         assert "world" in resp.content
         assert resp.token_count.prompt_tokens == 10
         assert resp.token_count.completion_tokens == 5
+
+    @pytest.mark.asyncio
+    @patch(_COST, return_value=0.0)
+    @patch(_ACOMPLETION)
+    async def test_stream_openai_models_pass_task_hint(
+        self, mock_ac: AsyncMock, mock_cost: MagicMock
+    ) -> None:
+        mock_ac.return_value = _async_iter(_mock_stream_chunks("hi"))
+        client = LiteLLMClient(role_configs=_role_configs(primary="openai/tta"))
+
+        await client.stream(ModelRole.GENERATION, MESSAGES, PARAMS)
+
+        call_kwargs = mock_ac.call_args.kwargs
+        assert call_kwargs["task"] == "generation"
 
     @pytest.mark.asyncio
     @patch(_COST, return_value=0.0)

--- a/tests/unit/llm/test_llm_client.py
+++ b/tests/unit/llm/test_llm_client.py
@@ -46,12 +46,20 @@ class TestGenerationParams:
         assert params.temperature == 0.7
         assert params.max_tokens == 1024
         assert params.stop == []
+        assert params.response_format is None
 
     def test_custom_values(self) -> None:
-        params = GenerationParams(temperature=0.3, max_tokens=512, stop=["END"])
+        response_format = {"type": "json_object"}
+        params = GenerationParams(
+            temperature=0.3,
+            max_tokens=512,
+            stop=["END"],
+            response_format=response_format,
+        )
         assert params.temperature == 0.3
         assert params.max_tokens == 512
         assert params.stop == ["END"]
+        assert params.response_format == response_format
 
 
 class TestLLMResponse:

--- a/tests/unit/llm/test_semaphore.py
+++ b/tests/unit/llm/test_semaphore.py
@@ -96,6 +96,20 @@ async def test_timeout_cancels_request() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_allows_per_call_timeout_override() -> None:
+    """A call-specific timeout can exceed the semaphore default."""
+    sem = LLMSemaphore(max_concurrent=1, queue_size=5, timeout=1)
+
+    async def slow() -> str:
+        await asyncio.sleep(1.2)
+        return "done"
+
+    result = await sem.execute(slow, timeout=2)
+
+    assert result == "done"
+
+
+@pytest.mark.asyncio
 async def test_active_and_waiting_counts() -> None:
     """active and waiting properties reflect real state."""
     sem = LLMSemaphore(max_concurrent=1, queue_size=5, timeout=5)

--- a/tests/unit/llm/test_smart_router_client.py
+++ b/tests/unit/llm/test_smart_router_client.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from tta.llm.client import GenerationParams, Message, MessageRole
+from tta.llm.errors import PermanentLLMError, TransientLLMError
+from tta.llm.roles import ModelRole
+from tta.llm.smart_router_client import SmartRouterLLMClient
+
+MESSAGES = [Message(role=MessageRole.USER, content="look around")]
+PARAMS = GenerationParams(temperature=0.5, max_tokens=100)
+
+
+def _client_with_response(response: httpx.Response) -> SmartRouterLLMClient:
+    client = SmartRouterLLMClient()
+    request = httpx.Request("POST", "http://router.test/v1/chat/completions")
+    response.request = request
+    post = AsyncMock(return_value=response)
+    health = AsyncMock(return_value=httpx.Response(200, json={"status": "ok"}))
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self.post = post
+            self.get = health
+
+        async def aclose(self) -> None:
+            return None
+
+    client._client = DummyClient()  # type: ignore[assignment]
+    return client
+
+
+@pytest.mark.asyncio
+async def test_generation_uses_generation_task_hint() -> None:
+    client = _client_with_response(
+        httpx.Response(
+            200,
+            json={
+                "model": "meta/llama-4-maverick-17b-128e-instruct",
+                "choices": [{"message": {"content": "The plaza is quiet."}}],
+            },
+            headers={"X-Latency-Ms": "1234"},
+        )
+    )
+
+    response = await client.generate(ModelRole.GENERATION, MESSAGES, PARAMS)
+
+    assert response.content == "The plaza is quiet."
+    assert client.call_history[-1]["task"] == "generation"
+
+
+@pytest.mark.asyncio
+async def test_http_503_raises_transient_error() -> None:
+    client = _client_with_response(
+        httpx.Response(
+            503,
+            json={"error": {"message": "No providers available"}},
+        )
+    )
+
+    with pytest.raises(TransientLLMError):
+        await client.generate(ModelRole.GENERATION, MESSAGES, PARAMS)
+
+
+@pytest.mark.asyncio
+async def test_http_400_raises_permanent_error() -> None:
+    client = _client_with_response(
+        httpx.Response(
+            400,
+            json={"error": {"message": "bad request"}},
+        )
+    )
+
+    with pytest.raises(PermanentLLMError):
+        await client.generate(ModelRole.GENERATION, MESSAGES, PARAMS)
+
+
+@pytest.mark.asyncio
+async def test_transport_error_raises_transient_error() -> None:
+    client = SmartRouterLLMClient()
+
+    class DummyClient:
+        async def post(self, *args: object, **kwargs: object) -> httpx.Response:
+            raise httpx.ConnectError("boom")
+
+        async def aclose(self) -> None:
+            return None
+
+    client._client = DummyClient()  # type: ignore[assignment]
+
+    with pytest.raises(TransientLLMError):
+        await client.generate(ModelRole.GENERATION, MESSAGES, PARAMS)

--- a/tests/unit/pipeline/test_generate.py
+++ b/tests/unit/pipeline/test_generate.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Generator
 from typing import cast
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
+import structlog
 
 from tta.llm.client import LLMResponse
 from tta.llm.testing import MockLLMClient
@@ -21,6 +23,13 @@ from tta.pipeline.stages.generate import generate_stage
 from tta.pipeline.types import PipelineDeps
 from tta.prompts.loader import FilePromptRegistry
 from tta.safety.hooks import SafetyResult
+
+
+@pytest.fixture(autouse=True)
+def _reset_structlog() -> Generator[None, None, None]:
+    structlog.reset_defaults()
+    yield
+    structlog.reset_defaults()
 
 
 def _make_state(**overrides: object) -> TurnState:
@@ -355,6 +364,70 @@ async def test_extraction_returns_empty_on_invalid_json() -> None:
 
     # Mock response is "You enter a dimly lit chamber." — not JSON
     assert result.world_state_updates == []
+
+
+@pytest.mark.asyncio
+async def test_extraction_timeout_degrades_and_preserves_narrative() -> None:
+    """Extraction timeout should not discard a successful narrative."""
+    state = _make_state()
+    deps = _make_deps()
+    generation_response = LLMResponse(
+        content="Narrative text.",
+        model_used="mock",
+        token_count=TokenCount(prompt_tokens=5, completion_tokens=3, total_tokens=8),
+        latency_ms=0.0,
+    )
+
+    with (
+        patch(
+            "tta.pipeline.stages.generate._llm_with_retries",
+            new=AsyncMock(return_value=generation_response),
+        ),
+        patch(
+            "tta.pipeline.stages.generate._extract_world_changes",
+            new=AsyncMock(side_effect=TimeoutError()),
+        ),
+    ):
+        result = await generate_stage(state, deps)
+
+    assert result.narrative_output == "Narrative text."
+    assert result.model_used == "mock"
+    assert result.token_count == generation_response.token_count
+    assert result.world_state_updates == []
+    assert result.suggested_actions is None
+
+
+@pytest.mark.asyncio
+async def test_extraction_timeout_logs_boundary_details() -> None:
+    """Timeout logs should show we failed after narrative generation succeeded."""
+    state = _make_state()
+    deps = _make_deps()
+    generation_response = LLMResponse(
+        content="Narrative text.",
+        model_used="mock",
+        token_count=TokenCount(prompt_tokens=5, completion_tokens=3, total_tokens=8),
+        latency_ms=0.0,
+    )
+
+    with (
+        patch(
+            "tta.pipeline.stages.generate._llm_with_retries",
+            new=AsyncMock(return_value=generation_response),
+        ),
+        patch(
+            "tta.pipeline.stages.generate._extract_world_changes",
+            new=AsyncMock(side_effect=TimeoutError()),
+        ),
+        structlog.testing.capture_logs() as logs,
+    ):
+        await generate_stage(state, deps)
+
+    extraction_timeout_logs = [
+        entry for entry in logs if entry.get("event") == "generation_extraction_timeout"
+    ]
+    assert extraction_timeout_logs
+    assert extraction_timeout_logs[0]["model_used"] == "mock"
+    assert extraction_timeout_logs[0]["narrative_len"] == len("Narrative text.")
 
 
 async def test_extraction_returns_parsed_list() -> None:

--- a/tests/unit/pipeline/test_generate.py
+++ b/tests/unit/pipeline/test_generate.py
@@ -28,6 +28,14 @@ from tta.safety.hooks import SafetyResult
 @pytest.fixture(autouse=True)
 def _reset_structlog() -> Generator[None, None, None]:
     structlog.reset_defaults()
+    # Clear cached BoundLoggerLazyProxy bindings so capture_logs()
+    # mutates the correct default_processors list — same pattern as
+    # tests/unit/universe/conftest.py (_reset_structlog_for_universe).
+    from tta.pipeline.stages import generate as _gen_mod
+
+    gen_log = getattr(_gen_mod, "log", None)
+    if gen_log is not None and "bind" in gen_log.__dict__:
+        del gen_log.bind
     yield
     structlog.reset_defaults()
 

--- a/tests/unit/pipeline/test_generate_extraction_parse.py
+++ b/tests/unit/pipeline/test_generate_extraction_parse.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+
+
+class TestParseExtractionResponse:
+    def test_parses_clean_json_payload(self) -> None:
+        from tta.pipeline.stages.generate import _parse_extraction_response
+
+        payload = json.dumps(
+            {
+                "world_changes": [
+                    {
+                        "entity": "door",
+                        "attribute": "state",
+                        "old_value": "closed",
+                        "new_value": "open",
+                        "reason": "Player turned the handle",
+                    }
+                ],
+                "suggested_actions": ["Step through", "Listen carefully", "Look back"],
+            }
+        )
+
+        parsed = _parse_extraction_response(payload)
+
+        assert isinstance(parsed, dict)
+        assert parsed["world_changes"][0]["entity"] == "door"
+        assert parsed["suggested_actions"] == [
+            "Step through",
+            "Listen carefully",
+            "Look back",
+        ]
+
+    def test_extracts_json_from_markdown_fence(self) -> None:
+        from tta.pipeline.stages.generate import _parse_extraction_response
+
+        payload = (
+            "```json\n"
+            "{\n"
+            '  "world_changes": [{"entity": "passageway", "attribute": "visibility", '
+            '"old_value": "hidden", "new_value": "visible", '
+            '"reason": "A hidden latch released"}],\n'
+            '  "suggested_actions": ['
+            '"Enter the passage", "Inspect the latch", "Call out"]\n'
+            "}\n"
+            "```"
+        )
+
+        parsed = _parse_extraction_response(payload)
+
+        assert isinstance(parsed, dict)
+        assert parsed["world_changes"][0]["entity"] == "passageway"
+        assert parsed["suggested_actions"][2] == "Call out"
+
+    def test_extracts_json_object_from_surrounding_text(self) -> None:
+        from tta.pipeline.stages.generate import _parse_extraction_response
+
+        payload = (
+            "I found the result below.\n"
+            '{"world_changes": [{"entity": "torch", "attribute": "state", '
+            '"old_value": "unlit", "new_value": "lit", '
+            '"reason": "The player struck flint"}], '
+            '"suggested_actions": ["Advance", "Study the room", "Put out the torch"]}'
+            "\nUse it carefully."
+        )
+
+        parsed = _parse_extraction_response(payload)
+
+        assert isinstance(parsed, dict)
+        assert parsed["world_changes"][0]["new_value"] == "lit"
+        assert parsed["suggested_actions"][0] == "Advance"
+
+    def test_returns_none_for_unparseable_output(self) -> None:
+        from tta.pipeline.stages.generate import _parse_extraction_response
+
+        assert _parse_extraction_response("") is None
+        assert _parse_extraction_response("not json at all") is None
+        assert _parse_extraction_response("```json\n{broken\n```") is None

--- a/tests/unit/playtest/test_playtest.py
+++ b/tests/unit/playtest/test_playtest.py
@@ -7,6 +7,7 @@ needing async infrastructure or mocked HTTP/LLM.
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -113,6 +114,161 @@ def test_blank_commentary_fields() -> None:
     assert c.agent_intent == "(turn timed out)"
     assert c.coherence_rating == 0.0
     assert c.surprise_level == 0.0
+
+
+@pytest.mark.asyncio
+async def test_run_reuses_created_game_without_resume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ANON_GAME_LIMIT recovery reuses an internal 'created' game directly."""
+    from tta.llm.client import LLMResponse
+    from tta.models.turn import TokenCount
+    from tta.playtest.agent import PlaytesterAgent
+
+    class _DummyLLM:
+        async def generate(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            del args, kwargs
+            return LLMResponse(
+                content="look around",
+                model_used="dummy",
+                token_count=TokenCount(
+                    prompt_tokens=1,
+                    completion_tokens=1,
+                    total_tokens=2,
+                ),
+                latency_ms=0.0,
+            )
+
+    class _FakeResponse:
+        def __init__(self, status_code: int, payload: dict) -> None:
+            self.status_code = status_code
+            self._payload = payload
+            self.headers: dict[str, str] = {}
+
+        def json(self) -> dict:
+            return self._payload
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise RuntimeError(f"HTTP {self.status_code}")
+
+    agent = PlaytesterAgent("http://example.test", _DummyLLM())
+    agent.setup("seed-1", "curious-explorer", 123)
+
+    request_log: list[tuple[str, str]] = []
+    game_id = "11111111-1111-1111-1111-111111111111"
+
+    async def _fake_request_with_backoff(self, client, method, url, **kwargs):  # type: ignore[no-untyped-def]
+        del self, client, kwargs
+        request_log.append((method, url))
+        if (method, url) == ("POST", "/api/v1/auth/anonymous"):
+            return _FakeResponse(200, {"data": {"access_token": "tok"}})
+        if (method, url) == ("PATCH", "/api/v1/players/me/consent"):
+            return _FakeResponse(200, {"data": {"ok": True}})
+        if (method, url) == ("POST", "/api/v1/games"):
+            return _FakeResponse(403, {"error": {"code": "ANON_GAME_LIMIT"}})
+        if (method, url) == ("POST", f"/api/v1/games/{game_id}/turns"):
+            return _FakeResponse(
+                202,
+                {
+                    "data": {
+                        "turn_id": "turn-1",
+                        "stream_url": f"/api/v1/games/{game_id}/stream",
+                    }
+                },
+            )
+        raise AssertionError(f"unexpected request: {(method, url)!r}")
+
+    async def _fake_consume_turn_stream(self, client, stream_url, turn_id):  # type: ignore[no-untyped-def]
+        del self, client, stream_url, turn_id
+        return "You see a quiet tavern."
+
+    async def _fake_generate_player_input(self, narrative, turn_index, temperature):  # type: ignore[no-untyped-def]
+        del self, narrative, turn_index, temperature
+        return "Look around"
+
+    async def _fake_generate_commentary(  # type: ignore[no-untyped-def]
+        self, turn_index, prev_narrative, player_input, narrative_output
+    ):
+        del self, prev_narrative, player_input, narrative_output
+        return SimpleNamespace(
+            turn_index=turn_index,
+            agent_intent="look around",
+            surprise_level=0.1,
+            surprise_note="steady",
+            coherence_rating=0.9,
+            coherence_note="coherent",
+        )
+
+    monkeypatch.setattr(
+        "tta.playtest.agent.PLAYTEST_MIN_TURNS",
+        1,
+    )
+    monkeypatch.setattr(
+        "tta.playtest.agent.PlaytesterAgent._request_with_backoff",
+        _fake_request_with_backoff,
+    )
+    monkeypatch.setattr(
+        "tta.playtest.agent.PlaytesterAgent._consume_turn_stream",
+        _fake_consume_turn_stream,
+    )
+    monkeypatch.setattr(
+        "tta.playtest.agent.PlaytesterAgent._generate_player_input",
+        _fake_generate_player_input,
+    )
+    monkeypatch.setattr(
+        "tta.playtest.agent.PlaytesterAgent._generate_commentary",
+        _fake_generate_commentary,
+    )
+
+    class _ListClient:
+        headers: dict[str, str] = {}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url: str):
+            request_log.append(("GET", url))
+            if url == "/api/v1/games":
+                return _FakeResponse(
+                    200,
+                    {
+                        "data": [
+                            {
+                                "game_id": game_id,
+                                "status": "active",
+                            }
+                        ]
+                    },
+                )
+            if url == f"/api/v1/games/{game_id}":
+                return _FakeResponse(
+                    200,
+                    {
+                        "data": {
+                            "game_id": game_id,
+                            "status": "created",
+                            "recent_turns": [],
+                        }
+                    },
+                )
+            raise AssertionError(f"unexpected GET: {url!r}")
+
+    monkeypatch.setattr(
+        "tta.playtest.agent.httpx.AsyncClient",
+        lambda *a, **k: _ListClient(),
+    )
+
+    report = await agent.run()
+
+    assert report.status == "complete"
+    assert report.game_id == game_id
+    assert ("GET", f"/api/v1/games/{game_id}") in request_log
+    assert ("POST", f"/api/v1/games/{game_id}/resume") not in request_log
+    assert ("POST", f"/api/v1/games/{game_id}/turns") in request_log
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/quality/test_s44_ac_compliance.py
+++ b/tests/unit/quality/test_s44_ac_compliance.py
@@ -199,6 +199,23 @@ async def test_qc04_notes_mention_enforcement_miss() -> None:
     assert "AC-2.3 enforcement miss" in qc04.notes
 
 
+@pytest.mark.spec("AC-44.03")
+@pytest.mark.asyncio
+async def test_qc04_not_evaluated_when_genesis_character_missing() -> None:
+    """AC-44.03: QC-04 is not_evaluated when genesis character metadata is absent."""
+    turns = [make_turn(turn_index=0, narrative="The dungeon is dark.")]
+    report = make_report(turns=turns, gameplay_turns_completed=1)
+    evaluator = NarrativeQualityEvaluator()
+
+    result = await evaluator.evaluate(report, genesis_character_name="")
+
+    qc04 = result.category(QC_CHARACTER_DEPTH)
+    assert qc04 is not None
+    assert qc04.status == "not_evaluated"
+    assert qc04.score is None
+    assert "missing genesis character metadata" in qc04.notes.lower()
+
+
 # ---------------------------------------------------------------------------
 # AC-44.04 — verdict=fail when any scored category < 0.40
 # ---------------------------------------------------------------------------
@@ -208,14 +225,24 @@ async def test_qc04_notes_mention_enforcement_miss() -> None:
 @pytest.mark.asyncio
 async def test_verdict_fail_when_individual_category_below_threshold() -> None:
     """AC-44.04: verdict=fail when any scored category < 0.40; fail_reasons set."""
-    # Force QC-01 low: coherence_rating = 0.1 across all turns → below 0.4
+    # Keep QC-04 evaluable so the verdict exercises the fail threshold, not
+    # the inconclusive path from missing metadata.
     turns = [
-        make_turn(turn_index=i, coherence_rating=0.1, surprise_level=0.8)
+        make_turn(
+            turn_index=i,
+            narrative="Arika presses deeper into the ruins.",
+            coherence_rating=0.1,
+            surprise_level=0.8,
+        )
         for i in range(5)
     ]
     report = make_report(turns=turns, gameplay_turns_completed=5)
     evaluator = NarrativeQualityEvaluator()
-    result = await evaluator.evaluate(report, consequence_count=0)
+    result = await evaluator.evaluate(
+        report,
+        genesis_character_name="Arika",
+        consequence_count=0,
+    )
 
     assert result.verdict == "fail"
     assert len(result.fail_reasons) > 0

--- a/tests/unit/test_s15_observability.py
+++ b/tests/unit/test_s15_observability.py
@@ -532,6 +532,69 @@ async def test_guarded_llm_call_creates_otel_span():
     assert "llm.latency_ms" in recorded_attrs
 
 
+@pytest.mark.asyncio
+async def test_guarded_llm_call_passes_role_timeout_to_semaphore():
+    """Role-config timeout is forwarded to the semaphore wrapper."""
+    from tta.llm.roles import ModelRole, ModelRoleConfig
+    from tta.pipeline.llm_guard import guarded_llm_call
+
+    response = _make_llm_response()
+    mock_llm = AsyncMock()
+    mock_llm.generate = AsyncMock(return_value=response)
+    mock_semaphore = AsyncMock(return_value=response)
+
+    deps = SimpleNamespace(
+        llm=mock_llm,
+        llm_semaphore=SimpleNamespace(execute=mock_semaphore),
+        llm_circuit_breaker=None,
+        llm_role_configs={
+            ModelRole.GENERATION: ModelRoleConfig(
+                primary="openai/tta",
+                fallback="openai/tta",
+                temperature=0.85,
+                max_tokens=1024,
+                timeout_seconds=90.0,
+            )
+        },
+        settings=SimpleNamespace(
+            session_cost_cap_usd=100.0,
+            session_cost_warn_pct=0.8,
+            turn_cost_cap_usd=10.0,
+        ),
+    )
+
+    mock_tracker = MagicMock()
+    mock_tracker.check_session_budget.return_value = "ok"
+    mock_tracker.turn_cost_usd = 0.0
+
+    class FakeSpan:
+        def set_attribute(self, key: str, value: Any) -> None:
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args: Any):
+            pass
+
+    class FakeTracer:
+        def start_as_current_span(self, name: str, **kwargs: Any):
+            return FakeSpan()
+
+    with (
+        patch("tta.pipeline.llm_guard.get_cost_tracker", return_value=mock_tracker),
+        patch("tta.pipeline.llm_guard.trace") as mock_trace,
+        patch("tta.pipeline.llm_guard.record_llm_generation"),
+        patch("tta.pipeline.llm_guard.record_daily_cost"),
+        patch("tta.pipeline.llm_guard.current_trace_id", return_value="trace-abc"),
+    ):
+        mock_trace.get_tracer.return_value = FakeTracer()
+        await guarded_llm_call(deps, ModelRole.GENERATION, [])  # type: ignore[arg-type]
+
+    mock_semaphore.assert_called_once()
+    assert mock_semaphore.call_args.kwargs["timeout"] == 90.0
+
+
 # ---------------------------------------------------------------------------
 # Langfuse–OTel linkage (AC-14)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Hardens the narrative generation pipeline across extraction parsing, LLM client routing, and genesis degradation handling.

### Changes

**Extraction hardening** (`generate.py`)
- Add `_parse_extraction_response()` — robust JSON extraction from generation output, handling fenced JSON, embedded objects, and prose-wrapped payloads
- Add structured logging for generation with world context diagnostics

**LLM client hardening** (`litellm_client.py`, `client.py`, `smart_router_client.py`)
- Task-aware router hints via `_router_task_for_model()`
- Structured output contracts for enrichment calls
- Transient vs permanent error distinction
- Serving profiles integration (`serving_profiles.py`) — opt-in, respects legacy callers

**Genesis degradation** (`genesis_lite.py`, `games.py`)
- Persist explicit genesis status metadata on timeout
- Add `GenesisStatus` enum for degradation tracking
- Timeout → degraded path preserves game creation

**Playtester agent** (`agent.py`)
- SSE turn completion hardening
- Timeout handling improvements

**Observability** (`langfuse.py`)
- Per-generation inline scoring (`FB-005`, `AC-09.8`)

**Tests**
- New: extraction parsing tests, smart router client tests, JWT edge case tests
- Extended: playtest, genesis, pipeline, observability test coverage

### Risk
Low. Backward-compatible. Serving profiles are opt-in; legacy callers fall through to role config defaults.