### PR TITLE
feat: implement AC-66.04 provider preference routing

### DIFF
--- a/plans/s66-ac6604-provider-preference.md
+++ b/plans/s66-ac6604-provider-preference.md
@@ -1,0 +1,187 @@
+# S66 AC-66.04 Provider-Preference Implementation Plan
+
+> **Status**: 📝 Draft
+> **Scope**: S66 AC-66.04 real implementation
+> **Owner**: Hermes
+> **For Hermes:** Use subagent-driven-development and free-agent-swarm review after each bounded slice; do not claim AC completion until `make trace` shows honest coverage and tests exercise real provider selection behavior.
+
+## Goal
+
+Implement the real AC-66.04 behavior from `specs/66-rate-limit-budget.md`:
+
+- Given Google is `NEAR_LIMIT`
+- And NVIDIA is `HEALTHY`
+- When a `LOW` tier call is admitted
+- Then the call is dispatched to a model on the NVIDIA provider
+- And no Google model is used for this call
+
+This is not a logging change. It must affect actual model/provider dispatch order.
+
+## Truth boundary
+
+The spike already introduced a typed provider-utilization signal seam.
+That did not complete AC-66.04.
+
+The real blocker discovered during prerequisite analysis is structural:
+
+- `RateLimitBudget` knows provider utilization, but only for admission/logging.
+- `LiteLLMClient._call_with_fallback()` owns actual model selection order.
+- `ModelRoleConfig` currently exposes only `primary` and `fallback` model strings.
+- Default `openai` backend config uses `openai/tta` for both generation primary and fallback, so there is no app-visible provider choice unless config supplies distinct provider-qualified models.
+
+Therefore this slice must do two things:
+
+1. Add an explicit provider-aware candidate ordering seam in the actual client path.
+2. Make that seam no-op when there are not multiple distinct provider candidates.
+
+Anything less is fake compliance.
+
+## Design constraints
+
+- Keep existing default behavior unchanged when no provider signal exists.
+- Never assume `HEALTHY`; `UNKNOWN` must not outrank explicit healthy providers.
+- Do not block `CRITICAL` requests on observability/provider lookup failures.
+- Fail open on snapshot lookup errors.
+- Do not introduce network dependency for tests.
+- Use stdlib + existing repo dependencies only.
+- Preserve current fallback/retry semantics inside a selected candidate.
+
+## Proposed implementation
+
+### 1. Extend role config to express provider candidates
+
+Add an optional ordered tuple/list of candidate model strings to `ModelRoleConfig`, with compatibility rules:
+
+- If `candidates` is unset:
+  - synthesize candidates from `(primary, fallback?)`
+- If `candidates` is set:
+  - `primary` becomes the first candidate
+  - `fallback` becomes the second candidate when present
+  - existing consumers remain compatible
+
+This keeps old config shape working while allowing explicit multi-provider generation choices such as:
+
+- `google/...`
+- `nvidia/...`
+- `groq/...`
+
+### 2. Add provider-ordering policy helper
+
+Create a helper in `tta.llm.provider_utilization` or `tta.llm.litellm_client` that:
+
+- extracts provider from each candidate model string
+- looks up provider state from an injected snapshot mapping
+- ranks candidates for low-priority work:
+  - `HEALTHY`
+  - `ELEVATED`
+  - `UNKNOWN`
+  - `NEAR_LIMIT`
+  - `EXHAUSTED`
+- preserves original declaration order as stable tiebreaker
+
+For `CRITICAL`/`HIGH`, keep declared order.
+For `LOW`/`BEST_EFFORT`, reorder by utilization preference.
+
+### 3. Thread task tier into the real dispatch path
+
+Today `RateLimitedLLMClient` admits by tier but does not pass tier/provider preference to `LiteLLMClient`.
+
+Add an internal optional dispatch-context parameter through the wrapped client path so the concrete client can know:
+
+- request tier
+- provider snapshot (or derived ranking inputs)
+
+Do this without breaking the public `LLMClient` protocol used by call sites. Likely shape:
+
+- keep `LLMClient` public methods unchanged
+- add optional concrete-only kwargs on `RateLimitedLLMClient -> LiteLLMClient`
+- or add a dedicated internal method used only when the wrapped client supports it
+
+### 4. Reorder candidate traversal in LiteLLMClient
+
+Replace the hard-coded `(primary, fallback)` traversal with:
+
+- build candidate list from config
+- reorder list when tier is `LOW`/`BEST_EFFORT` and provider signal exists
+- then keep the existing retry-per-tier / fall-through behavior
+
+This is the real AC-66.04 control point.
+
+### 5. Honest deferred-coverage cleanup
+
+Remove the deferred `AC-66.04` skip from `tests/unit/v2_deferred_coverage.py` only after:
+
+- unit tests prove provider-preference ordering
+- trace shows AC-66.04 covered by real tests
+
+## Test plan
+
+### Red tests to add first
+
+1. Candidate ordering helper:
+   - healthy beats near_limit for LOW
+   - exhausted always sorted last for LOW
+   - unknown does not beat healthy
+   - original order preserved within same state
+
+2. LiteLLMClient dispatch order:
+   - when generation config has `google/...` then `nvidia/...`
+   - and snapshot marks google `NEAR_LIMIT`, nvidia `HEALTHY`
+   - LOW tier attempts NVIDIA first
+   - HIGH/CRITICAL still attempt declared primary first
+
+3. No-op compatibility:
+   - with no snapshot, declared order remains unchanged
+   - with single candidate / same provider on both entries, behavior unchanged
+
+4. RateLimitedLLMClient integration:
+   - LOW request passes tier/context into inner client
+   - snapshot failure does not crash request path
+
+5. AC marker migration:
+   - real AC-66.04 tests get `@pytest.mark.spec("AC-66.04")`
+   - deferred skip removed only after the above pass
+
+## Files likely to change
+
+- `src/tta/llm/roles.py`
+- `src/tta/llm/litellm_client.py`
+- `src/tta/llm/rate_limiter.py`
+- `src/tta/llm/provider_utilization.py`
+- `tests/unit/llm/test_litellm_client.py`
+- `tests/unit/llm/test_rate_limited_client.py`
+- `tests/unit/llm/test_provider_utilization.py` or a new focused test module
+- `tests/unit/v2_deferred_coverage.py`
+
+## Verification
+
+Minimum gate before claiming completion:
+
+- focused pytest on touched llm modules
+- `ruff check src tests`
+- `ruff format --check src tests`
+- `make trace`
+
+Then perform an independent free-model review swarm against the diff.
+
+## Risks
+
+1. Config/API creep:
+   avoid exposing a broad new public API if an internal seam is enough.
+
+2. Fake provider preference on router aliases:
+   if both candidates are `openai/tta`, there is no app-visible provider distinction.
+   Tests must use provider-qualified model strings.
+
+3. Behavior drift for existing users:
+   default order must remain identical unless low-priority provider-aware routing is actually applicable.
+
+## Exit criteria
+
+AC-66.04 is complete only when all are true:
+
+- real tests with `@pytest.mark.spec("AC-66.04")` pass
+- deferred skip is removed
+- LOW/BEST_EFFORT dispatch demonstrably prefers healthier providers when distinct provider candidates exist
+- HIGH/CRITICAL behavior remains unchanged
+- `make trace` stays green

--- a/src/tta/api/app.py
+++ b/src/tta/api/app.py
@@ -207,6 +207,7 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         import os
 
         from tta.llm.litellm_client import LiteLLMClient
+        from tta.llm.rate_limiter import RateLimitedLLMClient
         from tta.llm.roles import (
             BACKEND_ROLE_CONFIGS,
             DEFAULT_ROLE_CONFIGS,
@@ -252,7 +253,9 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
                 )
             _effective_role_configs = _overridden
 
-        app.state.llm_client = LiteLLMClient(role_configs=_effective_role_configs)
+        app.state.llm_client = RateLimitedLLMClient(
+            inner=LiteLLMClient(role_configs=_effective_role_configs)
+        )
         app.state.llm_role_configs = _effective_role_configs
 
         # S17 FR-17.30: log configured LLM provider on startup for audit trail

--- a/src/tta/api/app.py
+++ b/src/tta/api/app.py
@@ -207,7 +207,8 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         import os
 
         from tta.llm.litellm_client import LiteLLMClient
-        from tta.llm.rate_limiter import RateLimitedLLMClient
+        from tta.llm.provider_utilization import InMemoryProviderUtilizationSnapshot
+        from tta.llm.rate_limiter import RateLimitBudget, RateLimitedLLMClient
         from tta.llm.roles import (
             BACKEND_ROLE_CONFIGS,
             DEFAULT_ROLE_CONFIGS,
@@ -234,6 +235,7 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
 
         _primary_override = _qualify_model_name(settings.litellm_model)
         _fallback_override = _qualify_model_name(settings.litellm_fallback_model)
+        _provider_snapshot = InMemoryProviderUtilizationSnapshot()
 
         # Allow env-var overrides for primary/fallback model per FR-17.30 audit.
         # If TTA_LITELLM_MODEL is non-default, override ALL roles so that
@@ -254,7 +256,11 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
             _effective_role_configs = _overridden
 
         app.state.llm_client = RateLimitedLLMClient(
-            inner=LiteLLMClient(role_configs=_effective_role_configs)
+            inner=LiteLLMClient(
+                role_configs=_effective_role_configs,
+                provider_utilization_snapshot=_provider_snapshot,
+            ),
+            budget=RateLimitBudget(provider_utilization_snapshot=_provider_snapshot),
         )
         app.state.llm_role_configs = _effective_role_configs
 

--- a/src/tta/llm/client.py
+++ b/src/tta/llm/client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Any, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 from pydantic import BaseModel, Field
 
@@ -13,6 +13,9 @@ from tta.llm.serving_profiles import (
     GenerationTrafficClass,
 )
 from tta.models.turn import TokenCount
+
+if TYPE_CHECKING:
+    from tta.llm.rate_limiter import TaskPriority
 
 
 class MessageRole(StrEnum):
@@ -77,6 +80,7 @@ class LLMClient(Protocol):
         *,
         generation_profile: GenerationServingProfile | None = None,
         traffic_class: GenerationTrafficClass | None = None,
+        task_priority: TaskPriority | None = None,
     ) -> LLMResponse: ...
 
     async def stream(
@@ -87,4 +91,5 @@ class LLMClient(Protocol):
         *,
         generation_profile: GenerationServingProfile | None = None,
         traffic_class: GenerationTrafficClass | None = None,
+        task_priority: TaskPriority | None = None,
     ) -> LLMResponse: ...

--- a/src/tta/llm/litellm_client.py
+++ b/src/tta/llm/litellm_client.py
@@ -34,6 +34,7 @@ from tta.llm.provider_utilization import (
     ProviderUtilization,
     ProviderUtilizationSnapshot,
     ProviderUtilizationState,
+    from_rate_limit_error,
 )
 from tta.llm.roles import (
     DEFAULT_ROLE_CONFIGS,
@@ -51,6 +52,7 @@ from tta.models.turn import TokenCount
 if TYPE_CHECKING:
     from tta.llm.rate_limiter import TaskPriority
 
+from tta.llm.rate_limiter import TaskPriority
 from tta.observability.metrics import (
     TURN_LLM_CALLS,
     TURN_LLM_DURATION,
@@ -214,6 +216,7 @@ class LiteLLMClient:
             except PermanentLLMError:
                 raise
             except TransientLLMError as exc:
+                self._record_provider_utilization(exc)
                 errors.append(exc)
                 log.warning(
                     "tier_failed",
@@ -241,8 +244,7 @@ class LiteLLMClient:
     ) -> list[tuple[str, TierName]]:
         if (
             role != ModelRole.GENERATION
-            or task_priority is None
-            or str(task_priority) not in {"low", "best_effort"}
+            or task_priority not in {TaskPriority.LOW, TaskPriority.BEST_EFFORT}
             or self._provider_utilization_snapshot is None
             or len(tiers) < 2
         ):
@@ -278,6 +280,23 @@ class LiteLLMClient:
             return snapshot.snapshot()
         except Exception:
             return None
+
+    def _record_provider_utilization(self, exc: Exception) -> None:
+        snapshot = self._provider_utilization_snapshot
+        if snapshot is None:
+            return
+        source_exc = exc.__cause__ if isinstance(exc.__cause__, Exception) else exc
+        record = getattr(snapshot, "record", None)
+        if callable(record):
+            try:
+                record(source_exc)
+                return
+            except Exception:
+                return
+        try:
+            from_rate_limit_error(source_exc)
+        except Exception:
+            return
 
     def _provider_for_model(self, model: str) -> str | None:
         if "/" not in model:

--- a/src/tta/llm/litellm_client.py
+++ b/src/tta/llm/litellm_client.py
@@ -7,7 +7,8 @@ See plans/llm-and-pipeline.md §1 for design details.
 from __future__ import annotations
 
 import time
-from typing import Any, Literal
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Literal
 
 import litellm
 import structlog
@@ -29,6 +30,11 @@ from tta.llm.errors import (
     TransientLLMError,
     classify_error,
 )
+from tta.llm.provider_utilization import (
+    ProviderUtilization,
+    ProviderUtilizationSnapshot,
+    ProviderUtilizationState,
+)
 from tta.llm.roles import (
     DEFAULT_ROLE_CONFIGS,
     ModelRole,
@@ -41,6 +47,10 @@ from tta.llm.serving_profiles import (
     resolve_generation_policy,
 )
 from tta.models.turn import TokenCount
+
+if TYPE_CHECKING:
+    from tta.llm.rate_limiter import TaskPriority
+
 from tta.observability.metrics import (
     TURN_LLM_CALLS,
     TURN_LLM_DURATION,
@@ -77,8 +87,10 @@ class LiteLLMClient:
     def __init__(
         self,
         role_configs: dict[ModelRole, ModelRoleConfig] | None = None,
+        provider_utilization_snapshot: ProviderUtilizationSnapshot | None = None,
     ) -> None:
         self._role_configs = role_configs or DEFAULT_ROLE_CONFIGS
+        self._provider_utilization_snapshot = provider_utilization_snapshot
 
     async def generate(
         self,
@@ -88,6 +100,7 @@ class LiteLLMClient:
         *,
         generation_profile: GenerationServingProfile | None = None,
         traffic_class: GenerationTrafficClass | None = None,
+        task_priority: TaskPriority | None = None,
     ) -> LLMResponse:
         """Generate a complete response (non-streaming)."""
         return await self._call_with_fallback(
@@ -97,6 +110,7 @@ class LiteLLMClient:
             stream=False,
             generation_profile=generation_profile,
             traffic_class=traffic_class,
+            task_priority=task_priority,
         )
 
     async def stream(
@@ -107,6 +121,7 @@ class LiteLLMClient:
         *,
         generation_profile: GenerationServingProfile | None = None,
         traffic_class: GenerationTrafficClass | None = None,
+        task_priority: TaskPriority | None = None,
     ) -> LLMResponse:
         """Buffer-then-stream: streams internally, returns LLMResponse."""
         return await self._call_with_fallback(
@@ -116,6 +131,7 @@ class LiteLLMClient:
             stream=True,
             generation_profile=generation_profile,
             traffic_class=traffic_class,
+            task_priority=task_priority,
         )
 
     async def _call_with_fallback(
@@ -127,6 +143,7 @@ class LiteLLMClient:
         stream: bool,
         generation_profile: GenerationServingProfile | None,
         traffic_class: GenerationTrafficClass | None,
+        task_priority: TaskPriority | None,
     ) -> LLMResponse:
         config = self._role_configs.get(role)
         if config is None:
@@ -157,6 +174,11 @@ class LiteLLMClient:
         ]
         if config.fallback:
             tiers.append((config.fallback, "fallback"))
+        tiers = self._order_tiers_by_provider_utilization(
+            tiers,
+            role=role,
+            task_priority=task_priority,
+        )
 
         errors: list[Exception] = []
         for model, tier_name in tiers:
@@ -209,6 +231,70 @@ class LiteLLMClient:
                 errors=errors,
             )
         raise AllTiersFailedError(role=str(role), errors=errors)
+
+    def _order_tiers_by_provider_utilization(
+        self,
+        tiers: list[tuple[str, TierName]],
+        *,
+        role: ModelRole,
+        task_priority: TaskPriority | None,
+    ) -> list[tuple[str, TierName]]:
+        if (
+            role != ModelRole.GENERATION
+            or task_priority is None
+            or str(task_priority) not in {"low", "best_effort"}
+            or self._provider_utilization_snapshot is None
+            or len(tiers) < 2
+        ):
+            return tiers
+
+        snapshot = self._safe_snapshot()
+        if snapshot is None:
+            return tiers
+
+        providers = [self._provider_for_model(model) for model, _ in tiers]
+        distinct_providers = {
+            provider for provider in providers if provider is not None
+        }
+        if len(distinct_providers) < 2:
+            return tiers
+
+        indexed = list(enumerate(tiers))
+        indexed.sort(
+            key=lambda item: (
+                self._provider_state_rank(
+                    snapshot.get(self._provider_for_model(item[1][0]) or "")
+                ),
+                item[0],
+            )
+        )
+        return [tier for _, tier in indexed]
+
+    def _safe_snapshot(self) -> Mapping[str, ProviderUtilization] | None:
+        snapshot = self._provider_utilization_snapshot
+        if snapshot is None:
+            return None
+        try:
+            return snapshot.snapshot()
+        except Exception:
+            return None
+
+    def _provider_for_model(self, model: str) -> str | None:
+        if "/" not in model:
+            return None
+        return model.split("/", 1)[0]
+
+    def _provider_state_rank(self, utilization: ProviderUtilization | None) -> int:
+        if utilization is None:
+            return 2
+        order = {
+            ProviderUtilizationState.HEALTHY: 0,
+            ProviderUtilizationState.ELEVATED: 1,
+            ProviderUtilizationState.UNKNOWN: 2,
+            ProviderUtilizationState.NEAR_LIMIT: 3,
+            ProviderUtilizationState.EXHAUSTED: 4,
+        }
+        return order.get(utilization.state, 2)
 
     @retry(
         retry=retry_if_exception_type(TransientLLMError),

--- a/src/tta/llm/provider_utilization.py
+++ b/src/tta/llm/provider_utilization.py
@@ -17,7 +17,7 @@ implemented here. That belongs to the slice that consumes this signal.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Protocol
 
@@ -75,6 +75,21 @@ class ProviderUtilizationSnapshot(Protocol):
 
 #: Type alias for concrete snapshot implementations
 type ProviderUtilizationSource = ProviderUtilizationSnapshot
+
+
+@dataclass
+class InMemoryProviderUtilizationSnapshot:
+    """Mutable in-process provider state store for routing and observability."""
+
+    _snapshot: dict[str, ProviderUtilization] = field(default_factory=dict)
+
+    def snapshot(self) -> Mapping[str, ProviderUtilization]:
+        return dict(self._snapshot)
+
+    def record(self, exc: Exception) -> ProviderUtilization:
+        utilization = from_rate_limit_error(exc)
+        self._snapshot[utilization.provider] = utilization
+        return utilization
 
 
 def from_rate_limit_error(exc: Exception) -> ProviderUtilization:

--- a/src/tta/llm/rate_limiter.py
+++ b/src/tta/llm/rate_limiter.py
@@ -346,25 +346,33 @@ class RateLimitedLLMClient:
         task_type: str = "",
         generation_profile=None,
         traffic_class=None,
+        task_priority: TaskPriority | None = None,
     ):
         """Generate with admission control per tier.
 
         CRITICAL tier bypasses the budget entirely.
         """
-        await self._enforce(tier, task_type)
+        effective_tier = task_priority or tier
+        await self._enforce(effective_tier, task_type)
         try:
             if generation_profile is None and traffic_class is None:
-                return await self._inner.generate(role, messages, params)
+                return await self._inner.generate(
+                    role,
+                    messages,
+                    params,
+                    task_priority=effective_tier,
+                )
             return await self._inner.generate(
                 role,
                 messages,
                 params,
                 generation_profile=generation_profile,
                 traffic_class=traffic_class,
+                task_priority=effective_tier,
             )
         finally:
-            if tier != TaskPriority.CRITICAL:
-                await self._budget.release(tier)
+            if effective_tier != TaskPriority.CRITICAL:
+                await self._budget.release(effective_tier)
 
     async def stream(
         self,
@@ -376,22 +384,30 @@ class RateLimitedLLMClient:
         task_type: str = "",
         generation_profile=None,
         traffic_class=None,
+        task_priority: TaskPriority | None = None,
     ):
         """Stream with admission control per tier."""
-        await self._enforce(tier, task_type)
+        effective_tier = task_priority or tier
+        await self._enforce(effective_tier, task_type)
         try:
             if generation_profile is None and traffic_class is None:
-                return await self._inner.stream(role, messages, params)
+                return await self._inner.stream(
+                    role,
+                    messages,
+                    params,
+                    task_priority=effective_tier,
+                )
             return await self._inner.stream(
                 role,
                 messages,
                 params,
                 generation_profile=generation_profile,
                 traffic_class=traffic_class,
+                task_priority=effective_tier,
             )
         finally:
-            if tier != TaskPriority.CRITICAL:
-                await self._budget.release(tier)
+            if effective_tier != TaskPriority.CRITICAL:
+                await self._budget.release(effective_tier)
 
     # ------------------------------------------------------------------
     # Internal

--- a/src/tta/llm/smart_router_client.py
+++ b/src/tta/llm/smart_router_client.py
@@ -18,12 +18,14 @@ FREE_MODEL_ROUTER_API_KEY
     API key for the free-model-router (default: \"free-model-router\").
 """
 
+from __future__ import annotations
+
 import asyncio
 import os
 import subprocess
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
 import structlog
@@ -32,6 +34,9 @@ from tta.llm.client import GenerationParams, LLMResponse, Message, TokenCount
 from tta.llm.errors import PermanentLLMError, TransientLLMError
 from tta.llm.roles import ModelRole
 from tta.llm.serving_profiles import GenerationServingProfile, GenerationTrafficClass
+
+if TYPE_CHECKING:
+    from tta.llm.rate_limiter import TaskPriority
 
 log = structlog.get_logger(__name__)
 
@@ -81,6 +86,7 @@ class SmartRouterLLMClient:
         *,
         generation_profile: GenerationServingProfile | None = None,
         traffic_class: GenerationTrafficClass | None = None,
+        task_priority: TaskPriority | None = None,
     ) -> LLMResponse:
         """Generate a response using free-model-router."""
         await self._ensure_ready()
@@ -185,6 +191,7 @@ class SmartRouterLLMClient:
         *,
         generation_profile: GenerationServingProfile | None = None,
         traffic_class: GenerationTrafficClass | None = None,
+        task_priority: TaskPriority | None = None,
     ) -> LLMResponse:
         """Buffer-then-stream: delegate to :meth:`generate`."""
         return await self.generate(
@@ -193,6 +200,7 @@ class SmartRouterLLMClient:
             params,
             generation_profile=generation_profile,
             traffic_class=traffic_class,
+            task_priority=task_priority,
         )
 
     # ------------------------------------------------------------------
@@ -212,7 +220,7 @@ class SmartRouterLLMClient:
                 self._server_proc.kill()
             self._server_proc = None
 
-    async def __aenter__(self) -> "SmartRouterLLMClient":
+    async def __aenter__(self) -> SmartRouterLLMClient:
         return self
 
     async def __aexit__(self, *_: Any) -> None:

--- a/src/tta/llm/testing.py
+++ b/src/tta/llm/testing.py
@@ -1,5 +1,9 @@
 """Deterministic mock LLM client for testing."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from tta.llm.client import (
     GenerationParams,
     LLMResponse,
@@ -11,6 +15,9 @@ from tta.llm.serving_profiles import (
     GenerationTrafficClass,
 )
 from tta.models.turn import TokenCount
+
+if TYPE_CHECKING:
+    from tta.llm.rate_limiter import TaskPriority
 
 MOCK_RESPONSE = "You enter a dimly lit chamber."
 
@@ -56,6 +63,7 @@ class MockLLMClient:
         *,
         generation_profile: GenerationServingProfile | None = None,
         traffic_class: GenerationTrafficClass | None = None,
+        task_priority: TaskPriority | None = None,
     ) -> LLMResponse:
         self.call_history.append(
             {
@@ -63,6 +71,7 @@ class MockLLMClient:
                 "role": role,
                 "messages": messages,
                 "params": params,
+                "task_priority": task_priority,
             }
         )
         return self._build_response(messages, role)
@@ -75,6 +84,7 @@ class MockLLMClient:
         *,
         generation_profile: GenerationServingProfile | None = None,
         traffic_class: GenerationTrafficClass | None = None,
+        task_priority: TaskPriority | None = None,
     ) -> LLMResponse:
         """Buffer-then-stream: returns complete LLMResponse like generate()."""
         self.call_history.append(
@@ -83,6 +93,7 @@ class MockLLMClient:
                 "role": role,
                 "messages": messages,
                 "params": params,
+                "task_priority": task_priority,
             }
         )
         return self._build_response(messages, role)

--- a/tests/unit/api/test_app.py
+++ b/tests/unit/api/test_app.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 from tta.api.app import create_app
 from tta.config import Settings
+from tta.llm.rate_limiter import RateLimitedLLMClient
 
 
 @pytest.fixture()
@@ -121,6 +122,10 @@ class TestLifespanWiring:
     def test_world_service_injected(self, app: FastAPI) -> None:
         with TestClient(app) as c:
             assert c.app.state.world_service is not None  # type: ignore[union-attr]
+
+    def test_default_app_uses_rate_limited_llm_client(self, app: FastAPI) -> None:
+        with TestClient(app) as c:
+            assert isinstance(c.app.state.llm_client, RateLimitedLLMClient)  # type: ignore[union-attr]
 
     def test_summary_service_qualifies_explicit_summary_model_alias(self) -> None:
         app = create_app(

--- a/tests/unit/api/test_app.py
+++ b/tests/unit/api/test_app.py
@@ -127,6 +127,18 @@ class TestLifespanWiring:
         with TestClient(app) as c:
             assert isinstance(c.app.state.llm_client, RateLimitedLLMClient)  # type: ignore[union-attr]
 
+    def test_default_app_shares_provider_snapshot_between_budget_and_inner_client(
+        self, app: FastAPI
+    ) -> None:
+        with TestClient(app) as c:
+            llm_client = c.app.state.llm_client  # type: ignore[union-attr]
+            assert isinstance(llm_client, RateLimitedLLMClient)
+            assert llm_client._budget._provider_utilization_snapshot is not None
+            assert (
+                llm_client._inner._provider_utilization_snapshot
+                is llm_client._budget._provider_utilization_snapshot
+            )
+
     def test_summary_service_qualifies_explicit_summary_model_alias(self) -> None:
         app = create_app(
             Settings(

--- a/tests/unit/llm/test_litellm_client.py
+++ b/tests/unit/llm/test_litellm_client.py
@@ -19,6 +19,11 @@ from tta.llm.errors import (
     TransientLLMError,
 )
 from tta.llm.litellm_client import LiteLLMClient
+from tta.llm.provider_utilization import (
+    ProviderUtilization,
+    ProviderUtilizationState,
+)
+from tta.llm.rate_limiter import TaskPriority
 from tta.llm.roles import ModelRole, ModelRoleConfig
 
 # ── helpers ──────────────────────────────────────────────────────────
@@ -52,6 +57,14 @@ def _role_configs(
 def _no_fallback_configs() -> dict[ModelRole, ModelRoleConfig]:
     """Role config with no fallback model."""
     return _role_configs(fallback=None)
+
+
+class _StaticProviderSnapshot:
+    def __init__(self, snapshot: dict[str, ProviderUtilization]) -> None:
+        self._snapshot = snapshot
+
+    def snapshot(self) -> dict[str, ProviderUtilization]:
+        return self._snapshot
 
 
 def _mock_response(
@@ -328,6 +341,85 @@ class TestFallback:
             await client.generate(ModelRole.GENERATION, MESSAGES)
 
         assert mock_ac.call_count == 1
+
+    @pytest.mark.spec("AC-66.04")
+    @pytest.mark.asyncio
+    @patch(_COST, return_value=0.0)
+    @patch(_ACOMPLETION)
+    async def test_low_tier_prefers_healthier_provider_candidate(
+        self, mock_ac: AsyncMock, mock_cost: MagicMock
+    ) -> None:
+        """LOW tier should try a healthier provider before a near-limit provider."""
+        mock_ac.return_value = _mock_response(content="from healthier provider")
+        client = LiteLLMClient(
+            role_configs=_role_configs(
+                primary="google/gemini-test",
+                fallback="nvidia/llama-test",
+            ),
+            provider_utilization_snapshot=_StaticProviderSnapshot(
+                {
+                    "google": ProviderUtilization(
+                        provider="google",
+                        state=ProviderUtilizationState.NEAR_LIMIT,
+                        source="test",
+                    ),
+                    "nvidia": ProviderUtilization(
+                        provider="nvidia",
+                        state=ProviderUtilizationState.HEALTHY,
+                        source="test",
+                    ),
+                }
+            ),
+        )
+
+        await client.generate(
+            ModelRole.GENERATION,
+            MESSAGES,
+            PARAMS,
+            task_priority=TaskPriority.LOW,
+        )
+
+        first_model = mock_ac.call_args_list[0].kwargs["model"]
+        assert first_model == "nvidia/llama-test"
+
+    @pytest.mark.asyncio
+    @patch(_COST, return_value=0.0)
+    @patch(_ACOMPLETION)
+    async def test_high_tier_keeps_declared_provider_order(
+        self, mock_ac: AsyncMock, mock_cost: MagicMock
+    ) -> None:
+        """HIGH tier keeps declared primary-first order even with provider signal."""
+        mock_ac.return_value = _mock_response(content="from declared primary")
+        client = LiteLLMClient(
+            role_configs=_role_configs(
+                primary="google/gemini-test",
+                fallback="nvidia/llama-test",
+            ),
+            provider_utilization_snapshot=_StaticProviderSnapshot(
+                {
+                    "google": ProviderUtilization(
+                        provider="google",
+                        state=ProviderUtilizationState.NEAR_LIMIT,
+                        source="test",
+                    ),
+                    "nvidia": ProviderUtilization(
+                        provider="nvidia",
+                        state=ProviderUtilizationState.HEALTHY,
+                        source="test",
+                    ),
+                }
+            ),
+        )
+
+        await client.generate(
+            ModelRole.GENERATION,
+            MESSAGES,
+            PARAMS,
+            task_priority=TaskPriority.HIGH,
+        )
+
+        first_model = mock_ac.call_args_list[0].kwargs["model"]
+        assert first_model == "google/gemini-test"
 
 
 # ── retry tests ─────────────────────────────────────────────────────

--- a/tests/unit/llm/test_litellm_client.py
+++ b/tests/unit/llm/test_litellm_client.py
@@ -22,6 +22,7 @@ from tta.llm.litellm_client import LiteLLMClient
 from tta.llm.provider_utilization import (
     ProviderUtilization,
     ProviderUtilizationState,
+    from_rate_limit_error,
 )
 from tta.llm.rate_limiter import TaskPriority
 from tta.llm.roles import ModelRole, ModelRoleConfig
@@ -65,6 +66,18 @@ class _StaticProviderSnapshot:
 
     def snapshot(self) -> dict[str, ProviderUtilization]:
         return self._snapshot
+
+
+class _MutableProviderSnapshot:
+    def __init__(self) -> None:
+        self._snapshot: dict[str, ProviderUtilization] = {}
+
+    def snapshot(self) -> dict[str, ProviderUtilization]:
+        return dict(self._snapshot)
+
+    def record(self, exc: Exception) -> None:
+        utilization = from_rate_limit_error(exc)
+        self._snapshot[utilization.provider] = utilization
 
 
 def _mock_response(
@@ -420,6 +433,64 @@ class TestFallback:
 
         first_model = mock_ac.call_args_list[0].kwargs["model"]
         assert first_model == "google/gemini-test"
+
+    @pytest.mark.spec("AC-66.04")
+    @pytest.mark.asyncio
+    @patch(_COST, return_value=0.0)
+    @patch(_ACOMPLETION)
+    async def test_low_tier_reorders_after_provider_rate_limit_signal(
+        self, mock_ac: AsyncMock, mock_cost: MagicMock
+    ) -> None:
+        """A real 429 should seed provider state for the next LOW-tier call."""
+        snapshot = _MutableProviderSnapshot()
+        seed_client = LiteLLMClient(
+            role_configs=_role_configs(
+                primary="google/gemini-test",
+                fallback=None,
+            ),
+            provider_utilization_snapshot=snapshot,
+        )
+        followup_client = LiteLLMClient(
+            role_configs=_role_configs(
+                primary="google/gemini-test",
+                fallback="nvidia/llama-test",
+            ),
+            provider_utilization_snapshot=snapshot,
+        )
+
+        rate_limit_exc = Exception("rate limited")
+        rate_limit_exc.status_code = 429  # type: ignore[attr-defined]
+        rate_limit_exc.model = "google/gemini-test"  # type: ignore[attr-defined]
+        rate_limit_exc.retry_after = None  # type: ignore[attr-defined]
+        rate_limit_exc._response_headers = {}  # type: ignore[attr-defined]
+        mock_ac.side_effect = [
+            rate_limit_exc,
+            rate_limit_exc,
+            rate_limit_exc,
+            _mock_response(content="from healthier provider"),
+        ]
+
+        with pytest.raises(AllTiersFailedError):
+            await seed_client.generate(
+                ModelRole.GENERATION,
+                MESSAGES,
+                PARAMS,
+                task_priority=TaskPriority.LOW,
+            )
+
+        assert (
+            snapshot.snapshot()["google"].state == ProviderUtilizationState.NEAR_LIMIT
+        )
+
+        await followup_client.generate(
+            ModelRole.GENERATION,
+            MESSAGES,
+            PARAMS,
+            task_priority=TaskPriority.LOW,
+        )
+
+        first_model = mock_ac.call_args_list[3].kwargs["model"]
+        assert first_model == "nvidia/llama-test"
 
 
 # ── retry tests ─────────────────────────────────────────────────────

--- a/tests/unit/llm/test_rate_limited_client.py
+++ b/tests/unit/llm/test_rate_limited_client.py
@@ -1,6 +1,7 @@
 """Tests for RateLimitedLLMClient — admission-controlled wrapper (S66 §9.1)."""
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
@@ -83,6 +84,7 @@ class TestRateLimitedClientHigh:
                 *,
                 generation_profile=None,
                 traffic_class=None,
+                task_priority=None,
             ):
                 await hold_event.wait()
                 return await orig_generate(
@@ -91,6 +93,7 @@ class TestRateLimitedClientHigh:
                     params,
                     generation_profile=generation_profile,
                     traffic_class=traffic_class,
+                    task_priority=task_priority,
                 )
 
             mock.generate = blocking_generate  # pyright: ignore[reportAttributeAccessIssue]
@@ -140,3 +143,32 @@ class TestRateLimitedClientHigh:
             messages=[Message(role=MessageRole.USER, content="no_tier")],
         )
         assert result.content == "default"
+
+    @pytest.mark.spec("AC-66.04")
+    async def test_low_tier_forwards_dispatch_context_to_inner_client(self) -> None:
+        """LOW tier must be forwarded so the inner client can reorder providers."""
+        from tta.llm.rate_limiter import (
+            RateLimitBudget,
+            RateLimitedLLMClient,
+            TaskPriority,
+        )
+
+        captured: dict[str, object] = {}
+
+        class RecordingInner:
+            async def generate(self, role, messages, params=None, **kwargs):
+                captured.update(kwargs)
+                return SimpleNamespace(content="ok")
+
+        budget = RateLimitBudget(high_concurrency=1)
+        client = RateLimitedLLMClient(inner=RecordingInner(), budget=budget)
+
+        result = await client.generate(
+            role=ModelRole.GENERATION,
+            messages=[Message(role=MessageRole.USER, content="prefer healthy")],
+            tier=TaskPriority.LOW,
+            task_type="npc_autonomy",
+        )
+
+        assert result.content == "ok"
+        assert captured["task_priority"] == TaskPriority.LOW

--- a/tests/unit/v2_deferred_coverage.py
+++ b/tests/unit/v2_deferred_coverage.py
@@ -5,17 +5,6 @@
 import pytest
 
 
-@pytest.mark.spec("AC-66.04")
-@pytest.mark.skip(
-    reason=(
-        "S66 approved target: provider-preference needs a provider-utilization "
-        "signal spike before implementation."
-    )
-)
-def test_ac66_04_deferred_provider_preference() -> None:
-    """AC-66.04 requires routing LOW calls away from NEAR_LIMIT providers."""
-
-
 @pytest.mark.spec("AC-03.07")
 @pytest.mark.skip(
     reason="V2 deferred: coherence checker/regeneration is not built yet."


### PR DESCRIPTION
## Summary
- implement the real AC-66.04 provider-preference behavior on the app/client path, not just in isolated tests
- thread dispatch priority through the LLM client protocol and rate-limited wrapper
- reorder generation primary/fallback candidates for LOW / BEST_EFFORT calls based on provider utilization state
- replace the deferred AC-66.04 placeholder with real unit coverage and restore full trace coverage

## What changed
- app startup now wires `RateLimitedLLMClient(inner=LiteLLMClient(...))` so dispatch context survives the default application path
- `LLMClient` protocol and concrete clients accept optional `task_priority`
- `RateLimitedLLMClient` forwards effective tier context to the inner client and releases budget against the effective tier
- `LiteLLMClient` reorders generation candidates only when:
  - role is `GENERATION`
  - task priority is `LOW` or `BEST_EFFORT`
  - a provider utilization snapshot exists
  - there are at least 2 distinct provider-qualified candidates
- `MockLLMClient` and `SmartRouterLLMClient` were updated for protocol conformance
- AC-66.04 tests now cover:
  - wrapper propagation of LOW-tier dispatch context
  - real provider ordering behavior at the LiteLLM dispatch seam
  - preservation of declared order for higher-priority calls
- removed the deferred AC-66.04 placeholder from `tests/unit/v2_deferred_coverage.py`

## Truth boundary
This PR changes actual provider dispatch order in `LiteLLMClient`, but only across the configured primary/fallback candidates available to that client.

Under stock config, the default generation config still does not materially exercise provider-preference if both candidates resolve to the same provider. In that case the seam is wired correctly but there is nothing to reorder. The new behavior becomes active when config exposes distinct provider-qualified candidates (for example `google/...` vs `nvidia/...`).

That limitation is explicit here rather than implied away.

## Validation
Local:
- `make gate`
- `uv run pytest tests/unit/llm/test_litellm_client.py tests/unit/llm/test_rate_limited_client.py -q`

Results:
- `make gate` passed
- `ruff format --check` passed
- `ruff check` passed
- `pyright` passed (`0 errors, 0 warnings`)
- trace passed: `357/357` approved ACs covered, `0` orphan citations
- local unit/bdd gate passed: `2987 passed`

Remote:
- PR CI is green (`quality`, `unit-test`, `integration-test`, `Merge Guard`, `build`)
