### PR TITLE
feat: complete S64 generation profile routing

### DIFF
--- a/migrations/postgres/versions/014_generation_profile.py
+++ b/migrations/postgres/versions/014_generation_profile.py
@@ -1,0 +1,32 @@
+"""Add generation_profile column to game_sessions (S64 Phase 3).
+
+Stores the canonical generation serving profile selected for a session.
+Default is 'balanced' per S64 FR-64.02.
+
+Revision ID: 014
+Revises: 013
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "014"
+down_revision = "013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "game_sessions",
+        sa.Column(
+            "generation_profile",
+            sa.Text(),
+            nullable=False,
+            server_default="balanced",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("game_sessions", "generation_profile")

--- a/plans/serving-profiles-phase3.md
+++ b/plans/serving-profiles-phase3.md
@@ -1,0 +1,62 @@
+# S64 Phase 3 — Session Preference Plumbing
+
+> **Parent**: plans/generation-serving-profiles.md §11
+> **Status**: 📝 Draft → executing
+> **Dependencies**: S64 Phases 1-2 complete (PR #215)
+
+## Goal
+
+Thread `generation_profile` from session creation → DB persistence → API responses
+→ turn pipeline → LLM client. Players get `balanced` by default; explicit selection
+survives resume/restore.
+
+## Steps
+
+### 1. DB migration (014)
+- Add `generation_profile TEXT NOT NULL DEFAULT 'balanced'` to `game_sessions`
+- Backfill: not needed (DEFAULT handles existing rows)
+
+### 2. Domain model
+- `GameSession` — add `generation_profile: str = "balanced"`
+- `TurnState` — add `generation_profile: str | None = None`
+
+### 3. API models
+- `CreateGameRequest` — add `generation_profile: str | None` with enum validation
+- `GameData` — add `generation_profile: str`
+- `GameSummary` — add `generation_profile: str`
+
+### 4. API routes
+- `create_game` — validate, store in DB, return in response
+- `get_game_state` / `list_games` — include profile in response
+- `submit_turn` — read profile from row, set on TurnState
+
+### 5. Pipeline threading
+- `dispatch_pipeline` — accept `generation_profile` param, set on TurnState
+- `generate_stage` / `_generate_narrative` — pass profile to `guarded_llm_call`
+- `guarded_llm_call` — accept `generation_profile`/`traffic_class`, forward to `deps.llm.generate()`
+
+### 6. Lifecycle
+- resume/restore routes preserve stored profile
+
+### 7. Admin
+- `admin_games.py` returns profile
+
+### 8. Tests
+- unit: model validation, profile rejection
+- unit: migration structure
+- integration: create with profile, restore preserves profile
+
+## Files touched
+- `migrations/postgres/versions/014_generation_profile.py` (NEW)
+- `src/tta/models/game.py` (GameSession, CreateGameRequest, GameData, GameSummary)
+- `src/tta/models/turn.py` (TurnState)
+- `src/tta/api/routes/games.py` (create, list, get)
+- `src/tta/api/routes/games_turns.py` (submit_turn)
+- `src/tta/api/routes/games_lifecycle.py` (resume/restore)
+- `src/tta/api/routes/admin_games.py` (if exists)
+- `src/tta/pipeline/orchestrator.py` (dispatch_pipeline)
+- `src/tta/pipeline/llm_guard.py` (guarded_llm_call)
+- `src/tta/pipeline/stages/generate.py` (generate_stage, _generate_narrative)
+- `src/tta/persistence/postgres_game.py` (all queries)
+- `tests/unit/models/test_game_models.py` (new/existing)
+- `tests/unit/test_migration_014.py` (NEW)

--- a/plans/system.md
+++ b/plans/system.md
@@ -301,12 +301,13 @@ CREATE INDEX idx_player_sessions_player ON player_sessions(player_id);
 
 -- Game sessions
 CREATE TABLE game_sessions (
-    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    player_id   UUID NOT NULL REFERENCES players(id),
-    status      TEXT NOT NULL DEFAULT 'active',  -- active, paused, completed
-    world_seed  JSONB NOT NULL,                  -- Genesis output
-    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    player_id           UUID NOT NULL REFERENCES players(id),
+    status              TEXT NOT NULL DEFAULT 'active',  -- active, paused, completed
+    world_seed          JSONB NOT NULL,                  -- Genesis output
+    generation_profile  TEXT NOT NULL DEFAULT 'balanced',  -- S64: fast | balanced | quality
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 -- Turn transcripts (append-only, durable record of each turn)

--- a/src/tta/api/routes/admin_games.py
+++ b/src/tta/api/routes/admin_games.py
@@ -54,7 +54,7 @@ async def get_game(
         row = await session.execute(
             sa.text(
                 "SELECT id, player_id, status, world_seed, title, "
-                "summary, turn_count, needs_recovery, "
+                "summary, turn_count, needs_recovery, generation_profile, "
                 "last_played_at, created_at, updated_at "
                 "FROM game_sessions WHERE id = :gid"
             ),
@@ -81,6 +81,7 @@ async def get_game(
             "player_id": str(game.player_id),
             "status": game.status,
             "world_seed": game.world_seed,
+            "generation_profile": getattr(game, "generation_profile", None) or "balanced",
             "title": game.title,
             "summary": game.summary,
             "turn_count": game.turn_count,

--- a/src/tta/api/routes/admin_games.py
+++ b/src/tta/api/routes/admin_games.py
@@ -15,6 +15,7 @@ from tta.admin.auth import AdminIdentity, require_admin
 from tta.api.errors import AppError
 from tta.api.routes._admin_helpers import audit
 from tta.errors import ErrorCategory
+from tta.llm.serving_profiles import coerce_generation_profile
 from tta.models.admin import TerminateRequest
 from tta.observability.metrics import SESSIONS_ACTIVE
 from tta.persistence.redis_session import evict_game_state
@@ -75,13 +76,21 @@ async def get_game(
     if recorder is not None:
         flags = await recorder.query(game_id=str(game_id), limit=20)
 
+    raw_generation_profile = getattr(game, "generation_profile", None)
+    try:
+        generation_profile = coerce_generation_profile(
+            raw_generation_profile if isinstance(raw_generation_profile, str) else None
+        ).value
+    except ValueError:
+        generation_profile = coerce_generation_profile(None).value
+
     return JSONResponse(
         content={
             "game_id": str(game.id),
             "player_id": str(game.player_id),
             "status": game.status,
             "world_seed": game.world_seed,
-            "generation_profile": getattr(game, "generation_profile", None) or "balanced",
+            "generation_profile": generation_profile,
             "title": game.title,
             "summary": game.summary,
             "turn_count": game.turn_count,

--- a/src/tta/api/routes/games.py
+++ b/src/tta/api/routes/games.py
@@ -154,25 +154,28 @@ async def create_game(
         for key, value in pref.items()
         if key in _GENESIS_SEED_KEYS and isinstance(value, str)
     }
+    profile = body.generation_profile or "balanced"
     world_seed_json = {
         "world_id": body.world_id,
         "preferences": seed_preferences,
+        "generation_profile": profile,
     }
 
     # Persist game row first — game exists even if genesis fails (S01)
     await pg.execute(
         sa.text(
             "INSERT INTO game_sessions "
-            "(id, player_id, status, world_seed, "
+            "(id, player_id, status, world_seed, generation_profile, "
             "created_at, updated_at, last_played_at) "
             "VALUES (:id, :pid, :status, "
-            "cast(:seed AS jsonb), :now, :now, :now)"
+            "cast(:seed AS jsonb), :profile, :now, :now, :now)"
         ),
         {
             "id": game_id,
             "pid": player.id,
             "status": GameStatus.created.value,
             "seed": json.dumps(world_seed_json),
+            "profile": profile,
             "now": now,
         },
     )
@@ -336,6 +339,7 @@ async def create_game(
             player_id=str(player.id),
             status=GameStatus.active.value,
             turn_count=0,
+            generation_profile=profile,
             narrative_intro=narrative_intro,
             genesis_status=genesis_status,
             genesis_error_code=genesis_error_code,
@@ -385,7 +389,7 @@ async def list_games(
     result = await pg.execute(
         sa.text(
             f"SELECT gs.id, gs.player_id, gs.status, gs.world_seed, "  # noqa: S608
-            f"gs.title, gs.summary, "
+            f"gs.title, gs.summary, gs.generation_profile, "
             f"COALESCE(tc.cnt, 0) AS turn_count, "
             f"gs.created_at, gs.updated_at, gs.last_played_at "
             f"FROM game_sessions gs "
@@ -409,6 +413,7 @@ async def list_games(
             game_id=str(r.id),
             status=_PUBLIC_STATE_MAP.get(r.status or "", r.status or ""),
             turn_count=r.turn_count or 0,
+            generation_profile=getattr(r, "generation_profile", None) or "balanced",
             title=r.title,
             summary=r.summary,
             created_at=r.created_at,
@@ -481,6 +486,7 @@ async def get_game_state(
             "player_id": str(row.player_id),
             "status": row.status,
             "turn_count": turn_count,
+            "generation_profile": getattr(row, "generation_profile", None) or "balanced",
             "title": row.title,
             "summary": row.summary,
             "created_at": row.created_at.isoformat(),

--- a/src/tta/api/routes/games.py
+++ b/src/tta/api/routes/games.py
@@ -229,6 +229,7 @@ async def create_game(
                 world_seed=seed,
                 llm=request.app.state.llm_client,
                 world_service=request.app.state.world_service,
+                generation_profile=profile,
             ),
             timeout=genesis_budget_seconds,
         )
@@ -486,7 +487,9 @@ async def get_game_state(
             "player_id": str(row.player_id),
             "status": row.status,
             "turn_count": turn_count,
-            "generation_profile": getattr(row, "generation_profile", None) or "balanced",
+            "generation_profile": (
+                getattr(row, "generation_profile", None) or "balanced"
+            ),
             "title": row.title,
             "summary": row.summary,
             "created_at": row.created_at.isoformat(),

--- a/src/tta/api/routes/games_helpers.py
+++ b/src/tta/api/routes/games_helpers.py
@@ -24,7 +24,7 @@ async def _get_owned_game(pg: AsyncSession, game_id: UUID, player: Player) -> sa
             "SELECT id, player_id, status, world_seed, "
             "title, summary, turn_count, last_played_at, "
             "deleted_at, needs_recovery, summary_generated_at, "
-            "total_cost_usd, cost_warning_sent, "
+            "total_cost_usd, cost_warning_sent, generation_profile, "
             "created_at, updated_at "
             "FROM game_sessions WHERE id = :id AND deleted_at IS NULL"
         ),

--- a/src/tta/api/routes/games_lifecycle.py
+++ b/src/tta/api/routes/games_lifecycle.py
@@ -254,6 +254,7 @@ async def resume_game(
             "player_id": str(row.player_id),
             "status": "active",
             "turn_count": turn_count,
+            "generation_profile": getattr(row, "generation_profile", None) or "balanced",
             "title": row.title,
             "context_summary": context_summary,
             "recap": recap,

--- a/src/tta/api/routes/games_lifecycle.py
+++ b/src/tta/api/routes/games_lifecycle.py
@@ -254,7 +254,9 @@ async def resume_game(
             "player_id": str(row.player_id),
             "status": "active",
             "turn_count": turn_count,
-            "generation_profile": getattr(row, "generation_profile", None) or "balanced",
+            "generation_profile": (
+                getattr(row, "generation_profile", None) or "balanced"
+            ),
             "title": row.title,
             "context_summary": context_summary,
             "recap": recap,

--- a/src/tta/api/routes/games_turns.py
+++ b/src/tta/api/routes/games_turns.py
@@ -351,6 +351,7 @@ async def submit_turn(
             game_state=game_state,
             session_cost_usd=float(getattr(row, "total_cost_usd", 0) or 0),
             player_id=str(player.id),
+            generation_profile=getattr(row, "generation_profile", None),
         )
     )
 

--- a/src/tta/api/routes/games_turns.py
+++ b/src/tta/api/routes/games_turns.py
@@ -352,6 +352,7 @@ async def submit_turn(
             session_cost_usd=float(getattr(row, "total_cost_usd", 0) or 0),
             player_id=str(player.id),
             generation_profile=getattr(row, "generation_profile", None),
+            traffic_class=body.traffic_class,
         )
     )
 

--- a/src/tta/genesis/genesis_lite.py
+++ b/src/tta/genesis/genesis_lite.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import re
 from datetime import UTC, datetime
+from typing import Any
 from uuid import UUID
 
 import structlog
@@ -18,6 +19,7 @@ from tta.genesis.prompts import (
 )
 from tta.llm.client import GenerationParams, LLMClient, Message, MessageRole
 from tta.llm.roles import ModelRole
+from tta.llm.serving_profiles import GenerationServingProfile, coerce_generation_profile
 from tta.models.world import WorldSeed, WorldTemplate
 from tta.world.service import WorldService
 
@@ -100,6 +102,8 @@ async def run_genesis_lite(
     world_seed: WorldSeed,
     llm: LLMClient,
     world_service: WorldService,
+    *,
+    generation_profile: GenerationServingProfile | str | None = None,
 ) -> GenesisResult:
     """Bootstrap a new game world from a seed and template.
 
@@ -114,6 +118,11 @@ async def run_genesis_lite(
     """
     template = world_seed.template
     template_key = template.metadata.template_key
+    resolved_generation_profile = (
+        coerce_generation_profile(generation_profile)
+        if generation_profile is not None
+        else None
+    )
     log.info(
         "genesis_lite_start",
         session_id=str(session_id),
@@ -126,6 +135,7 @@ async def run_genesis_lite(
         world_seed,
         llm,
         session_id=session_id,
+        generation_profile=resolved_generation_profile,
     )
 
     # 2 — build enriched seed and materialise the world graph
@@ -153,6 +163,7 @@ async def run_genesis_lite(
         location_name=loc_name,
         location_description=loc_desc,
         world_seed=world_seed,
+        generation_profile=resolved_generation_profile,
     )
 
     # 5 — extract genesis elements for post-genesis continuity
@@ -186,6 +197,7 @@ async def enrich_template(
     llm: LLMClient,
     *,
     session_id: UUID | None = None,
+    generation_profile: GenerationServingProfile | str | None = None,
 ) -> EnrichedTemplate:
     """Ask the LLM to generate names / descriptions.
 
@@ -201,6 +213,11 @@ async def enrich_template(
     (S02 AC-2.6).
     """
     # Defensive expansion for terse inputs (AC-2.8)
+    resolved_generation_profile = (
+        coerce_generation_profile(generation_profile)
+        if generation_profile is not None
+        else None
+    )
     tone = world_seed.tone or "mysterious"
     tech_level = world_seed.tech_level or "medieval"
     magic_presence = world_seed.magic_presence or "low"
@@ -251,6 +268,12 @@ async def enrich_template(
         ),
     ]
 
+    call_kwargs: dict[str, Any] = (
+        {"generation_profile": resolved_generation_profile}
+        if resolved_generation_profile is not None
+        else {}
+    )
+
     # --- first attempt ---
     response = await llm.generate(
         ModelRole.EXTRACTION,
@@ -260,6 +283,7 @@ async def enrich_template(
             max_tokens=2048,
             response_format=_enrichment_response_format(),
         ),
+        **call_kwargs,
     )
     first_error_msg: str | None = None
     try:
@@ -296,6 +320,7 @@ async def enrich_template(
             max_tokens=2048,
             response_format=_enrichment_response_format(),
         ),
+        **call_kwargs,
     )
     try:
         return _parse_enrichment(response.content)
@@ -482,6 +507,7 @@ async def _generate_intro(
     location_name: str,
     location_description: str,
     world_seed: WorldSeed,
+    generation_profile: GenerationServingProfile | str | None = None,
 ) -> str:
     """Generate a narrative intro paragraph via LLM."""
     user_prompt = INTRO_USER_PROMPT.format(
@@ -500,8 +526,19 @@ async def _generate_intro(
             content=user_prompt,
         ),
     ]
+    resolved_generation_profile = (
+        coerce_generation_profile(generation_profile)
+        if generation_profile is not None
+        else None
+    )
+    call_kwargs: dict[str, Any] = (
+        {"generation_profile": resolved_generation_profile}
+        if resolved_generation_profile is not None
+        else {}
+    )
     response = await llm.generate(
         ModelRole.GENERATION,
         messages,
+        **call_kwargs,
     )
     return response.content

--- a/src/tta/llm/rate_limiter.py
+++ b/src/tta/llm/rate_limiter.py
@@ -224,6 +224,8 @@ class RateLimitedLLMClient:
         *,
         tier: TaskPriority = TaskPriority.CRITICAL,
         task_type: str = "",
+        generation_profile=None,
+        traffic_class=None,
     ):
         """Generate with admission control per tier.
 
@@ -231,7 +233,15 @@ class RateLimitedLLMClient:
         """
         await self._enforce(tier, task_type)
         try:
-            return await self._inner.generate(role, messages, params)
+            if generation_profile is None and traffic_class is None:
+                return await self._inner.generate(role, messages, params)
+            return await self._inner.generate(
+                role,
+                messages,
+                params,
+                generation_profile=generation_profile,
+                traffic_class=traffic_class,
+            )
         finally:
             if tier != TaskPriority.CRITICAL:
                 await self._budget.release(tier)
@@ -244,11 +254,21 @@ class RateLimitedLLMClient:
         *,
         tier: TaskPriority = TaskPriority.CRITICAL,
         task_type: str = "",
+        generation_profile=None,
+        traffic_class=None,
     ):
         """Stream with admission control per tier."""
         await self._enforce(tier, task_type)
         try:
-            return await self._inner.stream(role, messages, params)
+            if generation_profile is None and traffic_class is None:
+                return await self._inner.stream(role, messages, params)
+            return await self._inner.stream(
+                role,
+                messages,
+                params,
+                generation_profile=generation_profile,
+                traffic_class=traffic_class,
+            )
         finally:
             if tier != TaskPriority.CRITICAL:
                 await self._budget.release(tier)

--- a/src/tta/models/game.py
+++ b/src/tta/models/game.py
@@ -95,6 +95,14 @@ class SubmitTurnRequest(BaseModel):
         None,
         description="Client-generated UUID for deduplication.",
     )
+    traffic_class: str | None = Field(
+        None,
+        description=(
+            "Optional generation traffic class for non-interactive clients "
+            "such as eval batches."
+        ),
+        pattern="^(interactive_player|interactive_smoke|bulk_eval|quality_benchmark)$",
+    )
 
     @field_validator("input")
     @classmethod

--- a/src/tta/models/game.py
+++ b/src/tta/models/game.py
@@ -50,6 +50,7 @@ class GameSession(BaseModel):
     last_played_at: datetime | None = None
     paused_at: datetime | None = None
     deleted_at: datetime | None = None
+    generation_profile: str = "balanced"
 
 
 class GameState(BaseModel):
@@ -70,6 +71,11 @@ class GameState(BaseModel):
 class CreateGameRequest(BaseModel):
     world_id: str | None = None
     preferences: dict[str, str | list[str]] = Field(default_factory=dict)
+    generation_profile: str | None = Field(
+        None,
+        description="Canonical generation serving profile: fast, balanced, or quality.",
+        pattern="^(fast|balanced|quality)$",
+    )
 
 
 _ZERO_WIDTH_CHARS = str.maketrans(
@@ -122,6 +128,7 @@ class GameData(BaseModel):
     player_id: str
     status: str
     turn_count: int
+    generation_profile: str = "balanced"
     title: str | None = None
     summary: str | None = None
     narrative_intro: str | None = None
@@ -139,6 +146,7 @@ class GameSummary(BaseModel):
     game_id: str
     status: str
     turn_count: int
+    generation_profile: str = "balanced"
     title: str | None = None
     summary: str | None = None
     created_at: datetime

--- a/src/tta/models/turn.py
+++ b/src/tta/models/turn.py
@@ -95,6 +95,9 @@ class TurnState(BaseModel):
     extraction_latency_ms: int | None = None
     context_partial: bool = False
 
+    # --- serving profiles (S64 Phase 3) ---
+    generation_profile: str | None = None
+
     # --- choice & consequence (S05) ---
     choice_classification: ChoiceClassification | None = None
     active_consequences: list[ConsequenceChain] | None = None

--- a/src/tta/models/turn.py
+++ b/src/tta/models/turn.py
@@ -97,6 +97,7 @@ class TurnState(BaseModel):
 
     # --- serving profiles (S64 Phase 3) ---
     generation_profile: str | None = None
+    traffic_class: str | None = None
 
     # --- choice & consequence (S05) ---
     choice_classification: ChoiceClassification | None = None

--- a/src/tta/persistence/postgres_game.py
+++ b/src/tta/persistence/postgres_game.py
@@ -30,7 +30,7 @@ class PostgresGameRepository:
                     "VALUES (:id, :player_id, "
                     "cast(:world_seed AS jsonb)) "
                     "RETURNING id, player_id, world_seed, "
-                    "status, total_cost_usd, cost_warning_sent, "
+                    "status, generation_profile, total_cost_usd, cost_warning_sent, "
                     "created_at, updated_at"
                 ),
                 {
@@ -46,6 +46,7 @@ class PostgresGameRepository:
                 player_id=row.player_id,
                 world_seed=row.world_seed,
                 status=GameStatus(row.status),
+                generation_profile=row.generation_profile or "balanced",
                 total_cost_usd=row.total_cost_usd,
                 cost_warning_sent=row.cost_warning_sent,
                 created_at=row.created_at,
@@ -58,7 +59,7 @@ class PostgresGameRepository:
                 sa.text(
                     "SELECT id, player_id, world_seed, status, "
                     "title, summary, turn_count, needs_recovery, "
-                    "total_cost_usd, cost_warning_sent, "
+                    "generation_profile, total_cost_usd, cost_warning_sent, "
                     "last_played_at, deleted_at, "
                     "created_at, updated_at "
                     "FROM game_sessions WHERE id = :id"
@@ -77,6 +78,7 @@ class PostgresGameRepository:
                 summary=row.summary,
                 turn_count=row.turn_count,
                 needs_recovery=row.needs_recovery,
+                generation_profile=row.generation_profile or "balanced",
                 total_cost_usd=row.total_cost_usd,
                 cost_warning_sent=row.cost_warning_sent,
                 last_played_at=row.last_played_at,
@@ -148,7 +150,7 @@ class PostgresGameRepository:
                 sa.text(
                     "SELECT id, player_id, world_seed, status, "
                     "title, summary, turn_count, needs_recovery, "
-                    "total_cost_usd, cost_warning_sent, "
+                    "generation_profile, total_cost_usd, cost_warning_sent, "
                     "last_played_at, deleted_at, "
                     "created_at, updated_at "
                     "FROM game_sessions "
@@ -169,6 +171,7 @@ class PostgresGameRepository:
                     summary=r.summary,
                     turn_count=r.turn_count,
                     needs_recovery=r.needs_recovery,
+                    generation_profile=r.generation_profile or "balanced",
                     total_cost_usd=r.total_cost_usd,
                     cost_warning_sent=r.cost_warning_sent,
                     last_played_at=r.last_played_at,

--- a/src/tta/pipeline/llm_guard.py
+++ b/src/tta/pipeline/llm_guard.py
@@ -22,7 +22,11 @@ from opentelemetry import trace
 from tta.llm.client import LLMResponse, Message
 from tta.llm.errors import BudgetExceededError
 from tta.llm.roles import ModelRole
-from tta.llm.serving_profiles import coerce_generation_profile
+from tta.llm.serving_profiles import (
+    GenerationTrafficClass,
+    coerce_generation_profile,
+    coerce_generation_traffic_class,
+)
 from tta.observability.daily_cost import record_daily_cost
 from tta.observability.langfuse import record_llm_generation
 from tta.observability.metrics import (
@@ -48,6 +52,7 @@ async def guarded_llm_call(
     prompt_hash: str | None = None,
     langfuse_prompt: Any | None = None,
     generation_profile: str | None = None,
+    traffic_class: GenerationTrafficClass | str | None = None,
 ) -> LLMResponse:
     """Call LLM with cost enforcement, semaphore, and circuit breaker.
 
@@ -89,6 +94,19 @@ async def guarded_llm_call(
                 model="",
             )
 
+    resolved_generation_profile = (
+        coerce_generation_profile(generation_profile) if generation_profile else None
+    )
+    resolved_traffic_class = (
+        coerce_generation_traffic_class(traffic_class) if traffic_class else None
+    )
+
+    llm_kwargs: dict[str, Any] = {}
+    if resolved_generation_profile is not None:
+        llm_kwargs["generation_profile"] = resolved_generation_profile
+    if resolved_traffic_class is not None:
+        llm_kwargs["traffic_class"] = resolved_traffic_class
+
     # --- LLM call with semaphore + circuit breaker ---
     async def _call() -> LLMResponse:
         if deps.llm_circuit_breaker:
@@ -96,20 +114,12 @@ async def guarded_llm_call(
                 return await deps.llm.generate(
                     role=role,
                     messages=messages,
-                    generation_profile=(
-                        coerce_generation_profile(generation_profile)
-                        if generation_profile
-                        else None
-                    ),
+                    **llm_kwargs,
                 )
         return await deps.llm.generate(
             role=role,
             messages=messages,
-            generation_profile=(
-                coerce_generation_profile(generation_profile)
-                if generation_profile
-                else None
-            ),
+            **llm_kwargs,
         )
 
     # Create OTel child span for this specific LLM call (AC-10)

--- a/src/tta/pipeline/llm_guard.py
+++ b/src/tta/pipeline/llm_guard.py
@@ -22,6 +22,7 @@ from opentelemetry import trace
 from tta.llm.client import LLMResponse, Message
 from tta.llm.errors import BudgetExceededError
 from tta.llm.roles import ModelRole
+from tta.llm.serving_profiles import coerce_generation_profile
 from tta.observability.daily_cost import record_daily_cost
 from tta.observability.langfuse import record_llm_generation
 from tta.observability.metrics import (
@@ -46,6 +47,7 @@ async def guarded_llm_call(
     fragment_versions: dict[str, str] | None = None,
     prompt_hash: str | None = None,
     langfuse_prompt: Any | None = None,
+    generation_profile: str | None = None,
 ) -> LLMResponse:
     """Call LLM with cost enforcement, semaphore, and circuit breaker.
 
@@ -91,8 +93,24 @@ async def guarded_llm_call(
     async def _call() -> LLMResponse:
         if deps.llm_circuit_breaker:
             async with deps.llm_circuit_breaker:
-                return await deps.llm.generate(role=role, messages=messages)
-        return await deps.llm.generate(role=role, messages=messages)
+                return await deps.llm.generate(
+                    role=role,
+                    messages=messages,
+                    generation_profile=(
+                        coerce_generation_profile(generation_profile)
+                        if generation_profile
+                        else None
+                    ),
+                )
+        return await deps.llm.generate(
+            role=role,
+            messages=messages,
+            generation_profile=(
+                coerce_generation_profile(generation_profile)
+                if generation_profile
+                else None
+            ),
+        )
 
     # Create OTel child span for this specific LLM call (AC-10)
     tracer = trace.get_tracer("tta")

--- a/src/tta/pipeline/orchestrator.py
+++ b/src/tta/pipeline/orchestrator.py
@@ -219,6 +219,7 @@ async def dispatch_pipeline(
     session_cost_usd: float = 0.0,
     player_id: str = "",
     generation_profile: str | None = None,
+    traffic_class: str | None = None,
 ) -> None:
     """Run the pipeline as a background task and persist results.
 
@@ -253,6 +254,7 @@ async def dispatch_pipeline(
         player_input=player_input,
         game_state=game_state,
         generation_profile=generation_profile,
+        traffic_class=traffic_class,
     )
 
     log.info(

--- a/src/tta/pipeline/orchestrator.py
+++ b/src/tta/pipeline/orchestrator.py
@@ -218,6 +218,7 @@ async def dispatch_pipeline(
     game_state: dict,
     session_cost_usd: float = 0.0,
     player_id: str = "",
+    generation_profile: str | None = None,
 ) -> None:
     """Run the pipeline as a background task and persist results.
 
@@ -251,6 +252,7 @@ async def dispatch_pipeline(
         turn_number=turn_number,
         player_input=player_input,
         game_state=game_state,
+        generation_profile=generation_profile,
     )
 
     log.info(

--- a/src/tta/pipeline/stages/generate.py
+++ b/src/tta/pipeline/stages/generate.py
@@ -334,6 +334,7 @@ async def generate_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
             fragment_versions=rendered_system_prompt.fragment_versions,
             prompt_hash=rendered_system_prompt.prompt_hash,
             langfuse_prompt=rendered_system_prompt.metadata.get("langfuse_prompt"),
+            generation_profile=state.generation_profile,
         )
         llm_elapsed_ms = (time.monotonic() - llm_start) * 1000
         narrative = response.content
@@ -493,6 +494,7 @@ async def _llm_with_retries(
     fragment_versions: dict[str, str] | None = None,
     prompt_hash: str | None = None,
     langfuse_prompt: Any | None = None,
+    generation_profile: str | None = None,
 ) -> LLMResponse:
     """Call LLM with retry cascade for transient failures (S03 FR-8).
 
@@ -512,6 +514,7 @@ async def _llm_with_retries(
                 fragment_versions=fragment_versions,
                 prompt_hash=prompt_hash,
                 langfuse_prompt=langfuse_prompt,
+                generation_profile=generation_profile,
             )
         except (TransientLLMError, AllTiersFailedError) as exc:
             last_exc = exc

--- a/src/tta/pipeline/stages/generate.py
+++ b/src/tta/pipeline/stages/generate.py
@@ -335,6 +335,7 @@ async def generate_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
             prompt_hash=rendered_system_prompt.prompt_hash,
             langfuse_prompt=rendered_system_prompt.metadata.get("langfuse_prompt"),
             generation_profile=state.generation_profile,
+            traffic_class=state.traffic_class,
         )
         llm_elapsed_ms = (time.monotonic() - llm_start) * 1000
         narrative = response.content
@@ -414,7 +415,10 @@ async def generate_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
     extract_start = time.monotonic()
     try:
         world_updates, suggestions = await _extract_world_changes(
-            narrative, state.player_input, deps
+            narrative,
+            state.player_input,
+            deps,
+            traffic_class=state.traffic_class,
         )
     except TimeoutError:
         extract_elapsed_ms = (time.monotonic() - extract_start) * 1000
@@ -495,6 +499,7 @@ async def _llm_with_retries(
     prompt_hash: str | None = None,
     langfuse_prompt: Any | None = None,
     generation_profile: str | None = None,
+    traffic_class: str | None = None,
 ) -> LLMResponse:
     """Call LLM with retry cascade for transient failures (S03 FR-8).
 
@@ -503,6 +508,13 @@ async def _llm_with_retries(
     Raises on non-transient or all-tiers-exhausted errors.
     """
     last_exc: Exception | None = None
+    serving_kwargs: dict[str, Any] = {}
+    if generation_profile is not None:
+        serving_kwargs["generation_profile"] = generation_profile
+    resolved_traffic_class = traffic_class or state.traffic_class
+    if resolved_traffic_class is not None:
+        serving_kwargs["traffic_class"] = resolved_traffic_class
+
     for attempt in range(_MAX_TRANSIENT_RETRIES + 1):
         try:
             return await guarded_llm_call(
@@ -514,7 +526,7 @@ async def _llm_with_retries(
                 fragment_versions=fragment_versions,
                 prompt_hash=prompt_hash,
                 langfuse_prompt=langfuse_prompt,
-                generation_profile=generation_profile,
+                **serving_kwargs,
             )
         except (TransientLLMError, AllTiersFailedError) as exc:
             last_exc = exc
@@ -559,6 +571,8 @@ async def _extract_world_changes(
     narrative: str,
     player_input: str,
     deps: PipelineDeps,
+    *,
+    traffic_class: str | None = None,
 ) -> tuple[list[dict], list[str]]:
     """Extract world state changes and suggested actions from narrative.
 
@@ -597,6 +611,7 @@ async def _extract_world_changes(
             fragment_versions=extraction_prompt.fragment_versions,
             prompt_hash=extraction_prompt.prompt_hash,
             langfuse_prompt=extraction_prompt.metadata.get("langfuse_prompt"),
+            traffic_class=traffic_class,
         )
         parsed = _parse_extraction_response(response.content)
         if parsed is None:

--- a/src/tta/pipeline/stages/understand.py
+++ b/src/tta/pipeline/stages/understand.py
@@ -163,6 +163,7 @@ async def understand_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
                 fragment_versions=rendered.fragment_versions,
                 prompt_hash=rendered.prompt_hash,
                 langfuse_prompt=rendered.metadata.get("langfuse_prompt"),
+                traffic_class=state.traffic_class,
             )
             parsed = _parse_classification_response(response.content)
             if parsed is None:
@@ -177,6 +178,7 @@ async def understand_stage(state: TurnState, deps: PipelineDeps) -> TurnState:
                     fragment_versions=rendered.fragment_versions,
                     prompt_hash=rendered.prompt_hash,
                     langfuse_prompt=rendered.metadata.get("langfuse_prompt"),
+                    traffic_class=state.traffic_class,
                 )
                 parsed = _parse_classification_response(response.content)
             if parsed is None:

--- a/src/tta/playtest/agent.py
+++ b/src/tta/playtest/agent.py
@@ -366,7 +366,10 @@ class PlaytesterAgent:
             client,
             "POST",
             f"/api/v1/games/{self._game_id}/turns",
-            json={"input": player_input},
+            json={
+                "input": player_input,
+                "traffic_class": GenerationTrafficClass.BULK_EVAL.value,
+            },
         )
         turn_data = resp.json()["data"]
         turn_id = str(turn_data["turn_id"])

--- a/tests/unit/genesis/test_genesis_lite.py
+++ b/tests/unit/genesis/test_genesis_lite.py
@@ -17,6 +17,7 @@ from tta.llm.client import (
     Message,
 )
 from tta.llm.roles import ModelRole
+from tta.llm.serving_profiles import GenerationServingProfile
 from tta.llm.testing import MockLLMClient
 from tta.models.turn import TokenCount
 from tta.models.world import (
@@ -171,6 +172,9 @@ class _SequenceMockLLM:
         role: ModelRole,
         messages: list[Message],
         params: GenerationParams | None = None,
+        *,
+        generation_profile: str | None = None,
+        traffic_class: str | None = None,
     ) -> LLMResponse:
         idx = min(
             self._index,
@@ -184,6 +188,8 @@ class _SequenceMockLLM:
                 "role": role,
                 "messages": messages,
                 "params": params,
+                "generation_profile": generation_profile,
+                "traffic_class": traffic_class,
             }
         )
         prompt_tokens = sum(len(m.content.split()) for m in messages)
@@ -327,6 +333,36 @@ class TestRunGenesisLite:
         assert len(llm.call_history) == 2
         assert llm.call_history[0]["role"] == ModelRole.EXTRACTION
         assert llm.call_history[1]["role"] == ModelRole.GENERATION
+
+    async def test_generation_profile_propagates_to_genesis_llm_calls(
+        self,
+    ) -> None:
+        """Game-scoped serving profile is applied during genesis."""
+        # Arrange
+        template = _make_test_template()
+        seed = _make_world_seed(template)
+        enrichment_json = _make_enrichment_json(template)
+        llm = _SequenceMockLLM(
+            [enrichment_json, "Quality-profile intro."],
+        )
+        world_svc = InMemoryWorldService()
+
+        # Act
+        await run_genesis_lite(
+            session_id=uuid4(),
+            player_id=uuid4(),
+            world_seed=seed,
+            llm=llm,
+            world_service=world_svc,
+            generation_profile="quality",
+        )
+
+        # Assert — enrichment and intro calls both inherit game profile.
+        assert len(llm.call_history) == 2
+        assert [call["generation_profile"] for call in llm.call_history] == [
+            GenerationServingProfile.QUALITY,
+            GenerationServingProfile.QUALITY,
+        ]
 
     async def test_world_service_called_with_session(
         self,

--- a/tests/unit/llm/test_s64_ac_compliance.py
+++ b/tests/unit/llm/test_s64_ac_compliance.py
@@ -261,3 +261,66 @@ def test_ac64_06_run_result_records_profile() -> None:
         generation_profile="quality",
     )
     assert result.generation_profile == "quality"
+
+
+@pytest.mark.asyncio
+@pytest.mark.spec("AC-64.06")
+async def test_ac64_06_batch_turn_generation_uses_bulk_eval_traffic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Eval/batch turn pipeline LLM calls carry bulk_eval traffic class."""
+    from tta.models.turn import TokenCount, TurnState
+    from tta.pipeline.stages import generate as generate_stage_module
+    from tta.pipeline.types import PipelineDeps
+
+    captured: dict[str, object] = {}
+
+    async def fake_guarded_llm_call(*args: object, **kwargs: object):
+        captured.update(kwargs)
+        from tta.llm.client import LLMResponse
+
+        return LLMResponse(
+            content="batch narrative",
+            model_used="mock-model",
+            token_count=TokenCount(
+                prompt_tokens=1,
+                completion_tokens=1,
+                total_tokens=2,
+            ),
+            latency_ms=0.0,
+        )
+
+    monkeypatch.setattr(
+        generate_stage_module,
+        "guarded_llm_call",
+        fake_guarded_llm_call,
+    )
+
+    state = TurnState(
+        session_id="00000000-0000-0000-0000-000000000001",
+        turn_id="00000000-0000-0000-0000-000000000002",
+        turn_number=1,
+        player_input="look around",
+        game_state={},
+        generation_profile="quality",
+        traffic_class=GenerationTrafficClass.BULK_EVAL.value,
+    )
+    deps = PipelineDeps(
+        llm=object(),
+        world=object(),
+        session_repo=object(),
+        turn_repo=object(),
+        safety_pre_input=object(),
+        safety_pre_gen=object(),
+        safety_post_gen=object(),
+    )
+
+    await generate_stage_module._llm_with_retries(
+        [Message(role=MessageRole.USER, content="prompt")],
+        deps,
+        state,
+        generation_profile=state.generation_profile,
+    )
+
+    assert captured["generation_profile"] == "quality"
+    assert captured["traffic_class"] == GenerationTrafficClass.BULK_EVAL.value

--- a/tests/unit/playtest/test_playtest.py
+++ b/tests/unit/playtest/test_playtest.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from tta.llm.serving_profiles import GenerationTrafficClass
 from tta.playtest.agent import (
     DEFAULT_PLAYER_INPUT,
     MAX_PLAYER_INPUT_CHARS,
@@ -156,11 +157,13 @@ async def test_run_reuses_created_game_without_resume(
     agent.setup("seed-1", "curious-explorer", 123)
 
     request_log: list[tuple[str, str]] = []
+    request_payloads: dict[tuple[str, str], dict] = {}
     game_id = "11111111-1111-1111-1111-111111111111"
 
     async def _fake_request_with_backoff(self, client, method, url, **kwargs):  # type: ignore[no-untyped-def]
-        del self, client, kwargs
+        del self, client
         request_log.append((method, url))
+        request_payloads[(method, url)] = kwargs.get("json") or {}
         if (method, url) == ("POST", "/api/v1/auth/anonymous"):
             return _FakeResponse(200, {"data": {"access_token": "tok"}})
         if (method, url) == ("PATCH", "/api/v1/players/me/consent"):
@@ -268,7 +271,11 @@ async def test_run_reuses_created_game_without_resume(
     assert report.game_id == game_id
     assert ("GET", f"/api/v1/games/{game_id}") in request_log
     assert ("POST", f"/api/v1/games/{game_id}/resume") not in request_log
-    assert ("POST", f"/api/v1/games/{game_id}/turns") in request_log
+    turn_request = ("POST", f"/api/v1/games/{game_id}/turns")
+    assert turn_request in request_log
+    assert request_payloads[turn_request]["traffic_class"] == (
+        GenerationTrafficClass.BULK_EVAL.value
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_migration_014.py
+++ b/tests/unit/test_migration_014.py
@@ -6,15 +6,9 @@ against a live database (no Postgres required).
 
 import pathlib
 
-import pytest
-
 REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 MIGRATION_PATH = (
-    REPO_ROOT
-    / "migrations"
-    / "postgres"
-    / "versions"
-    / "014_generation_profile.py"
+    REPO_ROOT / "migrations" / "postgres" / "versions" / "014_generation_profile.py"
 )
 
 
@@ -52,6 +46,6 @@ def test_column_type_is_text():
 
 def test_downgrade_drops_column():
     src = MIGRATION_PATH.read_text()
-    downgrade_src = src[src.find("def downgrade"):]
+    downgrade_src = src[src.find("def downgrade") :]
     assert "drop_column" in downgrade_src
     assert "generation_profile" in downgrade_src

--- a/tests/unit/test_migration_014.py
+++ b/tests/unit/test_migration_014.py
@@ -1,0 +1,57 @@
+"""Unit tests for Alembic migration 014 structure (S64 Phase 3).
+
+Validates the generation_profile column addition without executing
+against a live database (no Postgres required).
+"""
+
+import pathlib
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
+MIGRATION_PATH = (
+    REPO_ROOT
+    / "migrations"
+    / "postgres"
+    / "versions"
+    / "014_generation_profile.py"
+)
+
+
+def test_migration_file_exists():
+    assert MIGRATION_PATH.exists(), f"Missing: {MIGRATION_PATH}"
+
+
+def test_migration_revision_constants():
+    src = MIGRATION_PATH.read_text()
+    assert 'revision = "014"' in src
+    assert 'down_revision = "013"' in src
+
+
+def test_adds_generation_profile_column():
+    src = MIGRATION_PATH.read_text()
+    assert "generation_profile" in src
+    assert "add_column" in src
+    assert "game_sessions" in src
+
+
+def test_column_is_not_nullable():
+    src = MIGRATION_PATH.read_text()
+    assert "nullable=False" in src
+
+
+def test_column_has_server_default():
+    src = MIGRATION_PATH.read_text()
+    assert 'server_default="balanced"' in src
+
+
+def test_column_type_is_text():
+    src = MIGRATION_PATH.read_text()
+    assert "sa.Text()" in src
+
+
+def test_downgrade_drops_column():
+    src = MIGRATION_PATH.read_text()
+    downgrade_src = src[src.find("def downgrade"):]
+    assert "drop_column" in downgrade_src
+    assert "generation_profile" in downgrade_src


### PR DESCRIPTION
## Summary
- Carries selected generation_profile through create-game genesis and turn generation paths
- Adds eval/batch traffic_class plumbing so playtester/eval turns use bulk_eval
- Hardens optional kwarg forwarding for legacy mocks/clients and admin profile serialization
- Adds unit coverage for genesis profile propagation, batch traffic class propagation, and playtester turn payloads

## Verification
- [x] Staged-only ruff check on changed files
- [x] Staged-only ruff format --check on changed files
- [x] Targeted pytest: 49 passed during staged-only gate
- [x] Targeted pytest after readability fix: 93 passed
- [x] Full unit suite: 2868 passed
- [x] Alembic current: 014 (head)
- [x] Local independent reviewer pass: no security_concerns, no logic_errors

## Notes
- No GitHub/Copilot review requested; local free-model reviewer was used.
- Narrow integration turn-cycle smoke did not reach app logic because tests/integration/conftest.py unconditionally ran Alembic and timed out in fixture setup despite TTA_SKIP_MIGRATIONS=1. Schema was verified separately with alembic current.
- Unrelated queue-readiness artifacts are intentionally left uncommitted on the local branch/worktree.
