### PR TITLE
docs: approve S66 rate-limit budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ see `docs/release.md` for release rules.
   release readiness automation.
 - Add practical application evidence conventions and a deterministic evidence
   validator.
+- Approve S66 rate-limit budget after correcting stale S50 trace markers and
+  adding structured admission-control event evidence.
 
 ## [0.1.0] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ see `docs/release.md` for release rules.
   validator.
 - Approve S66 rate-limit budget after correcting stale S50 trace markers and
   adding structured admission-control event evidence.
+- Keep changed-file gates responsive on large worktrees by avoiding expensive
+  untracked-file scans during deterministic completion checks.
 
 ## [0.1.0] - 2026-05-27
 

--- a/scripts/changed_tests.py
+++ b/scripts/changed_tests.py
@@ -79,12 +79,17 @@ def _dedupe(values: Iterable[str]) -> list[str]:
 
 
 def changed_files_from_git(base_ref: str = "origin/main") -> list[str]:
-    """Return changed paths from merge-base diff plus unstaged/staged dirt."""
+    """Return committed diff plus unstaged/staged dirt.
+
+    Deliberately avoid a full untracked-file scan here. On large worktrees or
+    repos with generated local artifacts, `git ls-files --others` can dominate
+    the feedback loop or hang. This gate is intended for committed/staged work;
+    new files are covered once staged or committed.
+    """
     commands = [
         ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
         ["git", "diff", "--name-only"],
         ["git", "diff", "--cached", "--name-only"],
-        ["git", "ls-files", "--others", "--exclude-standard"],
     ]
     paths: list[str] = []
     for command in commands:

--- a/specs/66-rate-limit-budget.md
+++ b/specs/66-rate-limit-budget.md
@@ -1,11 +1,37 @@
 # S66 — Rate-Limit Budget & Task Prioritization
 
-> **Status**: 📝 Draft
+> **Status**: ✅ Approved
 > **Release Baseline**: 🆕 v2.1
 > **Level**: 3 — Resilience
 > **Dependencies**: S07 (LLM Integration), S23 (Error Handling & Resilience)
 > **Companion**: `plans/v2_1-architecture-review.md` §12, `docs/vision/TTA-CRITICAL-REVIEW.md` §1
-> **Last Updated**: 2026-05-14
+> **Last Updated**: 2026-05-27
+
+---
+
+## 0. Approval Reality Check
+
+This spec was approved after comparing the draft against the current
+`tta.llm.rate_limiter` implementation and tests.
+
+Current implementation evidence:
+
+- `RateLimitBudget` covers CRITICAL admission, HIGH/LOW FIFO queuing, LOW
+  throttling, BEST_EFFORT backpressure, and structured admission/queue/drop/
+  completion events.
+- `RateLimitedLLMClient` wraps `generate()` and `stream()` with tier-aware
+  admission control while preserving CRITICAL as the default backward-compatible
+  tier.
+- Existing tests were corrected from stale S50 markers to S66 markers because
+  the code implements this spec, not S50 concurrent universe loading.
+
+Deferred approved target:
+
+- AC-66.04 provider preference remains intentionally deferred until a concrete
+  provider-utilization signal is selected. The current in-process component
+  records `provider_utilization=None` and does not route calls by provider.
+  Planning for AC-66.04 MUST start with a spike that chooses between LiteLLM
+  response metadata, tracked 429s, or an FMR capacity endpoint.
 
 ---
 

--- a/specs/index.json
+++ b/specs/index.json
@@ -1,6 +1,6 @@
 {
   "spec_count": 70,
-  "total_words": 182895,
+  "total_words": 183028,
   "total_acceptance_criteria": 752,
   "specs": [
     {
@@ -2634,14 +2634,15 @@
       "file": "66-rate-limit-budget.md",
       "number": "S66",
       "title": "Rate-Limit Budget & Task Prioritization",
-      "status": "📝 Draft",
+      "status": "✅ Approved",
       "level": "3 — Resilience",
       "dependencies": [
         "S07 (LLM Integration)",
         "S23 (Error Handling & Resilience)"
       ],
-      "last_updated": "2026-05-14",
+      "last_updated": "2026-05-27",
       "sections": [
+        "Approval Reality Check",
         "How to Read This Spec",
         "Purpose",
         "Design Principles",
@@ -2657,7 +2658,7 @@
         "Out of Scope",
         "Open Questions"
       ],
-      "word_count": 2152,
+      "word_count": 2285,
       "has_acceptance_criteria": true,
       "acceptance_criteria_count": 6,
       "has_user_stories": true,

--- a/specs/index.md
+++ b/specs/index.md
@@ -124,7 +124,7 @@
 
 | # | Title | Status | Words | ACs | Gherkin | Stories | Edge Cases | Warnings |
 |---|-------|--------|------:|----:|-------:|:-------:|:----------:|----------|
-| S66 | [Rate-Limit Budget & Task Prioritization](66-rate-limit-budget.md) | 📝 Draft | 2152 | 6 | 0 | ✅ | ✅ | — |
+| S66 | [Rate-Limit Budget & Task Prioritization](66-rate-limit-budget.md) | ✅ Approved | 2285 | 6 | 0 | ✅ | ✅ | — |
 
 ## Process — Autonomous Pipeline Governance
 
@@ -135,7 +135,7 @@
 ## Summary
 
 - **Total specs**: 70
-- **Total words**: 182,895
+- **Total words**: 183,028
 - **Total acceptance criteria**: 752
 - **Specs with warnings**: 31/70
 - **Specs with Gherkin scenarios**: 66/70

--- a/src/tta/llm/rate_limiter.py
+++ b/src/tta/llm/rate_limiter.py
@@ -1,4 +1,4 @@
-"""Task-priority LLM admission control (S50).
+"""Task-priority LLM admission control (S66).
 
 RateLimitBudget enforces per-tier concurrency caps and queue-based
 admission for non-CRITICAL LLM calls. CRITICAL tier always admitted.
@@ -21,7 +21,7 @@ log = structlog.get_logger(__name__)
 
 
 class TaskPriority(StrEnum):
-    """LLM call priority tiers (S50 §4)."""
+    """LLM call priority tiers (S66 §4)."""
 
     CRITICAL = "critical"  # Player turns, Genesis v2 — never throttled
     HIGH = "high"  # Playtester sessions, quality evaluation
@@ -39,7 +39,7 @@ class _QueueEntry:
 
 
 class RateLimitBudget:
-    """In-process admission controller for LLM calls (S50).
+    """In-process admission controller for LLM calls (S66).
 
     CRITICAL tier calls bypass all limits. HIGH, LOW, and BEST_EFFORT
     calls are admitted under their configured concurrency caps and
@@ -84,6 +84,13 @@ class RateLimitBudget:
         return False at cap (caller must queue or reject)."""
         if tier == TaskPriority.CRITICAL:
             self._active[TaskPriority.CRITICAL] += 1
+            self._log_decision(
+                "rate_limit_admitted",
+                tier,
+                task_type,
+                decision="admitted",
+                queue_depth=0,
+            )
             return True
 
         sem = self._sem_for(tier)
@@ -91,10 +98,17 @@ class RateLimitBudget:
         if ok:
             await sem.acquire()
             self._active[tier] += 1
+            self._log_decision(
+                "rate_limit_admitted",
+                tier,
+                task_type,
+                decision="admitted",
+                queue_depth=len(self._queues[tier]),
+            )
         return ok
 
     async def admit_or_queue(self, tier: TaskPriority, task_type: str = "") -> bool:
-        """Request admission, queuing if at cap (FR-50.02).
+        """Request admission, queuing if at cap (FR-66.02).
 
         CRITICAL: always admitted immediately.
         HIGH/LOW/BEST_EFFORT: admitted if under cap, otherwise FIFO queued.
@@ -107,16 +121,17 @@ class RateLimitBudget:
         if await self.admit(tier, task_type):
             return True
 
-        # BEST_EFFORT backpressure check (FR-50.06)
+        # BEST_EFFORT backpressure check (FR-66.06)
         if tier == TaskPriority.BEST_EFFORT:
             queue_depth = len(self._queues[TaskPriority.BEST_EFFORT])
             if queue_depth >= self._best_effort_backpressure:
-                log.warning(
+                self._log_decision(
                     "rate_limit_dropped",
-                    tier=str(tier),
-                    task_type=task_type,
-                    queue_depth=queue_depth,
+                    tier,
+                    task_type,
                     decision="dropped",
+                    queue_depth=queue_depth,
+                    level="warning",
                 )
                 return False
 
@@ -124,10 +139,11 @@ class RateLimitBudget:
         entry = _QueueEntry(task_type=task_type)
         self._queues[tier].append(entry)
 
-        log.debug(
+        self._log_decision(
             "rate_limit_queued",
-            tier=str(tier),
-            task_type=task_type,
+            tier,
+            task_type,
+            decision="queued",
             queue_depth=len(self._queues[tier]),
         )
 
@@ -137,11 +153,13 @@ class RateLimitBudget:
         except TimeoutError:
             # Clean up stale queue entry
             self._remove_from_queue(tier, entry)
-            log.info(
+            self._log_decision(
                 "rate_limit_timeout",
-                tier=str(tier),
-                task_type=task_type,
+                tier,
+                task_type,
+                decision="rejected",
                 queue_depth=len(self._queues[tier]),
+                level="info",
             )
             raise
 
@@ -153,9 +171,24 @@ class RateLimitBudget:
         """Release a slot. If callers are queued, the next one gets admitted."""
         if tier == TaskPriority.CRITICAL:
             self._active[TaskPriority.CRITICAL] -= 1
+            self._log_decision(
+                "rate_limit_completed",
+                tier,
+                "",
+                decision="completed",
+                queue_depth=0,
+            )
             return
 
         self._active[tier] -= 1
+        queue_depth = len(self._queues[tier])
+        self._log_decision(
+            "rate_limit_completed",
+            tier,
+            "",
+            decision="completed",
+            queue_depth=queue_depth,
+        )
 
         # Try to admit the next queued caller
         if self._queues[tier]:
@@ -189,9 +222,30 @@ class RateLimitBudget:
         except ValueError:
             pass  # Already removed (raced with release)
 
+    def _log_decision(
+        self,
+        event: str,
+        tier: TaskPriority,
+        task_type: str,
+        *,
+        decision: str,
+        queue_depth: int,
+        level: str = "debug",
+    ) -> None:
+        """Emit the common S66 admission-control event shape."""
+        logger = getattr(log, level)
+        logger(
+            event,
+            tier=str(tier),
+            task_type=task_type,
+            decision=decision,
+            queue_depth=queue_depth,
+            provider_utilization=None,
+        )
+
 
 class RateLimitedLLMClient:
-    """Admission-controlled wrapper around LiteLLMClient (S50 §9.1).
+    """Admission-controlled wrapper around LiteLLMClient (S66 §9.1).
 
     CRITICAL tier calls pass through without admission overhead.
     HIGH/LOW/BEST_EFFORT calls go through RateLimitBudget.admit_or_queue().

--- a/tests/unit/llm/test_rate_limit_budget.py
+++ b/tests/unit/llm/test_rate_limit_budget.py
@@ -1,16 +1,17 @@
-"""Tests for RateLimitBudget — task-priority LLM admission control (S50).
+"""Tests for RateLimitBudget — task-priority LLM admission control (S66).
 
-RED phase starts here — no implementation exists yet.
+Existing implementation reality-check coverage for S66.
 """
 
 import asyncio
 
 import pytest
+from structlog.testing import capture_logs
 
 
-@pytest.mark.spec("AC-50.01")
+@pytest.mark.spec("AC-66.01")
 class TestCriticalTierAlwaysAdmitted:
-    """AC-50.01: Player turn not blocked under load."""
+    """AC-66.01: Player turn not blocked under load."""
 
     async def test_critical_admitted_when_high_tier_at_cap(self) -> None:
         """CRITICAL tier bypasses concurrency caps.
@@ -72,7 +73,7 @@ class TestCriticalTierAlwaysAdmitted:
         assert admitted, "CRITICAL must be admitted under all load conditions"
         assert elapsed_ms < 100, (
             f"CRITICAL admission took {elapsed_ms:.1f}ms, must be < 100ms "
-            f"(target < 1ms per NFR-50.01)"
+            f"(target < 1ms per NFR-66.01)"
         )
 
         # Cleanup
@@ -84,9 +85,9 @@ class TestCriticalTierAlwaysAdmitted:
         await budget.release(TaskPriority.CRITICAL)
 
 
-@pytest.mark.spec("AC-50.02", "AC-50.03")
+@pytest.mark.spec("AC-66.02", "AC-66.03")
 class TestNonCriticalTierConcurrency:
-    """AC-50.02 (playtester cap) and AC-50.03 (background throttled)."""
+    """AC-66.02 (playtester cap) and AC-66.03 (background throttled)."""
 
     async def test_high_tier_capped_at_configured_limit(self) -> None:
         """HIGH tier admits exactly N concurrent calls."""
@@ -155,9 +156,9 @@ class TestNonCriticalTierConcurrency:
         await budget.release(TaskPriority.LOW)
 
 
-@pytest.mark.spec("AC-50.02")
+@pytest.mark.spec("AC-66.02")
 class TestQueuingAtCap:
-    """FR-50.02 / AC-50.02: queued calls proceed when capacity frees (FIFO)."""
+    """FR-66.02 / AC-66.02: queued calls proceed when capacity frees (FIFO)."""
 
     async def test_high_tier_call_queues_and_proceeds_when_slot_frees(self) -> None:
         """A call at cap queues and is processed when a slot releases."""
@@ -284,35 +285,58 @@ class TestBackpressure:
         await budget.release(TaskPriority.BEST_EFFORT)
 
 
-@pytest.mark.spec("AC-50.05")
+@pytest.mark.spec("AC-66.05")
 class TestStructlogEvents:
-    """AC-50.05: structlog events on admission/queuing/rejection."""
+    """AC-66.05: structlog events on admission/queuing/rejection."""
 
     async def test_admission_logs_structlog_event(self) -> None:
-        """admit() emits a structlog event."""
+        """admit() emits a structured admitted decision event."""
         from tta.llm.rate_limiter import RateLimitBudget, TaskPriority
 
         budget = RateLimitBudget()
 
-        # Admission should produce a log
-        assert await budget.admit(TaskPriority.CRITICAL, task_type="player_turn")
-        await budget.release(TaskPriority.CRITICAL)
+        with capture_logs() as logs:
+            assert await budget.admit(TaskPriority.CRITICAL, task_type="player_turn")
+            await budget.release(TaskPriority.CRITICAL)
+
+        assert {
+            "event": "rate_limit_admitted",
+            "tier": "critical",
+            "task_type": "player_turn",
+            "decision": "admitted",
+            "queue_depth": 0,
+            "provider_utilization": None,
+            "log_level": "debug",
+        } in logs
+        assert any(
+            event["event"] == "rate_limit_completed"
+            and event["tier"] == "critical"
+            and event["decision"] == "completed"
+            for event in logs
+        )
 
     async def test_queue_logs_structlog_event(self) -> None:
-        """Queuing emits a structlog debug event."""
+        """Queuing emits a structured queued decision event."""
         from tta.llm.rate_limiter import RateLimitBudget, TaskPriority
 
         budget = RateLimitBudget(high_concurrency=1)
 
-        await budget.admit(TaskPriority.HIGH, task_type="playtester_1")
+        with capture_logs() as logs:
+            await budget.admit(TaskPriority.HIGH, task_type="playtester_1")
+            f = asyncio.ensure_future(
+                budget.admit_or_queue(TaskPriority.HIGH, task_type="playtester_2")
+            )
+            await asyncio.sleep(0)
+            await budget.release(TaskPriority.HIGH)
+            await f
+            await budget.release(TaskPriority.HIGH)
 
-        # This queues and should produce a log
-        f = asyncio.ensure_future(
-            budget.admit_or_queue(TaskPriority.HIGH, task_type="playtester_2")
+        assert any(
+            event["event"] == "rate_limit_queued"
+            and event["tier"] == "high"
+            and event["task_type"] == "playtester_2"
+            and event["decision"] == "queued"
+            and event["queue_depth"] == 1
+            and event["provider_utilization"] is None
+            for event in logs
         )
-        await asyncio.sleep(0)
-
-        # Cleanup
-        await budget.release(TaskPriority.HIGH)
-        await f
-        await budget.release(TaskPriority.HIGH)

--- a/tests/unit/llm/test_rate_limited_client.py
+++ b/tests/unit/llm/test_rate_limited_client.py
@@ -1,4 +1,4 @@
-"""Tests for RateLimitedLLMClient — admission-controlled wrapper (S50 §9.1)."""
+"""Tests for RateLimitedLLMClient — admission-controlled wrapper (S66 §9.1)."""
 
 import asyncio
 
@@ -8,10 +8,8 @@ from tta.llm.client import LLMClient, Message, MessageRole
 from tta.llm.roles import ModelRole
 from tta.llm.testing import MockLLMClient
 
-# RED: RateLimitedLLMClient doesn't exist yet
 
-
-@pytest.mark.spec("AC-50.01")
+@pytest.mark.spec("AC-66.01")
 class TestRateLimitedClientCritical:
     """CRITICAL tier calls pass through without admission check overhead."""
 
@@ -55,7 +53,7 @@ class TestRateLimitedClientCritical:
         assert len(mock.call_history) == 10
 
 
-@pytest.mark.spec("AC-50.02")
+@pytest.mark.spec("AC-66.02")
 class TestRateLimitedClientHigh:
     """HIGH tier calls respect concurrency cap."""
 
@@ -78,11 +76,24 @@ class TestRateLimitedClientHigh:
             # Save original generate, replace with blocking version
             orig_generate = mock.generate
 
-            async def blocking_generate(role, messages, params=None):
+            async def blocking_generate(
+                role,
+                messages,
+                params=None,
+                *,
+                generation_profile=None,
+                traffic_class=None,
+            ):
                 await hold_event.wait()
-                return await orig_generate(role, messages, params)
+                return await orig_generate(
+                    role,
+                    messages,
+                    params,
+                    generation_profile=generation_profile,
+                    traffic_class=traffic_class,
+                )
 
-            mock.generate = blocking_generate
+            mock.generate = blocking_generate  # pyright: ignore[reportAttributeAccessIssue]
             result = await client.generate(
                 role=ModelRole.GENERATION,
                 messages=[Message(role=MessageRole.USER, content="slow")],

--- a/tests/unit/scripts/test_changed_tests.py
+++ b/tests/unit/scripts/test_changed_tests.py
@@ -70,3 +70,30 @@ def test_text_report_is_discoverable_and_deterministic(changed_tests_module) -> 
     assert "Changed-test plan" in report
     assert "tests/unit/api" in report
     assert "uv run python plans/index_plans.py --validate" in report
+
+
+@pytest.mark.spec("AC-65.01")
+def test_changed_files_from_git_avoids_expensive_untracked_scan(
+    changed_tests_module,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    commands: list[list[str]] = []
+
+    class Result:
+        returncode = 0
+        stdout = ""
+
+    def fake_run(command, **_kwargs):
+        commands.append(command)
+        return Result()
+
+    monkeypatch.setattr(changed_tests_module.subprocess, "run", fake_run)
+
+    changed_tests_module.changed_files_from_git("origin/main")
+
+    assert ["git", "ls-files", "--others", "--exclude-standard"] not in commands
+    assert commands == [
+        ["git", "diff", "--name-only", "origin/main...HEAD"],
+        ["git", "diff", "--name-only"],
+        ["git", "diff", "--cached", "--name-only"],
+    ]

--- a/tests/unit/v2_deferred_coverage.py
+++ b/tests/unit/v2_deferred_coverage.py
@@ -5,12 +5,15 @@
 import pytest
 
 
-# This test is skipped because it is planned, but not yet implemented in v1.
-@pytest.mark.spec("AC-66.06")
-@pytest.mark.skip(reason="Not yet implemented in v1.")
-def test_ac66_06_backpressure_not_yet_implemented():
-    # This is a stub for AC-66.06 coverage deferral
-    pass
+@pytest.mark.spec("AC-66.04")
+@pytest.mark.skip(
+    reason=(
+        "S66 approved target: provider-preference needs a provider-utilization "
+        "signal spike before implementation."
+    )
+)
+def test_ac66_04_deferred_provider_preference() -> None:
+    """AC-66.04 requires routing LOW calls away from NEAR_LIMIT providers."""
 
 
 @pytest.mark.spec("AC-03.07")


### PR DESCRIPTION
## Summary
- approves S66 after comparing the draft to the current rate-limit implementation
- corrects stale S50 references/AC markers to S66 for the rate-limit budget tests
- adds structured admission-control event evidence for AC-66.05
- defers AC-66.04 provider preference explicitly pending a provider-utilization signal spike
- keeps changed-file gate discovery responsive by avoiding expensive untracked-file scans in the default PR-prep path

## Verification
- RED: structlog evidence tests failed before implementation
- uv run pytest tests/unit/llm/test_rate_limit_budget.py tests/unit/llm/test_rate_limited_client.py tests/unit/v2_deferred_coverage.py -q
- uv run pytest tests/unit/scripts/test_changed_tests.py -q
- make spec-check SPEC=specs/66-rate-limit-budget.md
- make trace
- make complete-check
- make gate

## Stack
- Retargeted/rebased onto main after #222 merged.
- Replaces closed stacked PR #223, which could not be reopened after the parent branch was deleted.
