### PR TITLE
feat: spike provider utilization signal

### DIFF
--- a/.barnacle/work/items/FB-06604.json
+++ b/.barnacle/work/items/FB-06604.json
@@ -1,7 +1,7 @@
 {
   "id": "FB-06604",
   "title": "Spike S66 AC-66.04 provider-utilization signal",
-  "stage": "REVIEWED",
+  "stage": "PR_OPEN",
   "spec_ref": "specs/66-rate-limit-budget.md",
   "plan_ref": "plans/s66-provider-utilization-spike.md",
   "ac_ids": [
@@ -24,7 +24,7 @@
   ],
   "last_gate_result": "pass",
   "review_status": "pass",
-  "pr_number": null,
+  "pr_number": 226,
   "release_note_required": false,
   "changelog_entry": "",
   "blocked_reason": ""

--- a/.barnacle/work/items/FB-06604.json
+++ b/.barnacle/work/items/FB-06604.json
@@ -1,7 +1,7 @@
 {
   "id": "FB-06604",
   "title": "Spike S66 AC-66.04 provider-utilization signal",
-  "stage": "PLAN_DRAFT",
+  "stage": "REVIEWED",
   "spec_ref": "specs/66-rate-limit-budget.md",
   "plan_ref": "plans/s66-provider-utilization-spike.md",
   "ac_ids": [
@@ -17,11 +17,13 @@
   ],
   "evidence_files": [
     "plans/s66-provider-utilization-spike.md",
+    "src/tta/llm/provider_utilization.py",
+    "src/tta/llm/rate_limiter.py",
     "tests/unit/llm/test_provider_utilization.py",
     "tests/unit/llm/test_rate_limit_budget.py"
   ],
-  "last_gate_result": "",
-  "review_status": "",
+  "last_gate_result": "pass",
+  "review_status": "pass",
   "pr_number": null,
   "release_note_required": false,
   "changelog_entry": "",

--- a/plans/s66-provider-utilization-spike.md
+++ b/plans/s66-provider-utilization-spike.md
@@ -244,7 +244,86 @@ uv run python scripts/workflow_state.py status
 make trace
 ```
 
-## 6. Testing strategy
+## 6. Spike Result
+
+Result: complete for the signal-seam objective; AC-66.04 remains deferred.
+
+### 6.1 Selected source
+
+Selected first source: observed LiteLLM/FMR 429 events with retry-after metadata.
+
+Why this won:
+
+- deterministic in unit tests with synthetic exceptions;
+- no live spend, no network probing;
+- directly represents provider exhaustion/congestion;
+- already aligned with existing `tta.llm.errors.classify_error()` transient handling.
+
+Implemented evidence:
+
+- `src/tta/llm/provider_utilization.py` introduces:
+  - `ProviderUtilizationState`
+  - `ProviderUtilization`
+  - `ProviderUtilizationSnapshot`
+  - `from_rate_limit_error(exc)`
+- `tests/unit/llm/test_provider_utilization.py` proves:
+  - 429 + retry-after => `EXHAUSTED`
+  - 429 without retry-after => `NEAR_LIMIT`
+  - missing signal => `UNKNOWN`, not `HEALTHY`
+- `src/tta/llm/rate_limiter.py` now accepts an optional provider snapshot and logs serialized provider state when a provider is supplied.
+- `tests/unit/llm/test_rate_limit_budget.py` proves log enrichment without any routing claim.
+
+### 6.2 Implementation seam
+
+Chosen seam:
+
+- signal production lives outside `RateLimitBudget`;
+- `RateLimitBudget` remains admission-only and receives:
+  - `provider` (optional string context)
+  - `provider_utilization_snapshot` (optional injected snapshot source)
+- log enrichment happens via `_provider_utilization_for(provider)` and `_log_decision(..., provider_utilization=...)`.
+
+This keeps HTTP/LiteLLM internals out of `RateLimitBudget` and preserves a clean boundary for the real routing slice.
+
+### 6.3 Rejected or deferred alternatives
+
+1. LiteLLM response headers
+   - Deferred.
+   - Useful, but the response-object/header contract is less stable and harder to test cleanly than synthetic 429 exceptions.
+
+2. FMR capacity endpoint
+   - Deferred to the next slice.
+   - Architecturally attractive for proactive routing, but it requires a documented, stable local endpoint contract and should be introduced only when routing behavior is actually implemented.
+
+### 6.4 Exact next routing tests for the real AC-66.04 slice
+
+These are the next tests to add when provider-aware routing is implemented:
+
+```python
+@pytest.mark.spec("AC-66.04")
+def test_low_tier_prefers_healthy_provider_over_near_limit_provider():
+    ...
+
+@pytest.mark.spec("AC-66.04")
+def test_best_effort_avoids_exhausted_provider_when_healthy_alternative_exists():
+    ...
+
+@pytest.mark.spec("AC-66.04")
+def test_unknown_provider_state_does_not_override_explicit_healthy_choice():
+    ...
+
+@pytest.mark.spec("AC-66.04")
+def test_admission_logs_selected_provider_and_utilization_basis_when_routed():
+    ...
+```
+
+Required behavior for that slice:
+
+- LOW/BEST_EFFORT calls must choose a model/provider using provider state;
+- `NEAR_LIMIT` and `EXHAUSTED` providers must be deprioritized when healthier alternatives exist;
+- `tests/unit/v2_deferred_coverage.py` may only drop the AC-66.04 skip once that routing behavior exists.
+
+## 7. Testing strategy
 
 Use no-spend tests only:
 
@@ -261,14 +340,14 @@ Do not run live LLM calls for this spike. If a local FMR endpoint must be probed
 - Capture and paste the exact response shape into the Spike Result section before implementation consumes it.
 
 
-## 7. Acceptance criteria for this plan
+## 8. Acceptance criteria for this plan
 
 - The plan is indexed by `plans/index_plans.py` without new warnings specific to this file.
 - A machine-readable work item references `specs/66-rate-limit-budget.md`, this plan, and `AC-66.04`.
 - The first implementation task is a spike with no-spend evidence, not a routing rewrite.
 - AC-66.04 remains truthfully deferred until routing behavior exists.
 
-## 8. Validation commands
+## 9. Validation commands
 
 ```bash
 uv run python plans/index_plans.py --validate

--- a/src/tta/llm/provider_utilization.py
+++ b/src/tta/llm/provider_utilization.py
@@ -1,0 +1,142 @@
+"""Provider-utilization state modeling for S66 AC-66.04.
+
+This module provides the signal seam for provider-aware routing. It is
+deliberately minimal and decoupled from LiteLLM and HTTP clients — the
+data model and parser functions can be tested in isolation without live
+network calls.
+
+Signal sources (in priority order):
+1. 429/retry-after events from LiteLLM exceptions (primary, implemented)
+2. LiteLLM response headers (future slice)
+3. FMR capacity endpoint (future slice, requires network)
+
+Routing behavior (LOW calls prefer HEALTHY over NEAR_LIMIT) is NOT
+implemented here. That belongs to the slice that consumes this signal.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Protocol
+
+
+class ProviderUtilizationState(StrEnum):
+    """Provider utilization level (S66 §2.3).
+
+    UNKNOWN is the safe default — never assume HEALTHY without evidence.
+    AC-66.04 routing must not bias toward HEALTHY when no signal exists.
+    """
+
+    HEALTHY = "healthy"  # <50% RPM — prefer for LOW/BEST_EFFORT
+    ELEVATED = "elevated"  # 50-80% RPM — acceptable
+    NEAR_LIMIT = "near_limit"  # >80% RPM — avoid for LOW/BEST_EFFORT
+    EXHAUSTED = "exhausted"  # 429 received — do not use
+    UNKNOWN = "unknown"  # No signal — safe default, never HEALTHY
+
+
+@dataclass(frozen=True)
+class ProviderUtilization:
+    """Immutable record of a provider's current utilization.
+
+    Created from: rate-limit errors, response headers, FMR snapshots.
+    Serializable for structlog output and future persistence.
+    """
+
+    provider: str
+    """Provider name, e.g. 'google', 'groq', 'nvidia'."""
+
+    state: ProviderUtilizationState
+    """Derived utilization level."""
+
+    rpm_utilization: float | None = None
+    """Observed RPM utilization as a fraction [0.0, 1.0], if available."""
+
+    retry_after_seconds: float | None = None
+    """Seconds the provider asked us to wait, from Retry-After header."""
+
+    source: str = "unknown"
+    """Traceability tag: which signal produced this record."""
+
+
+class ProviderUtilizationSnapshot(Protocol):
+    """Injectable interface for querying provider state.
+
+    Implement this protocol to supply provider state from any source
+    (LiteLLM exception handlers, FMR capacity endpoint, in-memory cache).
+    RateLimitBudget accepts an optional snapshot for log enrichment.
+    """
+
+    def snapshot(self) -> Mapping[str, ProviderUtilization]:
+        """Return current utilization state for all tracked providers."""
+        ...
+
+
+#: Type alias for concrete snapshot implementations
+type ProviderUtilizationSource = ProviderUtilizationSnapshot
+
+
+def from_rate_limit_error(exc: Exception) -> ProviderUtilization:
+    """Build ProviderUtilization from a LiteLLM RateLimitError.
+
+    This is the primary spike signal. When LiteLLM raises a 429, the
+    exception carries retry-after metadata that encodes provider state.
+
+    Args:
+        exc: A LiteLLM RateLimitError (or synthetic equivalent) with
+            attributes: model, status_code, retry_after, _response_headers.
+
+    Returns:
+        ProviderUtilization with provider, state, retry_after_seconds,
+        and source tag.
+
+    Signal mapping:
+        - retry_after is not None → EXHAUSTED (provider asked us to wait)
+        - retry_after is None and status is 429 → NEAR_LIMIT (congested)
+        - other 429 with Retry-After header → EXHAUSTED
+    """
+    provider = _extract_provider(exc)
+
+    retry_after: float | None = getattr(exc, "retry_after", None)
+    headers: dict[str, str] = getattr(exc, "_response_headers", {})
+
+    # Parse Retry-After header if retry_after attribute is not set
+    if retry_after is None:
+        retry_after_header = headers.get("retry-after") or headers.get("Retry-After")
+        if retry_after_header is not None:
+            try:
+                retry_after = float(retry_after_header)
+            except ValueError:
+                retry_after = None
+
+    # State derivation
+    if retry_after is not None:
+        state = ProviderUtilizationState.EXHAUSTED
+        source = "retry_after_header"
+    else:
+        # 429 without Retry-After: congested but not fully exhausted
+        state = ProviderUtilizationState.NEAR_LIMIT
+        source = "429_no_retry_after"
+
+    return ProviderUtilization(
+        provider=provider,
+        state=state,
+        retry_after_seconds=retry_after,
+        source=source,
+    )
+
+
+def _extract_provider(exc: Exception) -> str:
+    """Extract provider name from a LiteLLM exception's model attribute.
+
+    LiteLLM model strings are '{provider}/{model}', e.g. 'google/gemini-2.0-flash'.
+    Returns 'unknown' if the model attribute is missing or malformed.
+    """
+    model: str = getattr(exc, "model", "") or ""
+    if "/" in model:
+        return model.split("/", 1)[0]
+    if model:
+        # Bare model name — treat as provider (some deployments use this)
+        return model
+    return "unknown"

--- a/src/tta/llm/provider_utilization.py
+++ b/src/tta/llm/provider_utilization.py
@@ -97,9 +97,18 @@ def from_rate_limit_error(exc: Exception) -> ProviderUtilization:
         - other 429 with Retry-After header → EXHAUSTED
     """
     provider = _extract_provider(exc)
+    status_code = getattr(exc, "status_code", None)
 
     retry_after: float | None = getattr(exc, "retry_after", None)
     headers: dict[str, str] = getattr(exc, "_response_headers", {})
+
+    if status_code != 429:
+        return ProviderUtilization(
+            provider=provider,
+            state=ProviderUtilizationState.UNKNOWN,
+            retry_after_seconds=retry_after,
+            source="non_429_error",
+        )
 
     # Parse Retry-After header if retry_after attribute is not set
     if retry_after is None:

--- a/src/tta/llm/rate_limiter.py
+++ b/src/tta/llm/rate_limiter.py
@@ -17,6 +17,8 @@ from typing import Any
 
 import structlog
 
+from tta.llm.provider_utilization import ProviderUtilizationSnapshot
+
 log = structlog.get_logger(__name__)
 
 
@@ -54,7 +56,7 @@ class RateLimitBudget:
         best_effort_backpressure: int = 10,
         queue_timeout_high: float = 300.0,
         queue_timeout_low: float = 600.0,
-        provider_utilization_snapshot: Any | None = None,
+        provider_utilization_snapshot: ProviderUtilizationSnapshot | None = None,
     ) -> None:
         self._high_concurrency = high_concurrency
         self._low_concurrency = low_concurrency
@@ -90,7 +92,6 @@ class RateLimitBudget:
     ) -> bool:
         """Request immediate admission. CRITICAL always true; others
         return False at cap (caller must queue or reject)."""
-        provider_utilization = self._provider_utilization_for(provider)
         if tier == TaskPriority.CRITICAL:
             self._active[TaskPriority.CRITICAL] += 1
             self._log_decision(
@@ -99,10 +100,11 @@ class RateLimitBudget:
                 task_type,
                 decision="admitted",
                 queue_depth=0,
-                provider_utilization=provider_utilization,
+                provider_utilization=None,
             )
             return True
 
+        provider_utilization = self._provider_utilization_for(provider)
         sem = self._sem_for(tier)
         ok = sem.locked() is False
         if ok:
@@ -254,18 +256,21 @@ class RateLimitBudget:
         if provider is None or self._provider_utilization_snapshot is None:
             return None
 
-        snapshot = self._provider_utilization_snapshot.snapshot()
-        utilization = snapshot.get(provider)
-        if utilization is None:
-            return None
+        try:
+            snapshot = self._provider_utilization_snapshot.snapshot()
+            utilization = snapshot.get(provider)
+            if utilization is None:
+                return None
 
-        return {
-            "provider": utilization.provider,
-            "state": str(utilization.state),
-            "rpm_utilization": utilization.rpm_utilization,
-            "retry_after_seconds": utilization.retry_after_seconds,
-            "source": utilization.source,
-        }
+            return {
+                "provider": utilization.provider,
+                "state": str(utilization.state),
+                "rpm_utilization": utilization.rpm_utilization,
+                "retry_after_seconds": utilization.retry_after_seconds,
+                "source": utilization.source,
+            }
+        except Exception:
+            return None
 
     def _remove_from_queue(self, tier: TaskPriority, entry: _QueueEntry) -> None:
         """Remove a specific entry from the tier queue (O(n) — rare)."""

--- a/src/tta/llm/rate_limiter.py
+++ b/src/tta/llm/rate_limiter.py
@@ -54,12 +54,14 @@ class RateLimitBudget:
         best_effort_backpressure: int = 10,
         queue_timeout_high: float = 300.0,
         queue_timeout_low: float = 600.0,
+        provider_utilization_snapshot: Any | None = None,
     ) -> None:
         self._high_concurrency = high_concurrency
         self._low_concurrency = low_concurrency
         self._best_effort_backpressure = best_effort_backpressure
         self._queue_timeout_high = queue_timeout_high
         self._queue_timeout_low = queue_timeout_low
+        self._provider_utilization_snapshot = provider_utilization_snapshot
 
         self._high_sem = asyncio.Semaphore(high_concurrency)
         self._low_sem = asyncio.Semaphore(low_concurrency)
@@ -79,9 +81,16 @@ class RateLimitBudget:
     # Public API
     # ------------------------------------------------------------------
 
-    async def admit(self, tier: TaskPriority, task_type: str = "") -> bool:
+    async def admit(
+        self,
+        tier: TaskPriority,
+        task_type: str = "",
+        *,
+        provider: str | None = None,
+    ) -> bool:
         """Request immediate admission. CRITICAL always true; others
         return False at cap (caller must queue or reject)."""
+        provider_utilization = self._provider_utilization_for(provider)
         if tier == TaskPriority.CRITICAL:
             self._active[TaskPriority.CRITICAL] += 1
             self._log_decision(
@@ -90,6 +99,7 @@ class RateLimitBudget:
                 task_type,
                 decision="admitted",
                 queue_depth=0,
+                provider_utilization=provider_utilization,
             )
             return True
 
@@ -104,10 +114,17 @@ class RateLimitBudget:
                 task_type,
                 decision="admitted",
                 queue_depth=len(self._queues[tier]),
+                provider_utilization=provider_utilization,
             )
         return ok
 
-    async def admit_or_queue(self, tier: TaskPriority, task_type: str = "") -> bool:
+    async def admit_or_queue(
+        self,
+        tier: TaskPriority,
+        task_type: str = "",
+        *,
+        provider: str | None = None,
+    ) -> bool:
         """Request admission, queuing if at cap (FR-66.02).
 
         CRITICAL: always admitted immediately.
@@ -117,8 +134,10 @@ class RateLimitBudget:
 
         Raises asyncio.TimeoutError if the queue timeout expires.
         """
+        provider_utilization = self._provider_utilization_for(provider)
+
         # Fast path: try immediate admission
-        if await self.admit(tier, task_type):
+        if await self.admit(tier, task_type, provider=provider):
             return True
 
         # BEST_EFFORT backpressure check (FR-66.06)
@@ -132,6 +151,7 @@ class RateLimitBudget:
                     decision="dropped",
                     queue_depth=queue_depth,
                     level="warning",
+                    provider_utilization=provider_utilization,
                 )
                 return False
 
@@ -145,6 +165,7 @@ class RateLimitBudget:
             task_type,
             decision="queued",
             queue_depth=len(self._queues[tier]),
+            provider_utilization=provider_utilization,
         )
 
         timeout = self._timeout_for(tier)
@@ -160,6 +181,7 @@ class RateLimitBudget:
                 decision="rejected",
                 queue_depth=len(self._queues[tier]),
                 level="info",
+                provider_utilization=provider_utilization,
             )
             raise
 
@@ -167,8 +189,14 @@ class RateLimitBudget:
         self._active[tier] += 1
         return True
 
-    async def release(self, tier: TaskPriority) -> None:
+    async def release(
+        self,
+        tier: TaskPriority,
+        *,
+        provider: str | None = None,
+    ) -> None:
         """Release a slot. If callers are queued, the next one gets admitted."""
+        provider_utilization = self._provider_utilization_for(provider)
         if tier == TaskPriority.CRITICAL:
             self._active[TaskPriority.CRITICAL] -= 1
             self._log_decision(
@@ -177,6 +205,7 @@ class RateLimitBudget:
                 "",
                 decision="completed",
                 queue_depth=0,
+                provider_utilization=provider_utilization,
             )
             return
 
@@ -188,6 +217,7 @@ class RateLimitBudget:
             "",
             decision="completed",
             queue_depth=queue_depth,
+            provider_utilization=provider_utilization,
         )
 
         # Try to admit the next queued caller
@@ -215,6 +245,28 @@ class RateLimitBudget:
             return self._queue_timeout_low
         return 60.0  # BEST_EFFORT
 
+    def _provider_utilization_for(self, provider: str | None) -> dict[str, Any] | None:
+        """Return serialized provider-utilization state for logging.
+
+        This is an observability seam only. It does not affect admission
+        or routing behavior in this spike.
+        """
+        if provider is None or self._provider_utilization_snapshot is None:
+            return None
+
+        snapshot = self._provider_utilization_snapshot.snapshot()
+        utilization = snapshot.get(provider)
+        if utilization is None:
+            return None
+
+        return {
+            "provider": utilization.provider,
+            "state": str(utilization.state),
+            "rpm_utilization": utilization.rpm_utilization,
+            "retry_after_seconds": utilization.retry_after_seconds,
+            "source": utilization.source,
+        }
+
     def _remove_from_queue(self, tier: TaskPriority, entry: _QueueEntry) -> None:
         """Remove a specific entry from the tier queue (O(n) — rare)."""
         try:
@@ -231,8 +283,17 @@ class RateLimitBudget:
         decision: str,
         queue_depth: int,
         level: str = "debug",
+        provider_utilization: Any = None,
     ) -> None:
-        """Emit the common S66 admission-control event shape."""
+        """Emit the common S66 admission-control event shape.
+
+        Args:
+            provider_utilization: Optional ProviderUtilization record to include
+                in the log. When None (default), logs provider_utilization=None
+                for backward compatibility. When supplied, logs the full record
+                for observability without changing routing behavior (that
+                belongs to the AC-66.04 implementation slice).
+        """
         logger = getattr(log, level)
         logger(
             event,
@@ -240,7 +301,7 @@ class RateLimitBudget:
             task_type=task_type,
             decision=decision,
             queue_depth=queue_depth,
-            provider_utilization=None,
+            provider_utilization=provider_utilization,
         )
 
 

--- a/tests/unit/llm/test_provider_utilization.py
+++ b/tests/unit/llm/test_provider_utilization.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import pytest
 
 
-@pytest.mark.spec("AC-66.04")
 class TestProviderUtilizationState:
     """State enum covers all provider utilization levels."""
 
@@ -49,7 +48,6 @@ class TestProviderUtilizationState:
         assert ProviderUtilizationState.UNKNOWN == "unknown"
 
 
-@pytest.mark.spec("AC-66.04")
 class TestProviderUtilizationDataclass:
     """ProviderUtilization is a frozen, serializable record."""
 
@@ -107,7 +105,6 @@ class TestProviderUtilizationDataclass:
             pu.provider = "anthropic"  # type: ignore[reportAttributeAccessIssue]
 
 
-@pytest.mark.spec("AC-66.04")
 class TestFrom429Event:
     """Build ProviderUtilization from a LiteLLM RateLimitError or synthetic 429."""
 
@@ -174,6 +171,27 @@ class TestFrom429Event:
 
         assert pu.provider == "openai"
 
+    def test_non_429_defaults_to_unknown(self) -> None:
+        """Non-429 errors must not be misclassified as provider pressure."""
+        from tta.llm.provider_utilization import (
+            ProviderUtilizationState,
+            from_rate_limit_error,
+        )
+
+        exc = _make_rate_limit_error(
+            status_code=500,
+            retry_after=None,
+            model="google/gemini-2.0-flash",
+            headers={},
+        )
+
+        pu = from_rate_limit_error(exc)
+
+        assert pu.provider == "google"
+        assert pu.state == ProviderUtilizationState.UNKNOWN
+        assert pu.retry_after_seconds is None
+        assert pu.source == "non_429_error"
+
     def test_missing_signal_is_unknown_not_healthy(self) -> None:
         """UNKNOWN is the safe default — never assume HEALTHY without evidence.
 
@@ -193,7 +211,6 @@ class TestFrom429Event:
         assert ProviderUtilizationState.UNKNOWN != ProviderUtilizationState.HEALTHY
 
 
-@pytest.mark.spec("AC-66.04")
 class TestProviderUtilizationSnapshot:
     """Optional snapshot interface for batch provider state queries."""
 

--- a/tests/unit/llm/test_provider_utilization.py
+++ b/tests/unit/llm/test_provider_utilization.py
@@ -1,0 +1,250 @@
+"""Tests for provider-utilization state modeling (S66 AC-66.04 spike).
+
+These tests define the provider-utilization signal seam before any runtime
+integration. The spike uses 429/retry-after events as the primary signal
+source — deterministic in unit tests, no spend, directly observable from
+LiteLLM exceptions.
+
+AC-66.04 routing behavior (LOW calls prefer HEALTHY over NEAR_LIMIT) is
+NOT implemented in this spike. That belongs to the next slice.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.spec("AC-66.04")
+class TestProviderUtilizationState:
+    """State enum covers all provider utilization levels."""
+
+    def test_healthy_state_value(self) -> None:
+        """HEALTHY maps to 'healthy' string for log observability."""
+        from tta.llm.provider_utilization import ProviderUtilizationState
+
+        assert ProviderUtilizationState.HEALTHY == "healthy"
+
+    def test_elevated_state_value(self) -> None:
+        """ELEVATED maps to 'elevated' string."""
+        from tta.llm.provider_utilization import ProviderUtilizationState
+
+        assert ProviderUtilizationState.ELEVATED == "elevated"
+
+    def test_near_limit_state_value(self) -> None:
+        """NEAR_LIMIT maps to 'near_limit' string."""
+        from tta.llm.provider_utilization import ProviderUtilizationState
+
+        assert ProviderUtilizationState.NEAR_LIMIT == "near_limit"
+
+    def test_exhausted_state_value(self) -> None:
+        """EXHAUSTED maps to 'exhausted' string."""
+        from tta.llm.provider_utilization import ProviderUtilizationState
+
+        assert ProviderUtilizationState.EXHAUSTED == "exhausted"
+
+    def test_unknown_state_value(self) -> None:
+        """UNKNOWN maps to 'unknown' — safe default, not HEALTHY."""
+        from tta.llm.provider_utilization import ProviderUtilizationState
+
+        assert ProviderUtilizationState.UNKNOWN == "unknown"
+
+
+@pytest.mark.spec("AC-66.04")
+class TestProviderUtilizationDataclass:
+    """ProviderUtilization is a frozen, serializable record."""
+
+    def test_required_fields(self) -> None:
+        """Must capture provider and state at minimum."""
+        from tta.llm.provider_utilization import (
+            ProviderUtilization,
+            ProviderUtilizationState,
+        )
+
+        pu = ProviderUtilization(
+            provider="google", state=ProviderUtilizationState.HEALTHY
+        )
+        assert pu.provider == "google"
+        assert pu.state == ProviderUtilizationState.HEALTHY
+        assert pu.rpm_utilization is None
+        assert pu.retry_after_seconds is None
+        assert pu.source == "unknown"
+
+    def test_full_fields(self) -> None:
+        """All fields are captured when available."""
+        from tta.llm.provider_utilization import (
+            ProviderUtilization,
+            ProviderUtilizationState,
+        )
+
+        pu = ProviderUtilization(
+            provider="groq",
+            state=ProviderUtilizationState.NEAR_LIMIT,
+            rpm_utilization=0.85,
+            retry_after_seconds=2.5,
+            source="retry_after_header",
+        )
+        assert pu.provider == "groq"
+        assert pu.state == ProviderUtilizationState.NEAR_LIMIT
+        assert pu.rpm_utilization == 0.85
+        assert pu.retry_after_seconds == 2.5
+        assert pu.source == "retry_after_header"
+
+    def test_is_frozen(self) -> None:
+        """Immutable to prevent accidental mutation in concurrent contexts."""
+        import dataclasses
+
+        from tta.llm.provider_utilization import (
+            ProviderUtilization,
+            ProviderUtilizationState,
+        )
+
+        assert dataclasses.is_dataclass(ProviderUtilization)
+        # frozen=True is enforced at runtime by dataclass
+        pu = ProviderUtilization(
+            provider="openai", state=ProviderUtilizationState.HEALTHY
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            pu.provider = "anthropic"  # type: ignore[reportAttributeAccessIssue]
+
+
+@pytest.mark.spec("AC-66.04")
+class TestFrom429Event:
+    """Build ProviderUtilization from a LiteLLM RateLimitError or synthetic 429."""
+
+    def test_exhausted_from_retry_after_seconds(self) -> None:
+        """A 429 with retry_after_seconds marks provider EXHAUSTED.
+
+        This is the primary spike signal: when LiteLLM raises RateLimitError,
+        the exception exposes retry-after metadata. This is the most reliable
+        provider-awareness signal we can extract without network probing.
+        """
+        from tta.llm.provider_utilization import (
+            ProviderUtilizationState,
+            from_rate_limit_error,
+        )
+
+        exc = _make_rate_limit_error(
+            status_code=429,
+            retry_after=2.0,
+            model="google/gemini-2.0-flash",
+            headers={"retry-after": "2"},
+        )
+        pu = from_rate_limit_error(exc)
+
+        assert pu.provider == "google"
+        assert pu.state == ProviderUtilizationState.EXHAUSTED
+        assert pu.retry_after_seconds == 2.0
+        assert pu.source == "retry_after_header"
+
+    def test_near_limit_from_high_utilization(self) -> None:
+        """A 429 with no retry_after but high rpm marks provider NEAR_LIMIT.
+
+        When the server returns 429 but without a Retry-After header (e.g.,
+        immediate backoff), the provider is congested but not fully exhausted.
+        """
+        from tta.llm.provider_utilization import (
+            ProviderUtilizationState,
+            from_rate_limit_error,
+        )
+
+        exc = _make_rate_limit_error(
+            status_code=429,
+            retry_after=None,
+            model="nvidia/llama-3.3-70b-instruct",
+            headers={},
+        )
+        pu = from_rate_limit_error(exc)
+
+        assert pu.provider == "nvidia"
+        assert pu.state == ProviderUtilizationState.NEAR_LIMIT
+        assert pu.retry_after_seconds is None
+        assert pu.source == "429_no_retry_after"
+
+    def test_extracts_provider_from_model_name(self) -> None:
+        """Provider is the model prefix, extracted from 'openai/gpt-4o'."""
+        from tta.llm.provider_utilization import from_rate_limit_error
+
+        exc = _make_rate_limit_error(
+            status_code=429,
+            retry_after=1.0,
+            model="openai/gpt-4o",
+            headers={"retry-after": "1"},
+        )
+        pu = from_rate_limit_error(exc)
+
+        assert pu.provider == "openai"
+
+    def test_missing_signal_is_unknown_not_healthy(self) -> None:
+        """UNKNOWN is the safe default — never assume HEALTHY without evidence.
+
+        AC-66.04 requires actual signal before routing preferences change.
+        A missing signal must not bias routing toward HEALTHY.
+        """
+        from tta.llm.provider_utilization import (
+            ProviderUtilization,
+            ProviderUtilizationState,
+        )
+
+        pu = ProviderUtilization(
+            provider="google", state=ProviderUtilizationState.UNKNOWN
+        )
+        assert pu.state == ProviderUtilizationState.UNKNOWN
+        # The key invariant: UNKNOWN != HEALTHY
+        assert ProviderUtilizationState.UNKNOWN != ProviderUtilizationState.HEALTHY
+
+
+@pytest.mark.spec("AC-66.04")
+class TestProviderUtilizationSnapshot:
+    """Optional snapshot interface for batch provider state queries."""
+
+    def test_snapshot_protocol(self) -> None:
+        """A ProviderUtilizationSnapshot maps provider names to state."""
+        from collections.abc import Mapping
+
+        from tta.llm.provider_utilization import (
+            ProviderUtilization,
+            ProviderUtilizationSnapshot,
+            ProviderUtilizationState,
+        )
+
+        # Inline fake implementing the protocol for test isolation
+        class FakeSnapshot:
+            def snapshot(self) -> Mapping[str, ProviderUtilization]:
+                return {
+                    "google": ProviderUtilization(
+                        provider="google",
+                        state=ProviderUtilizationState.NEAR_LIMIT,
+                        source="retry_after_header",
+                    ),
+                }
+
+        snapshot: ProviderUtilizationSnapshot = FakeSnapshot()
+        state_map = snapshot.snapshot()
+        assert "google" in state_map
+        assert state_map["google"].state == ProviderUtilizationState.NEAR_LIMIT
+
+
+# ---------------------------------------------------------------------------
+# Test helpers — synthetic LiteLLM RateLimitError without live calls
+# ---------------------------------------------------------------------------
+
+
+def _make_rate_limit_error(
+    *,
+    status_code: int,
+    retry_after: float | None,
+    model: str,
+    headers: dict[str, str],
+) -> Exception:
+    """Build a synthetic LiteLLM RateLimitError with known attributes.
+
+    LiteLLM's RateLimitError has: status_code, response_headers, retry_after,
+    model, and message.
+    """
+    # Use a minimal mock that sets the attributes LiteLLM actually uses
+    exc = Exception(f"Rate limit exceeded for model={model}")
+    exc.status_code = status_code
+    exc.model = model
+    exc._response_headers: dict[str, str] = headers  # type: ignore[reportAttributeAccessIssue]
+    exc.retry_after = retry_after  # type: ignore[reportAttributeAccessIssue]
+    return exc

--- a/tests/unit/llm/test_rate_limit_budget.py
+++ b/tests/unit/llm/test_rate_limit_budget.py
@@ -4,6 +4,7 @@ Existing implementation reality-check coverage for S66.
 """
 
 import asyncio
+from collections.abc import Mapping
 
 import pytest
 from structlog.testing import capture_logs
@@ -391,3 +392,55 @@ class TestStructlogEvents:
         }
         assert "routing_decision" not in admitted_event
         assert "provider_selected_by_utilization" not in admitted_event
+
+    async def test_critical_admission_ignores_snapshot_lookup_failures(self) -> None:
+        """Observability snapshot failures must not block CRITICAL admission."""
+        from tta.llm.provider_utilization import ProviderUtilization
+        from tta.llm.rate_limiter import RateLimitBudget, TaskPriority
+
+        class BrokenSnapshot:
+            def snapshot(self) -> Mapping[str, ProviderUtilization]:
+                raise RuntimeError("snapshot unavailable")
+
+        budget = RateLimitBudget(provider_utilization_snapshot=BrokenSnapshot())
+
+        with capture_logs() as logs:
+            assert await budget.admit(
+                TaskPriority.CRITICAL,
+                task_type="player_turn",
+                provider="google",
+            )
+            await budget.release(TaskPriority.CRITICAL, provider="google")
+
+        admitted_event = next(
+            event for event in logs if event["event"] == "rate_limit_admitted"
+        )
+        assert admitted_event["tier"] == "critical"
+        assert admitted_event["provider_utilization"] is None
+
+    async def test_snapshot_lookup_failures_fail_open_for_non_critical_logs(
+        self,
+    ) -> None:
+        """Observability seam must fail open when snapshot lookup raises."""
+        from tta.llm.provider_utilization import ProviderUtilization
+        from tta.llm.rate_limiter import RateLimitBudget, TaskPriority
+
+        class BrokenSnapshot:
+            def snapshot(self) -> Mapping[str, ProviderUtilization]:
+                raise RuntimeError("snapshot unavailable")
+
+        budget = RateLimitBudget(provider_utilization_snapshot=BrokenSnapshot())
+
+        with capture_logs() as logs:
+            assert await budget.admit(
+                TaskPriority.LOW,
+                task_type="npc_autonomy",
+                provider="google",
+            )
+            await budget.release(TaskPriority.LOW, provider="google")
+
+        admitted_event = next(
+            event for event in logs if event["event"] == "rate_limit_admitted"
+        )
+        assert admitted_event["tier"] == "low"
+        assert admitted_event["provider_utilization"] is None

--- a/tests/unit/llm/test_rate_limit_budget.py
+++ b/tests/unit/llm/test_rate_limit_budget.py
@@ -340,3 +340,54 @@ class TestStructlogEvents:
             and event["provider_utilization"] is None
             for event in logs
         )
+
+    async def test_admission_logs_provider_utilization_when_snapshot_supplied(
+        self,
+    ) -> None:
+        """Admission logs include provider state when a snapshot and provider are known.
+
+        This spike enriches observability only. It does NOT claim provider-aware
+        routing yet — the decision remains the normal admission decision.
+        """
+        from tta.llm.provider_utilization import (
+            ProviderUtilization,
+            ProviderUtilizationState,
+        )
+        from tta.llm.rate_limiter import RateLimitBudget, TaskPriority
+
+        class FakeSnapshot:
+            def snapshot(self) -> dict[str, ProviderUtilization]:
+                return {
+                    "google": ProviderUtilization(
+                        provider="google",
+                        state=ProviderUtilizationState.NEAR_LIMIT,
+                        retry_after_seconds=2.0,
+                        source="retry_after_header",
+                    )
+                }
+
+        budget = RateLimitBudget(provider_utilization_snapshot=FakeSnapshot())
+
+        with capture_logs() as logs:
+            assert await budget.admit(
+                TaskPriority.LOW,
+                task_type="npc_autonomy",
+                provider="google",
+            )
+            await budget.release(TaskPriority.LOW, provider="google")
+
+        admitted_event = next(
+            event for event in logs if event["event"] == "rate_limit_admitted"
+        )
+        assert admitted_event["tier"] == "low"
+        assert admitted_event["task_type"] == "npc_autonomy"
+        assert admitted_event["decision"] == "admitted"
+        assert admitted_event["provider_utilization"] == {
+            "provider": "google",
+            "state": "near_limit",
+            "rpm_utilization": None,
+            "retry_after_seconds": 2.0,
+            "source": "retry_after_header",
+        }
+        assert "routing_decision" not in admitted_event
+        assert "provider_selected_by_utilization" not in admitted_event


### PR DESCRIPTION
## Summary
- add a typed provider-utilization signal seam for S66 AC-66.04 spike work
- enrich `RateLimitBudget` admission/completion logs with optional provider utilization context
- document spike results while keeping AC-66.04 truthfully deferred until routing exists

## Validation
- uv run pytest tests/unit/llm/test_provider_utilization.py tests/unit/llm/test_rate_limit_budget.py -q
- uv run python plans/index_plans.py --validate
- uv run python scripts/workflow_state.py status
- make trace
- make complete-check
- make gate
