### PR TITLE
docs: approve local gate governance specs

### DIFF
--- a/specs/65-local-ci-gate.md
+++ b/specs/65-local-ci-gate.md
@@ -1,6 +1,6 @@
 # S65 — Local CI Gate
 
-> **Status**: 🔍 Review
+> **Status**: ✅ Approved
 > **Layer**: Process / Developer Tooling
 > **Dependencies**: Makefile targets `check-format`, `lint`, `trace`, `validate-specs`, `validate-plans`, `validate-openapi`, `test-unit`, `test-integration`
 > **Last Updated**: 2026-05-26
@@ -126,10 +126,10 @@ Feature: Local CI gate
 
 ### Criteria Checklist
 
-- [ ] **AC-65.01**: `make gate` runs the standard local CI sequence.
-- [ ] **AC-65.02**: `make gate` exits non-zero when any prerequisite fails.
-- [ ] **AC-65.03**: `make gate-full` includes `test-integration` after `gate`.
-- [ ] **AC-65.04**: Both targets appear in `make help`.
+- [x] **AC-65.01**: `make gate` runs the standard local CI sequence.
+- [x] **AC-65.02**: `make gate` exits non-zero when any prerequisite fails.
+- [x] **AC-65.03**: `make gate-full` includes `test-integration` after `gate`.
+- [x] **AC-65.04**: Both targets appear in `make help`.
 
 ## 8. Dependencies & Integration Boundaries
 

--- a/specs/67-autonomous-queue-readiness-gate.md
+++ b/specs/67-autonomous-queue-readiness-gate.md
@@ -1,6 +1,6 @@
 # S67 — Autonomous Queue Readiness Gate
 
-> **Status**: 🔍 Review
+> **Status**: ✅ Approved
 > **Level**: Process — Autonomous Pipeline Governance
 > **Dependencies**: S65 (Local CI Gate), spec/plan indexes, `.hermes/pipeline/queue/FB-*.json`
 > **Last Updated**: 2026-05-26
@@ -133,10 +133,10 @@ Feature: Autonomous queue readiness gate
 
 ### Criteria Checklist
 
-- [ ] **AC-67.01**: Draft specs route to SPEC_POLISH, not IMPLEMENT.
-- [ ] **AC-67.02**: Duplicate spec IDs block queue routing.
-- [ ] **AC-67.03**: Bounded approved AC gaps can become IMPLEMENT candidates with validation commands.
-- [ ] **AC-67.04**: Strict mode exits non-zero when no implementation candidates exist.
+- [x] **AC-67.01**: Draft specs route to SPEC_POLISH, not IMPLEMENT.
+- [x] **AC-67.02**: Duplicate spec IDs block queue routing.
+- [x] **AC-67.03**: Bounded approved AC gaps can become IMPLEMENT candidates with validation commands.
+- [x] **AC-67.04**: Strict mode exits non-zero when no implementation candidates exist.
 
 ## 8. Dependencies & Integration Boundaries
 


### PR DESCRIPTION
## Summary
- promote S65 Local CI Gate from draft/review into approved canonical specs
- promote S67 Autonomous Queue Readiness Gate from draft/review into approved canonical specs
- mark AC checklist items complete based on current Makefile/queue-gate evidence

## Verification
- uv run ruff format --check scripts/queue_readiness_gate.py tests/unit/scripts/test_queue_readiness_gate.py
- uv run pytest tests/unit/scripts/test_queue_readiness_gate.py -q
- uv run python specs/index_specs.py --validate
- uv run python specs/trace_acs.py --validate
- make -n gate
- make -n gate-full
- make help | grep -E 'gate|gate-full|test-integration'